### PR TITLE
Fix install script entry point instruction

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -85,4 +85,4 @@ install_ruby_deps
 echo
 echo "✅  Tout est prêt !"
 echo "Pour lancer :"
-echo "  bundle exec ruby bin/media_librarian.rb --config ~/.medialibrarian/settings.yml"
+echo "  bundle exec ruby librarian.rb --config ~/.medialibrarian/settings.yml"


### PR DESCRIPTION
## Summary
- update the post-install instructions to invoke the real librarian.rb entrypoint
- ensure references to the removed bin script are removed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f384c9ab6883279908eb3790f3090e