### PR TITLE
Introduce boot container for CLI and init scripts

### DIFF
--- a/boot/librarian.rb
+++ b/boot/librarian.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative '../lib/media_librarian/application'
+
+module MediaLibrarian
+  module Boot
+    module_function
+
+    def application
+      @application ||= MediaLibrarian.application
+    end
+
+    def container
+      @container ||= application.container
+    end
+  end
+end

--- a/init/db.rb
+++ b/init/db.rb
@@ -1,6 +1,10 @@
+require_relative '../boot/librarian'
+
 # Set up and open app DB
-app = MediaLibrarian.app
+container = MediaLibrarian::Boot.container
+app = container.application
 
 # Accessing through the container eagerly materializes the shared services.
 app.db
 app.calibre
+

--- a/init/email.rb
+++ b/init/email.rb
@@ -1,5 +1,7 @@
 # Configure email alerts
-app = MediaLibrarian.app
+require_relative '../boot/librarian'
+
+app = MediaLibrarian::Boot.application
 app.email_templates = File.expand_path('../app/mailer_templates', __dir__)
 FileUtils.mkdir_p(app.email_templates) unless File.exist?(app.email_templates)
 app.email = app.config['email']

--- a/init/ffmpeg_settings.rb
+++ b/init/ffmpeg_settings.rb
@@ -1,4 +1,6 @@
-app = MediaLibrarian.app
+require_relative '../boot/librarian'
+
+app = MediaLibrarian::Boot.application
 settings = app.config['ffmpeg_settings'] || {}
 app.ffmpeg_crf = settings['crf'] || 22
 app.ffmpeg_preset = settings['preset'] || 'medium'

--- a/init/global.rb
+++ b/init/global.rb
@@ -1,6 +1,7 @@
+require_relative '../boot/librarian'
 require_relative 'languages_translation'
 
-app = MediaLibrarian.app
+app = MediaLibrarian::Boot.application
 app.str_closeness
 app.tracker_client
 app.tracker_client_last_login

--- a/init/goodreads.rb
+++ b/init/goodreads.rb
@@ -1,4 +1,6 @@
-app = MediaLibrarian.app
+require_relative '../boot/librarian'
+
+app = MediaLibrarian::Boot.application
 goodreads = app.config['goodreads']
 
 if goodreads && goodreads['api_key'] && goodreads['api_secret']

--- a/init/kodi.rb
+++ b/init/kodi.rb
@@ -1,5 +1,7 @@
 # start Kodi client
-app = MediaLibrarian.app
+require_relative '../boot/librarian'
+
+app = MediaLibrarian::Boot.application
 app.kodi = nil
 
 if app.config['kodi']

--- a/init/mechanizer.rb
+++ b/init/mechanizer.rb
@@ -1,1 +1,3 @@
-MediaLibrarian.app.mechanizer = Mechanize.new
+require_relative '../boot/librarian'
+
+MediaLibrarian::Boot.application.mechanizer = Mechanize.new

--- a/init/thetvdb.rb
+++ b/init/thetvdb.rb
@@ -1,3 +1,6 @@
 # Start thetvdb client
-config = MediaLibrarian.app.config
-MediaLibrarian.app.tvdb = config['tvdb'] && config['tvdb']['api_key'] ? TvdbParty::Search.new(config['tvdb']['api_key']) : nil
+require_relative '../boot/librarian'
+
+app = MediaLibrarian::Boot.application
+config = app.config
+app.tvdb = config['tvdb'] && config['tvdb']['api_key'] ? TvdbParty::Search.new(config['tvdb']['api_key']) : nil

--- a/init/tmdb.rb
+++ b/init/tmdb.rb
@@ -1,2 +1,4 @@
-app = MediaLibrarian.app
+require_relative '../boot/librarian'
+
+app = MediaLibrarian::Boot.application
 Tmdb::Api.key(app.config['tmdb']['api_key']) if app.config['tmdb'] && app.config['tmdb']['api_key']

--- a/init/torrenting.rb
+++ b/init/torrenting.rb
@@ -1,4 +1,6 @@
-app = MediaLibrarian.app
+require_relative '../boot/librarian'
+
+app = MediaLibrarian::Boot.application
 app.deluge_connected = nil
 
 if app.config['deluge'] && !app.config['deluge'].empty?

--- a/init/trackers.rb
+++ b/init/trackers.rb
@@ -1,2 +1,4 @@
-app = MediaLibrarian.app
-app.trackers
+require_relative '../boot/librarian'
+
+MediaLibrarian::Boot.container.trackers
+

--- a/init/trakt.rb
+++ b/init/trakt.rb
@@ -1,6 +1,7 @@
+require_relative '../boot/librarian'
 require_relative 'db'
 
-app = MediaLibrarian.app
+app = MediaLibrarian::Boot.application
 
 if app.config['trakt']
   app.trakt_account = app.config['trakt']['account_id']

--- a/librarian.rb
+++ b/librarian.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative 'lib/media_librarian/application'
+require_relative 'boot/librarian'
 require_relative 'lib/media_librarian/command_registry'
 require_relative 'lib/media_librarian/app_container_support'
 
@@ -8,7 +8,7 @@ class Librarian
   include MediaLibrarian::AppContainerSupport
 
   attr_accessor :args, :quit, :reload
-  attr_reader :command_registry, :app
+  attr_reader :command_registry, :app, :container
 
   class << self
     attr_accessor :debug_classes
@@ -22,7 +22,9 @@ class Librarian
 
   self.debug_classes = []
 
-  def initialize(app:, args: ARGV)
+  def initialize(container:, args: ARGV)
+    @container = container
+    app = container.application
     self.class.configure(app: app)
     @app = app
     @args = args
@@ -245,7 +247,8 @@ class Librarian
   end
 end
 
-librarian = Librarian.new(app: MediaLibrarian.app)
+container = MediaLibrarian::Boot.container
+librarian = Librarian.new(container: container)
 arguments = librarian.args.dup
 first_time = true
 


### PR DESCRIPTION
## Summary
- add a boot module that exposes the shared MediaLibrarian container
- update the CLI entrypoint to accept an injected container and reuse its services
- update init scripts to load the new boot module instead of constructing the application directly

## Testing
- ruby -c librarian.rb
- ruby -c init/db.rb
- ruby -c init/email.rb
- ruby -c init/trakt.rb

------
https://chatgpt.com/codex/tasks/task_e_68f49f15eedc832789f1427893e350dd