### PR TITLE
Fix Utils.bash to run complex shell commands

### DIFF
--- a/lib/utils.rb
+++ b/lib/utils.rb
@@ -5,8 +5,7 @@ class Utils
   @lock = Mutex.new
 
   def self.bash(command)
-    escaped_command = Shellwords.escape(command)
-    system "bash -c #{escaped_command}"
+    system('bash', '-c', command)
   end
 
   def self.check_if_active(active_hours = {})


### PR DESCRIPTION
## Summary
- remove the over-escaping in `Utils.bash`
- execute commands via `bash -c` so compound shell commands run correctly

## Testing
- ruby -e 'system("bash", "-c", "echo foo && echo bar")'


------
https://chatgpt.com/codex/tasks/task_e_68f385af95508327bd7c2088feaac855