### PR TITLE
Add CLI container stubs and integration tests

### DIFF
--- a/librarian.rb
+++ b/librarian.rb
@@ -247,16 +247,18 @@ class Librarian
   end
 end
 
-container = MediaLibrarian::Boot.container
-librarian = Librarian.new(container: container)
-arguments = librarian.args.dup
-first_time = true
+if $PROGRAM_NAME == __FILE__
+  container = MediaLibrarian::Boot.container
+  librarian = Librarian.new(container: container)
+  arguments = librarian.args.dup
+  first_time = true
 
-while ((librarian.reload && !Daemon.is_daemon?) || first_time)
-  first_time = false
-  librarian.args = arguments.dup
-  librarian.reload = false
-  librarian.run!
+  while ((librarian.reload && !Daemon.is_daemon?) || first_time)
+    first_time = false
+    librarian.args = arguments.dup
+    librarian.reload = false
+    librarian.run!
+  end
+
+  librarian.leave
 end
-
-librarian.leave

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,12 @@
+# Test Suite
+
+The test suite exercises the `librarian` command line interface using lightweight
+stubs for the application container. The helpers in `test/support` build a
+sandboxed environment with fake speakers, dispatchers and pid files so that
+commands can run without touching the real filesystem or network services.
+
+Run the tests with:
+
+```
+bundle exec ruby -Itest test/librarian_cli_test.rb
+```

--- a/test/librarian_cli_test.rb
+++ b/test/librarian_cli_test.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require_relative 'test_helper'
+
+class LibrarianCliTest < Minitest::Test
+  def setup
+    super
+    reset_librarian_state!
+    @environments = []
+  end
+
+  def teardown
+    @environments.each(&:cleanup)
+    reset_librarian_state!
+    super
+  end
+
+  def test_help_command_dispatches_through_args_dispatch
+    env = use_environment
+
+    librarian = Librarian.new(container: env.container, args: ['help'])
+    librarian.run!
+
+    dispatches = env.application.args_dispatch.dispatched_commands
+    assert_equal 1, dispatches.length
+    assert_equal ['help'], dispatches.first[:command]
+    assert_includes env.application.speaker.messages, "Welcome to your library assistant!\n\n"
+  end
+
+  def test_nested_command_invokes_dispatcher
+    env = use_environment
+
+    librarian = Librarian.new(container: env.container, args: ['daemon', 'status'])
+    librarian.run!
+
+    dispatches = env.application.args_dispatch.dispatched_commands
+    assert_equal 1, dispatches.length
+    assert_equal ['daemon', 'status'], dispatches.first[:command]
+  end
+
+  def test_dependencies_are_isolated_per_container
+    first_speaker = TestSupport::Fakes::Speaker.new
+    first_dispatch = TestSupport::Fakes::ArgsDispatch.new
+    env1 = use_environment(speaker: first_speaker, args_dispatch: first_dispatch)
+
+    librarian1 = Librarian.new(container: env1.container, args: ['help'])
+    librarian1.run!
+
+    second_speaker = TestSupport::Fakes::Speaker.new
+    second_dispatch = TestSupport::Fakes::ArgsDispatch.new
+    env2 = use_environment(speaker: second_speaker, args_dispatch: second_dispatch)
+
+    librarian2 = Librarian.new(container: env2.container, args: ['help'])
+    librarian2.run!
+
+    assert_equal 1, first_dispatch.dispatched_commands.length
+    assert_equal 1, second_dispatch.dispatched_commands.length
+    assert_includes first_speaker.messages, "Welcome to your library assistant!\n\n"
+    assert_includes second_speaker.messages, "Welcome to your library assistant!\n\n"
+  end
+
+  private
+
+  def use_environment(**overrides)
+    env = build_stubbed_environment(**overrides)
+    @environments << env
+    env
+  end
+end

--- a/test/support/container_helpers.rb
+++ b/test/support/container_helpers.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require 'tmpdir'
+require 'fileutils'
+
+module TestSupport
+  module ContainerHelpers
+    def build_stubbed_environment(**overrides)
+      StubbedEnvironment.new(**overrides)
+    end
+
+    class StubbedEnvironment
+      attr_reader :application, :container, :root_path
+
+      def initialize(speaker: TestSupport::Fakes::Speaker.new,
+                     args_dispatch: TestSupport::Fakes::ArgsDispatch.new)
+        @root_path = Dir.mktmpdir('librarian-test')
+        FileUtils.mkdir_p(File.join(@root_path, 'init'))
+        @application = StubApplication.new(root: @root_path,
+                                           speaker: speaker,
+                                           args_dispatch: args_dispatch)
+        @container = StubContainer.new(application: @application)
+      end
+
+      def cleanup
+        FileUtils.remove_entry(root_path) if root_path && Dir.exist?(root_path)
+      end
+    end
+
+    class StubContainer
+      attr_reader :application
+
+      def initialize(application:)
+        @application = application
+      end
+    end
+
+    class StubApplication
+      attr_accessor :librarian, :speaker, :args_dispatch
+      attr_reader :root, :loader, :template_dir, :pidfile,
+                  :env_flags, :config_dir, :config_file, :config_example
+
+      def initialize(root:, speaker:, args_dispatch:)
+        @root = root
+        @loader = NullLoader.new
+        @env_flags = {}
+        @config_dir = File.join(root, 'config')
+        FileUtils.mkdir_p(@config_dir)
+        @config_file = File.join(@config_dir, 'conf.yml')
+        @config_example = File.join(@config_dir, 'conf.example.yml')
+        @template_dir = File.join(root, 'templates')
+        FileUtils.mkdir_p(@template_dir)
+        pid_dir = File.join(root, 'tmp')
+        FileUtils.mkdir_p(pid_dir)
+        @pidfile = File.join(pid_dir, 'librarian.pid')
+        @speaker = speaker
+        @args_dispatch = args_dispatch
+      end
+
+      class NullLoader
+        def eager_load; end
+      end
+    end
+  end
+
+  module Fakes
+    class Speaker
+      attr_reader :messages
+
+      def initialize
+        @messages = []
+      end
+
+      def speak_up(message, *_args)
+        @messages << message
+      end
+
+      def tell_error(error, context = nil)
+        @messages << [:error, error, context]
+      end
+    end
+
+    class ArgsDispatch
+      attr_reader :dispatched_commands, :shown_actions
+
+      def initialize
+        @dispatched_commands = []
+        @shown_actions = []
+      end
+
+      def dispatch(app_name, command, actions, *_rest)
+        @dispatched_commands << { app: app_name, command: command.dup, actions: actions }
+        :dispatched
+      end
+
+      def show_available(app_name, actions)
+        @shown_actions << { app: app_name, actions: actions }
+        :shown
+      end
+
+      def set_env_variables(*)
+        # no-op in tests
+      end
+    end
+  end
+end

--- a/test/support/dependency_stubs.rb
+++ b/test/support/dependency_stubs.rb
@@ -1,0 +1,164 @@
+# frozen_string_literal: true
+
+# Minimal dependency stubs that allow the CLI to execute inside the test
+# environment without booting the full application stack. Only the methods used
+# by the integration tests are implemented.
+unless defined?(Daemon)
+  class Daemon
+    class << self
+      def is_daemon?
+        false
+      end
+
+      def thread_cache_add(*)
+        # no-op in tests
+      end
+
+      def job_id
+        'test-job'
+      end
+
+      def dump_env_flags(*)
+        {}
+      end
+
+      def fetch_function_config(*)
+        []
+      end
+
+      def get_children_count(*)
+        0
+      end
+
+      def clear_waiting_worker(*)
+        # no-op in tests
+      end
+
+      def consolidate_children(*)
+        # no-op in tests
+      end
+
+      def merge_notifications(*)
+        # no-op in tests
+      end
+    end
+  end
+end
+
+unless defined?(LibraryBus)
+  class LibraryBus
+    class << self
+      def initialize_queue(*)
+        queues
+      end
+
+      def put_in_queue(value, thread = Thread.current)
+        queues[thread.object_id] << value unless value.nil?
+      end
+
+      def merge_queue(thread = Thread.current)
+        queues.delete(thread.object_id)
+      end
+
+      private
+
+      def queues
+        @queues ||= Hash.new { |memo, key| memo[key] = [] }
+      end
+    end
+  end
+end
+
+unless defined?(TimeUtils)
+  module TimeUtils
+    module_function
+
+    def seconds_in_words(_seconds)
+      '0 seconds'
+    end
+  end
+end
+
+if defined?(Utils)
+  class Utils
+    class << self
+      def lock_time_get(*)
+        ''
+      end
+
+      def lock_block(*)
+        yield if block_given?
+      end
+
+      def lock_time_merge(*)
+        # no-op in tests
+      end
+
+      def arguments_dump(*)
+        'arguments'
+      end
+    end
+  end
+else
+  class Utils
+    class << self
+      def lock_time_get(*)
+        ''
+      end
+
+      def lock_block(*)
+        yield if block_given?
+      end
+
+      def lock_time_merge(*)
+        # no-op in tests
+      end
+
+      def arguments_dump(*)
+        'arguments'
+      end
+    end
+  end
+end
+
+unless defined?(Report)
+  class Report
+    class << self
+      def sent_out(*)
+        # no-op in tests
+      end
+
+      def push_email(*)
+        # no-op in tests
+      end
+    end
+  end
+end
+
+unless defined?(Env)
+  class Env
+    class << self
+      def email_notif?(*_args)
+        false
+      end
+
+      def debug?(*_args)
+        false
+      end
+    end
+  end
+end
+
+unless defined?(ExecutionHooks)
+  module ExecutionHooks
+    module_function
+
+    def on_the_fly_hooking(*)
+      # no-op in tests
+    end
+
+    def alias_hook(sym)
+      "__#{sym}__hooked__"
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+
+require_relative 'support/dependency_stubs'
+require_relative '../librarian'
+require_relative 'support/container_helpers'
+
+module TestSupport
+  module LibrarianState
+    def reset_librarian_state!
+      singleton = Librarian.singleton_class
+      singleton.instance_variable_set(:@app, nil)
+      singleton.instance_variable_set(:@command_registry, nil)
+      Librarian.debug_classes = []
+    end
+  end
+end
+
+Minitest::Test.include(TestSupport::ContainerHelpers)
+Minitest::Test.include(TestSupport::LibrarianState)


### PR DESCRIPTION
## Summary
- guard the CLI entrypoint so the librarian executable can be required in tests
- add stubbed container helpers and dependency shims for exercising CLI commands in isolation
- introduce CLI integration tests and test documentation describing the sandboxed harness

## Testing
- bundle exec ruby -Itest test/librarian_cli_test.rb

------
https://chatgpt.com/codex/tasks/task_e_68f4a5f798248327b43f77bbeffbc8c6