### PR TITLE
Introduce container for MediaLibrarian services

### DIFF
--- a/init/db.rb
+++ b/init/db.rb
@@ -1,9 +1,6 @@
 # Set up and open app DB
 app = MediaLibrarian.app
-db_path = File.join(app.config_dir, 'librarian.db')
-app.db = Storage::Db.new(db_path)
 
-library_config = app.config['calibre_library']
-if library_config && library_config['path'].to_s != ''
-  app.calibre = File.exist?(library_config['path']) ? Storage::Db.new(library_config['path'], 1) : nil
-end
+# Accessing through the container eagerly materializes the shared services.
+app.db
+app.calibre

--- a/init/global.rb
+++ b/init/global.rb
@@ -1,9 +1,9 @@
 require_relative 'languages_translation'
 
 app = MediaLibrarian.app
-app.str_closeness = FuzzyStringMatch::JaroWinkler.create(:pure)
-app.tracker_client = {}
-app.tracker_client_last_login = {}
+app.str_closeness
+app.tracker_client
+app.tracker_client_last_login
 
 CACHING_TTL = 108_000
 USER_INPUT_TIMEOUT = 600

--- a/init/trackers.rb
+++ b/init/trackers.rb
@@ -1,15 +1,2 @@
 app = MediaLibrarian.app
-app.trackers = {}
-return unless File.directory?(app.tracker_dir)
-
-Dir.each_child(app.tracker_dir) do |tracker|
-  file_path = File.join(app.tracker_dir, tracker)
-  begin
-    opts = YAML.load_file(file_path)
-    next unless opts['api_url'] && opts['api_key']
-    tracker_name = tracker.sub(/\.yml$/, '')
-    app.trackers[tracker_name] = TorznabTracker.new(opts, tracker_name)
-  rescue StandardError => e
-    app.speaker.tell_error(e, Utils.arguments_dump(binding))
-  end
-end
+app.trackers

--- a/lib/media_librarian/application.rb
+++ b/lib/media_librarian/application.rb
@@ -1,6 +1,7 @@
 require 'bundler/setup'
 require 'zeitwerk'
 require 'fileutils'
+require_relative 'container'
 
 module MediaLibrarian
   APP_NAME = 'librarian'.freeze
@@ -16,17 +17,10 @@ module MediaLibrarian
                 :tracker_dir,
                 :pid_dir,
                 :pidfile,
-                :speaker,
-                :args_dispatch,
-                :config,
-                :api_option,
-                :workers_pool_size,
-                :queue_slots,
-                :loader
+                :loader,
+                :container
 
     attr_accessor :daemon_client,
-                  :db,
-                  :calibre,
                   :email,
                   :email_templates,
                   :ffmpeg_crf,
@@ -40,11 +34,7 @@ module MediaLibrarian
                   :remove_torrent_on_completion,
                   :trakt_account,
                   :trakt,
-                  :trackers,
-                  :librarian,
-                  :str_closeness,
-                  :tracker_client,
-                  :tracker_client_last_login
+                  :librarian
 
     def initialize(root: File.expand_path('../..', __dir__))
       @root = root
@@ -52,7 +42,83 @@ module MediaLibrarian
       setup_dependencies
       setup_loader
       setup_environment
-      setup_configuration
+      @container = Container.new(self)
+    end
+
+    def config
+      container.config
+    end
+
+    def speaker
+      container.speaker
+    end
+
+    def speaker=(value)
+      container.speaker = value
+    end
+
+    def args_dispatch
+      container.args_dispatch
+    end
+
+    def api_option
+      container.api_option
+    end
+
+    def workers_pool_size
+      container.workers_pool_size
+    end
+
+    def queue_slots
+      container.queue_slots
+    end
+
+    def db
+      container.db
+    end
+
+    def db=(value)
+      container.db = value
+    end
+
+    def calibre
+      container.calibre
+    end
+
+    def calibre=(value)
+      container.calibre = value
+    end
+
+    def trackers
+      container.trackers
+    end
+
+    def trackers=(value)
+      container.trackers = value
+    end
+
+    def str_closeness
+      container.str_closeness
+    end
+
+    def str_closeness=(value)
+      container.str_closeness = value
+    end
+
+    def tracker_client
+      container.tracker_client
+    end
+
+    def tracker_client=(value)
+      container.tracker_client = value
+    end
+
+    def tracker_client_last_login
+      container.tracker_client_last_login
+    end
+
+    def tracker_client_last_login=(value)
+      container.tracker_client_last_login = value
     end
 
     private
@@ -96,19 +162,6 @@ module MediaLibrarian
       end
 
       FileUtils.mkdir_p(File.join(@config_dir, 'log'))
-
-      @speaker = SimpleSpeaker::Speaker.new
-      @args_dispatch = SimpleArgsDispatch::Agent.new(@speaker, @env_flags)
-    end
-
-    def setup_configuration
-      @config = SimpleConfigMan.load_settings(@config_dir, @config_file, @config_example)
-      @api_option = {
-        'bind_address' => '127.0.0.1',
-        'listen_port' => '8888'
-      }
-      @workers_pool_size = (@config['daemon'] && @config['daemon']['workers_pool_size']) || 4
-      @queue_slots = (@config['daemon'] && @config['daemon']['queue_slots']) || 4
     end
   end
 

--- a/lib/media_librarian/container.rb
+++ b/lib/media_librarian/container.rb
@@ -1,0 +1,172 @@
+# frozen_string_literal: true
+
+require 'yaml'
+
+module MediaLibrarian
+  # Container responsible for managing application wide service instances.
+  # All services are instantiated once during boot and reused everywhere.
+  # Hash based structures are deep frozen to protect against accidental
+  # mutation while shared objects that need to keep mutable state remain
+  # unfrozen.
+  class Container
+    attr_reader :application
+
+    def initialize(application)
+      @application = application
+      @services = {}
+      bootstrap!
+    end
+
+    def config
+      services.fetch(:config)
+    end
+
+    def speaker
+      services.fetch(:speaker)
+    end
+
+    def speaker=(value)
+      store(:speaker, value, freeze: false)
+      store(:args_dispatch, SimpleArgsDispatch::Agent.new(speaker, application.env_flags), freeze: false)
+      speaker
+    end
+
+    def args_dispatch
+      services.fetch(:args_dispatch)
+    end
+
+    def db
+      services.fetch(:db)
+    end
+
+    def db=(value)
+      store(:db, value, freeze: false)
+    end
+
+    def calibre
+      services.fetch(:calibre)
+    end
+
+    def calibre=(value)
+      store(:calibre, value, freeze: false)
+    end
+
+    def trackers
+      services.fetch(:trackers)
+    end
+
+    def trackers=(value)
+      store(:trackers, value)
+    end
+
+    def str_closeness
+      services.fetch(:str_closeness)
+    end
+
+    def str_closeness=(value)
+      store(:str_closeness, value, freeze: false)
+    end
+
+    def tracker_client
+      services.fetch(:tracker_client)
+    end
+
+    def tracker_client=(value)
+      store(:tracker_client, value, freeze: false)
+    end
+
+    def tracker_client_last_login
+      services.fetch(:tracker_client_last_login)
+    end
+
+    def tracker_client_last_login=(value)
+      store(:tracker_client_last_login, value, freeze: false)
+    end
+
+    def api_option
+      services.fetch(:api_option)
+    end
+
+    def workers_pool_size
+      services.fetch(:workers_pool_size)
+    end
+
+    def queue_slots
+      services.fetch(:queue_slots)
+    end
+
+    private
+
+    attr_reader :services
+
+    def bootstrap!
+      store(:config, SimpleConfigMan.load_settings(application.config_dir,
+                                                  application.config_file,
+                                                  application.config_example))
+
+      store(:speaker, SimpleSpeaker::Speaker.new, freeze: false)
+      store(:args_dispatch, SimpleArgsDispatch::Agent.new(speaker, application.env_flags), freeze: false)
+
+      store(:db, Storage::Db.new(File.join(application.config_dir, 'librarian.db')), freeze: false)
+      store(:calibre, build_calibre, freeze: false)
+
+      store(:trackers, build_trackers)
+
+      store(:str_closeness, FuzzyStringMatch::JaroWinkler.create(:pure), freeze: false)
+      store(:tracker_client, {}, freeze: false)
+      store(:tracker_client_last_login, {}, freeze: false)
+
+      store(:api_option, 'bind_address' => '127.0.0.1', 'listen_port' => '8888')
+
+      daemon_config = config.fetch('daemon', {})
+      store(:workers_pool_size, daemon_config['workers_pool_size'] || 4, freeze: true)
+      store(:queue_slots, daemon_config['queue_slots'] || 4, freeze: true)
+    end
+
+    def build_calibre
+      library_config = config['calibre_library']
+      return nil unless library_config && library_config['path'].to_s != ''
+
+      File.exist?(library_config['path']) ? Storage::Db.new(library_config['path'], 1) : nil
+    end
+
+    def build_trackers
+      return {} unless File.directory?(application.tracker_dir)
+
+      Dir.each_child(application.tracker_dir).each_with_object({}) do |tracker, memo|
+        file_path = File.join(application.tracker_dir, tracker)
+        next unless File.file?(file_path)
+
+        opts = YAML.load_file(file_path)
+        next unless opts['api_url'] && opts['api_key']
+
+        tracker_name = tracker.sub(/\.yml$/, '')
+        memo[tracker_name] = TorznabTracker.new(opts, tracker_name)
+      rescue StandardError => e
+        speaker.tell_error(e, Utils.arguments_dump(binding)) if speaker.respond_to?(:tell_error)
+      end
+    end
+
+    def store(name, value, freeze: true)
+      services[name] = freeze ? deep_freeze(value) : value
+    end
+
+    def deep_freeze(value)
+      case value
+      when Hash
+        value.each do |k, v|
+          deep_freeze(k)
+          deep_freeze(v)
+        end
+        value.freeze
+      when Array
+        value.each { |entry| deep_freeze(entry) }
+        value.freeze
+      when String
+        value.freeze
+      else
+        value
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- introduce a MediaLibrarian::Container that builds and freezes shared services once
- refactor the application façade to delegate service access through the container
- update initialization scripts to rely on the container-managed services instead of re-instantiating them

## Testing
- ruby -c lib/media_librarian/container.rb
- ruby -c lib/media_librarian/application.rb

------
https://chatgpt.com/codex/tasks/task_e_68f3eda7e86c8327ba06347be54f29e0