### PR TITLE
Refine service extraction and add unit coverage

### DIFF
--- a/app/services/media_librarian/services.rb
+++ b/app/services/media_librarian/services.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module MediaLibrarian
+  module Services
+  end
+end

--- a/app/services/media_librarian/services/base_service.rb
+++ b/app/services/media_librarian/services/base_service.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+module MediaLibrarian
+  module Services
+    class BaseService
+      include MediaLibrarian::AppContainerSupport
+
+      def initialize(app: self.class.app, speaker: nil, file_system: nil)
+        @app = app
+        @speaker = speaker || SpeakerAdapter.new(app&.speaker)
+        @file_system = file_system || FileSystemAdapter.new
+      end
+
+      private
+
+      attr_reader :app, :speaker, :file_system
+    end
+
+    class SpeakerAdapter
+      def initialize(delegate)
+        @delegate = delegate
+      end
+
+      def speak_up(message, *args)
+        delegate&.speak_up(message, *args)
+      end
+
+      def ask_if_needed(question, no_prompt = 0, default = nil)
+        delegate&.ask_if_needed(question, no_prompt, default)
+      end
+
+      def tell_error(error, context = nil, *_args)
+        delegate&.tell_error(error, context)
+      end
+
+      private
+
+      attr_reader :delegate
+    end
+
+    class FileSystemAdapter
+      def initialize(delegate = FileUtils)
+        @delegate = delegate
+      end
+
+      def exist?(path)
+        File.exist?(path)
+      end
+
+      def directory?(path)
+        File.directory?(path)
+      end
+
+      def search_folder(path, criteria)
+        delegate.search_folder(path, criteria)
+      end
+
+      def get_extension(path)
+        delegate.get_extension(path)
+      end
+
+      def mkdir(path)
+        delegate.mkdir(path)
+      end
+
+      def mkdir_p(path)
+        delegate.mkdir_p(path)
+      end
+
+      def mv(source, destination)
+        delegate.mv(source, destination)
+      end
+
+      def rm_r(path)
+        delegate.rm_r(path)
+      end
+
+      def md5sum(path)
+        delegate.md5sum(path)
+      end
+
+      def ln_r(source, destination)
+        delegate.ln_r(source, destination)
+      end
+
+      def chdir(path, &block)
+        Dir.chdir(path, &block)
+      end
+
+      private
+
+      attr_reader :delegate
+    end
+  end
+end

--- a/app/services/media_librarian/services/list_management_service.rb
+++ b/app/services/media_librarian/services/list_management_service.rb
@@ -1,0 +1,232 @@
+# frozen_string_literal: true
+
+module MediaLibrarian
+  module Services
+    class CustomListRequest
+      attr_reader :name, :description, :origin, :criteria, :no_prompt
+
+      def initialize(name:, description:, origin: 'collection', criteria: {}, no_prompt: 0)
+        @name = name
+        @description = description
+        @origin = origin
+        @criteria = criteria
+        @no_prompt = no_prompt
+      end
+    end
+
+    class MediaListSizeRequest
+      attr_reader :list, :folder, :type_filter
+
+      def initialize(list: [], folder: {}, type_filter: '')
+        @list = list
+        @folder = folder
+        @type_filter = type_filter
+      end
+    end
+
+    class SearchListRequest
+      attr_reader :source_type, :category, :source, :no_prompt
+
+      def initialize(source_type:, category:, source:, no_prompt: 0)
+        @source_type = source_type
+        @category = category
+        @source = source
+        @no_prompt = no_prompt
+      end
+    end
+
+    class ListManagementService < BaseService
+      def create_custom_list(request)
+        speaker.speak_up("Fetching items from #{request.origin}...", 0)
+        new_list = {
+          'movies' => TraktAgent.list(request.origin, 'movies'),
+          'shows' => TraktAgent.list(request.origin, 'shows')
+        }
+        dest_list = TraktAgent.list('lists').find { |list| list['name'] == request.name }
+        to_delete = {}
+        if dest_list
+          speaker.speak_up("List #{request.name} exists", 0)
+          to_delete = TraktAgent.parse_custom_list(TraktAgent.list(request.name))
+        else
+          speaker.speak_up("List #{request.name} doesn't exist, creating it...")
+          TraktAgent.create_list(request.name, request.description)
+        end
+        speaker.speak_up("Ok, we have added #{(new_list['movies'].length + new_list['shows'].length)} items from #{request.origin}, let's chose what to include in the new list #{request.name}.", 0)
+        %w[movies shows].each do |type|
+          apply_list_criteria(request, type, new_list, to_delete)
+        end
+        speaker.speak_up("List #{request.name} is up to date!", 0)
+      end
+
+      def get_media_list_size(request)
+        list = request.list
+        folder = request.folder
+        type_filter = request.type_filter
+        if list.nil? || list.empty?
+          list_name = speaker.ask_if_needed('Please enter the name of the trakt list you want to know the total disk size of (of medias on your set folder): ')
+          list = TraktAgent.list(list_name, '')
+        end
+        parsed_media = {}
+        list_size = 0
+        list_paths = []
+        list.each do |item|
+          type = item['type'] == 'season' ? 'show' : item['type']
+          resource_type = item['type']
+          next unless %w[movie show].include?(type)
+          list_type = type[-1] == 's' ? type : "#{type}s"
+          next if type_filter && type_filter != '' && type_filter != list_type
+          parsed_media[list_type] ||= {}
+          folder[list_type] ||= speaker.ask_if_needed("Enter the path of the folder where your #{type}s media are stored: ")
+          title = "#{item[type]['title']}#{' (' + item[type]['year'].to_s + ')' if list_type == 'movies' && item[type]['year'].to_i > 0}"
+          next if parsed_media[list_type][title] && resource_type != 'season'
+          folders = file_system.search_folder(folder[list_type], { 'regex' => StringUtils.title_match_string(title), 'maxdepth' => (type == 'show' ? 1 : nil), 'includedir' => 1, 'return_first' => 1 })
+          file = folders.first
+          if file
+            if resource_type == 'season'
+              season = item[resource_type]['number'].to_s
+              season_file = file_system.search_folder(file[0], { 'regex' => "season.#{season}", 'maxdepth' => 1, 'includedir' => 1, 'return_first' => 1 }).first
+              if season_file
+                list_size += FileUtils.get_disk_size(season_file[0]).to_d
+                list_paths << season_file[0]
+              end
+            else
+              list_size += FileUtils.get_disk_size(file[0]).to_d
+              list_paths << file[0]
+            end
+          else
+            speaker.speak_up("#{title} NOT FOUND in #{folder[list_type]}")
+          end
+          parsed_media[list_type][title] = item[type]
+        end
+        speaker.speak_up("The total disk size of this list is #{(list_size / 1024 / 1024 / 1024).round(2)} GB")
+        [list_size, list_paths]
+      rescue StandardError => e
+        speaker.tell_error(e, Utils.arguments_dump(binding))
+        [0, []]
+      end
+
+      def get_search_list(request)
+        unless request.source.is_a?(Hash) && request.source['existing_folder'] && request.source['existing_folder'][request.category]
+          speaker.speak_up("get_search_list: empty/invalid source for category=#{request.category}, returning empty", 0) if speaker
+          return [{ request.category => {} }, {}]
+        end
+        return [{}, {}] unless request.source['existing_folder'][request.category]
+
+        search_list = {}
+        existing_files = {}
+        cache_name = "#{request.source_type}#{request.category}#{request.source['existing_folder'][request.category]}#{request.source['list_name']}"
+        Utils.lock_block(__method__.to_s + cache_name) do
+          search_list, existing_files = build_search_list(request, cache_name)
+        end
+        [existing_files.deep_dup, (search_list[cache_name] || {}).deep_dup]
+      end
+
+      private
+
+      def apply_list_criteria(request, type, new_list, to_delete)
+        criteria = request.criteria[type] || {}
+        if (criteria['noadd'] && criteria['noadd'].to_i > 0) || speaker.ask_if_needed("Do you want to add #{type} items? (y/n)", request.no_prompt, 'y') != 'y'
+          new_list.delete(type)
+          new_list[type] = to_delete[type] if criteria['add_only'].to_i > 0 && to_delete && to_delete[type]
+          return
+        end
+        folder = speaker.ask_if_needed("What is the path of your folder where #{type} are stored? (in full)", criteria['folder'].nil? ? 0 : 1, criteria['folder'])
+        %w[released_before released_after days_older days_newer entirely_watched partially_watched ended not_ended watched canceled].each do |criterion|
+          value = speaker.ask_if_needed("Enter the value to keep only #{type} #{criterion.gsub('_', ' ')}: (empty to not use this filter)", request.no_prompt, criteria[criterion])
+          next if value.to_s == ''
+
+          new_list[type] = TraktAgent.filter_trakt_list(new_list[type], type, criterion, criteria['include'], criteria['add_only'], to_delete[type], value, folder)
+        end
+        review_items(request, type, new_list, to_delete, criteria, folder)
+        new_list[type].map! do |item|
+          item[type[0...-1]]['seasons'] = item['seasons'].map { |season| season.reject { |key, _| key == 'episodes' } } if item['seasons']
+          item[type[0...-1]]
+        end
+        speaker.speak_up('Updating items in the list...', 0)
+        TraktAgent.remove_from_list(to_delete[type], request.name, type) unless to_delete.nil? || to_delete.empty? || to_delete[type].nil? || to_delete[type].empty? || criteria['add_only'].to_i > 0
+        TraktAgent.add_to_list(new_list[type], request.name, type)
+      end
+
+      def review_items(request, type, new_list, to_delete, criteria, folder)
+        return unless criteria['review'] || speaker.ask_if_needed("Do you want to review #{type} individually? (y/n)", request.no_prompt, 'n') == 'y'
+
+        review_criteria = criteria['review'] || {}
+        speaker.speak_up('Preparing list of files to review...', 0)
+        new_list[type].reverse_each do |item|
+          title = item[type[0...-1]]['title']
+          year = item[type[0...-1]]['year']
+          title = "#{title} (#{year})" if year.to_i > 0 && type == 'movies'
+          folders = file_system.search_folder(folder, { 'regex' => StringUtils.title_match_string(title), 'maxdepth' => (type == 'shows' ? 1 : nil), 'includedir' => 1, 'return_first' => 1 })
+          file = folders.first
+          size = file ? FileUtils.get_disk_size(file[0]) : -1
+          if size.to_d < 0 && (review_criteria['remove_deleted'].to_i > 0 || speaker.ask_if_needed("No folder found for #{title}, do you want to delete the item from the list? (y/n)", request.no_prompt, 'n') == 'y')
+            speaker.speak_up "No folder found for '#{title}', removing from list" if Env.debug?
+            new_list[type].delete(item)
+            next
+          end
+          base_condition = criteria['add_only'].to_i.zero? || !TraktAgent.search_list(type[0...-1], item, to_delete[type])
+          inclusion_condition = criteria['include'].nil? || !criteria['include'].include?(title)
+          decision = speaker.ask_if_needed(
+            "Do you want to add #{type} '#{title}' (disk size #{[(size.to_d / 1024 / 1024 / 1024).round(2), 0].max} GB) to the list (y/n)",
+            review_criteria['add_all'].to_i,
+            'y'
+          )
+          unless base_condition && inclusion_condition && decision.to_s == 'y'
+            speaker.speak_up "Removing '#{title}' from list" if Env.debug?
+            new_list[type].delete(item)
+            next
+          end
+          handle_show_seasons(type, item, review_criteria)
+          print '.'
+        end
+      end
+
+      def handle_show_seasons(type, item, review_criteria)
+        return unless type == 'shows'
+        return unless (review_criteria['add_all'].to_i == 0 || review_criteria['no_season'].to_i > 0) && ((review_criteria['add_all'].to_i == 0 && review_criteria['no_season'].to_i > 0) || speaker.ask_if_needed("Do you want to keep all seasons of #{item['show']['title']}? (y/n)", 0, 'n') != 'y')
+
+        choice = speaker.ask_if_needed("Which seasons do you want to keep? (separated by comma, like this: '1,2,3', empty for none", 0, '').to_s.split(',')
+        if choice.empty?
+          item['seasons'] = nil
+        else
+          item['seasons'].select! { |season| choice.map! { |n| n.to_i }.include?(season['number']) }
+        end
+      end
+
+      def build_search_list(request, cache_name)
+        search_list = {}
+        existing_files = {}
+        case request.source_type
+        when 'filesystem'
+          search_list[cache_name] = Library.process_folder(type: request.category, folder: request.source['existing_folder'][request.category], no_prompt: request.no_prompt, filter_criteria: request.source['filter_criteria'], item_name: request.source['item_name'])
+          existing_files[request.category] = search_list[cache_name].dup
+        when 'trakt'
+          speaker.speak_up("Parsing trakt list '#{request.source['list_name']}', can take a long time...", 0)
+          TraktAgent.list(request.source['list_name']).each do |item|
+            type = item['type'] rescue next
+            trakt_object = item[type]
+            type = Utils.regularise_media_type(type)
+            next unless type == request.category
+            next if Time.now.year < (trakt_object['year'] || Time.now.year + 3)
+
+            search_list[cache_name] = Library.parse_media({ type: 'trakt', name: "#{trakt_object['title']} (#{trakt_object['year']})".gsub('/', ' ') }, type, request.no_prompt, search_list[cache_name] || {}, {}, {}, { trakt_obj: trakt_object, trakt_list: request.source['list_name'], trakt_type: type }, '', trakt_object['ids'])
+          end
+        when 'lists'
+          speaker.speak_up("Parsing search list '#{request.source['list_name']}', can take a long time...", 0)
+          list_name = (request.source['list_name'] || 'default').to_s
+          entries = ListStore.fetch_list(list_name)
+          entries.each do |row|
+            ttype = ('movies'.include?(row[:type]) ? 'movies' : row[:type]) || 'movies'
+            key = row[:title].to_s + row[:year].to_s + ttype.to_s
+            next if key.empty?
+
+            search_list[cache_name] = Library.parse_media({ type: 'lists', name: "#{row[:title]} (#{row[:year]})".gsub('/', ' ') }, ttype, request.no_prompt, search_list[cache_name] || {}, {}, {}, { obj_title: row[:title], obj_year: row[:year], obj_url: row[:url], obj_type: ttype }, '', { 'tmdb' => row[:tmdb], 'imdb' => row[:imdb] })
+          end
+        end
+        existing_files[request.category] = Library.process_folder(type: request.category, folder: request.source['existing_folder'][request.category], no_prompt: request.no_prompt, remove_duplicates: 0)
+        existing_files[request.category][:shows] = search_list[cache_name][:shows] if search_list[cache_name]&.dig(:shows) && request.category.to_s == 'shows'
+        [search_list, existing_files]
+      end
+    end
+  end
+end

--- a/app/services/media_librarian/services/media_conversion_service.rb
+++ b/app/services/media_librarian/services/media_conversion_service.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+
+module MediaLibrarian
+  module Services
+    class MediaConversionRequest
+      attr_reader :path, :input_format, :output_format, :no_warning,
+                  :rename_original, :move_destination, :search_pattern,
+                  :qualities
+
+      def initialize(path:, input_format:, output_format:, no_warning: 0,
+                     rename_original: 1, move_destination: '', search_pattern: '',
+                     qualities: nil)
+        @path = path
+        @input_format = input_format
+        @output_format = output_format
+        @no_warning = no_warning
+        @rename_original = rename_original
+        @move_destination = move_destination
+        @search_pattern = search_pattern
+        @qualities = qualities
+      end
+    end
+
+    class MediaConversionService < BaseService
+      def convert(request)
+        last_name = ''
+        results = []
+        type_pair = EXTENSIONS_TYPE.find { |_type, values| values.include?(request.input_format) }
+        return speaker.speak_up('Unknown input format') unless type_pair
+
+        type = type_pair.first
+        unless VALID_CONVERSION_INPUTS[type]&.include?(request.input_format)
+          return speaker.speak_up("Invalid input format, needs to be one of #{VALID_CONVERSION_INPUTS[type]}")
+        end
+        unless VALID_CONVERSION_OUTPUT[type]&.include?(request.output_format)
+          return speaker.speak_up("Invalid output format, needs to be one of #{VALID_CONVERSION_OUTPUT[type]}")
+        end
+
+        if request.no_warning.to_i.zero? && request.input_format == 'pdf'
+          continue = speaker.ask_if_needed(
+            'WARNING: The images extractor is incomplete, can result in corrupted or incomplete CBZ file. Do you want to continue? (y/n)'
+          )
+          return unless continue == 'y'
+        end
+
+        unless file_system.exist?(request.path)
+          return speaker.speak_up("#{request.path} does not exist!")
+        end
+
+        if file_system.directory?(request.path)
+          directory_results, last_name = convert_directory(request)
+          results += directory_results
+        elsif request.search_pattern.to_s != ''
+          speaker.speak_up 'Can not use search_pattern if path is not a directory'
+        else
+          file_results, last_name = convert_file(request, type)
+          results += file_results
+        end
+        results
+      rescue StandardError => e
+        speaker.tell_error(e, Utils.arguments_dump(binding))
+        cleanup_failed_conversion(last_name, request)
+        raise e
+      end
+
+      private
+
+      def convert_directory(request)
+        directory_results = []
+        last_name = ''
+        criteria = {
+          'regex' => ".*#{request.search_pattern.to_s + '.*' if request.search_pattern.to_s != ''}\\.#{request.input_format}"
+        }
+        file_system.search_folder(request.path, criteria).each do |file|
+          nested_request = MediaConversionRequest.new(
+            path: file[0],
+            input_format: request.input_format,
+            output_format: request.output_format,
+            no_warning: 1,
+            rename_original: request.rename_original,
+            move_destination: request.move_destination,
+            search_pattern: '',
+            qualities: request.qualities
+          )
+          nested_results = convert(nested_request)
+          directory_results += nested_results
+          last_name = File.basename(file[0]).gsub(/(.*)\.[\w\d]{1,4}/, '\\1') if nested_results.any?
+        end
+        [directory_results, last_name]
+      end
+
+      def convert_file(request, type)
+        name = ''
+        results = []
+        file_system.chdir(File.dirname(request.path)) do
+          destination = request.move_destination.to_s == '' ? Dir.pwd : request.move_destination
+          name = File.basename(request.path).gsub(/(.*)\.[\w\d]{1,4}/, '\\1')
+          dest_file = File.join(destination, "#{name.gsub(/^_?/, '')}.#{request.output_format}")
+          final_file = dest_file
+
+          if File.exist?(File.basename(dest_file))
+            if request.input_format == request.output_format
+              dest_file = File.join(destination, "#{name.gsub(/^_?/, '')}.proper.#{request.output_format}")
+            else
+              return results
+            end
+          end
+
+          speaker.speak_up("Will convert #{name} to #{request.output_format.to_s.upcase} format #{dest_file}")
+          ensure_destination_directory(name)
+
+          skipping = case type
+                     when :books
+                       Book.convert_comics(request.path, name, request.input_format, request.output_format, dest_file, request.no_warning)
+                     when :music
+                       Music.convert_songs(request.path, dest_file, request.input_format, request.output_format, request.qualities)
+                     when :video
+                       VideoUtils.convert_videos(request.path, dest_file, request.input_format, request.output_format)
+                     end
+          return [results, name] if skipping.to_i.positive?
+
+          handle_original_file(request, dest_file, final_file)
+          speaker.speak_up("#{name} converted!")
+          results << final_file
+        end
+        [results, name]
+      end
+
+      def ensure_destination_directory(name)
+        dir = File.dirname(name)
+        return if dir == '.'
+
+        file_system.mkdir(dir) unless File.directory?(dir)
+      end
+
+      def handle_original_file(request, dest_file, final_file)
+        if request.rename_original.to_i.positive?
+          file_system.mv(File.basename(request.path), "_#{File.basename(request.path)}_")
+        end
+        file_system.mv(dest_file, final_file) if final_file != dest_file
+      end
+
+      def cleanup_failed_conversion(name, request)
+        return if name.to_s == ''
+
+        dir = File.dirname(request.path) + '/' + name
+        file_system.rm_r(dir) if Dir.exist?(dir)
+      end
+    end
+  end
+end

--- a/app/services/media_librarian/services/remote_sync_service.rb
+++ b/app/services/media_librarian/services/remote_sync_service.rb
@@ -1,0 +1,180 @@
+# frozen_string_literal: true
+
+module MediaLibrarian
+  module Services
+    class RemoteComparisonRequest
+      attr_reader :path, :remote_server, :remote_user, :filter_criteria,
+                  :ssh_opts, :no_prompt
+
+      def initialize(path:, remote_server:, remote_user:, filter_criteria: {},
+                     ssh_opts: {}, no_prompt: 0)
+        @path = path
+        @remote_server = remote_server
+        @remote_user = remote_user
+        @filter_criteria = filter_criteria
+        @ssh_opts = ssh_opts
+        @no_prompt = no_prompt
+      end
+    end
+
+    class RemoteFetchRequest
+      attr_reader :local_folder, :remote_user, :remote_server, :remote_folder,
+                  :clean_remote_folder, :bandwidth_limit, :ssh_opts,
+                  :active_hours, :exclude_folders_in_check, :monitor_options
+
+      def initialize(local_folder:, remote_user:, remote_server:, remote_folder:,
+                     clean_remote_folder: [], bandwith_limit: 0, ssh_opts: {},
+                     active_hours: {}, exclude_folders_in_check: [],
+                     monitor_options: {})
+        @local_folder = local_folder
+        @remote_user = remote_user
+        @remote_server = remote_server
+        @remote_folder = remote_folder
+        @clean_remote_folder = clean_remote_folder
+        @bandwidth_limit = bandwith_limit
+        @ssh_opts = ssh_opts
+        @active_hours = active_hours
+        @exclude_folders_in_check = exclude_folders_in_check
+        @monitor_options = monitor_options
+      end
+    end
+
+    class RemoteSyncService < BaseService
+      def compare_remote_files(request)
+        speaker.speak_up("Starting cleaning remote files on #{request.remote_user}@#{request.remote_server}:#{request.path} using criteria #{request.filter_criteria}, no_prompt=#{request.no_prompt}")
+        ssh_opts = Utils.recursive_typify_keys(request.ssh_opts) || {}
+        tries = 10
+        list = file_system.directory?(request.path) ?
+               file_system.search_folder(request.path, request.filter_criteria) :
+               [[request.path, '']]
+        list.each do |file_entry|
+          begin
+            f_path = file_entry[0]
+            speaker.speak_up("Comparing #{f_path} on local and remote #{request.remote_server}")
+            local_md5sum = file_system.md5sum(f_path)
+            remote_md5sum = fetch_remote_md5sum(request, ssh_opts, f_path)
+            speaker.speak_up("Local md5sum is #{local_md5sum}")
+            speaker.speak_up("Remote md5sum is #{remote_md5sum}")
+            handle_comparison_result(request, f_path, local_md5sum, remote_md5sum)
+          rescue StandardError => e
+            speaker.tell_error(e, "RemoteSyncService.compare_remote_files - file #{file_entry[0]}")
+            retry if (tries -= 1) > 0
+          end
+        end
+      end
+
+      def fetch_media_box(request)
+        loop do
+          begin
+            unless Utils.check_if_active(request.active_hours)
+              sleep 30
+              next
+            end
+            fetch_once(request)
+          rescue StandardError => e
+            speaker.tell_error(e, Utils.arguments_dump(binding))
+            sleep 180
+          end
+        end
+      end
+
+      def fetch_media_box_core(local_folder, remote_user, remote_server, remote_folder,
+                                clean_remote_folder = [], bandwith_limit = 0,
+                                ssh_opts = {}, active_hours = {}, exclude_folders = [])
+        request = RemoteFetchRequest.new(
+          local_folder: local_folder,
+          remote_user: remote_user,
+          remote_server: remote_server,
+          remote_folder: remote_folder,
+          clean_remote_folder: clean_remote_folder,
+          bandwith_limit: bandwith_limit,
+          ssh_opts: ssh_opts,
+          active_hours: active_hours,
+          exclude_folders_in_check: exclude_folders
+        )
+        fetch_once(request)
+      end
+
+      private
+
+      def fetch_once(request)
+        remote_box = "#{request.remote_user}@#{request.remote_server}:#{request.remote_folder}"
+        rsynced_clean = false
+        speaker.speak_up("Starting media synchronisation with #{remote_box} - #{Time.now.utc}", 0)
+        return speaker.speak_up('Would run synchonisation') if Env.pretend?
+
+        base_opts = ['--verbose', '--recursive', '--acls', '--times', '--remove-source-files', '--human-readable', "--bwlimit=#{request.bandwidth_limit}"]
+        opts = base_opts + ["--partial-dir=#{request.local_folder}/.rsync-partial"]
+        speaker.speak_up("Running the command: rsync #{opts.join(' ')} #{remote_box}/ #{request.local_folder}") if Env.debug?
+        Rsync.run("#{remote_box}/", request.local_folder, opts, request.ssh_opts['port'] || 22, request.ssh_opts['keys']) do |result|
+          result.changes.each do |change|
+            speaker.speak_up "#{change.filename} (#{change.summary})"
+          end
+          if result.success?
+            rsynced_clean = true
+          else
+            speaker.speak_up result.error
+          end
+        end
+        clean_remote_directories(request) if rsynced_clean
+        ensure_local_remote_consistency(request, rsynced_clean)
+        speaker.speak_up("Finished media box synchronisation - #{Time.now.utc}", 0)
+        raise 'Rsync failure' unless rsynced_clean
+      end
+
+      def clean_remote_directories(request)
+        return unless request.clean_remote_folder.is_a?(Array)
+
+        request.clean_remote_folder.each do |folder|
+          speaker.speak_up("Cleaning folder #{folder} on #{request.remote_server}", 0) if Env.debug?
+          Net::SSH.start(request.remote_server, request.remote_user, Utils.recursive_typify_keys(request.ssh_opts)) do |ssh|
+            ssh.exec!('find ' + folder.to_s + ' -type d -empty -exec rmdir "{}" \;')
+          end
+        end
+      end
+
+      def ensure_local_remote_consistency(request, rsynced_clean)
+        return if rsynced_clean || Utils.check_if_active(request.active_hours)
+
+        comparison_request = RemoteComparisonRequest.new(
+          path: request.local_folder,
+          remote_server: request.remote_server,
+          remote_user: request.remote_user,
+          filter_criteria: { 'days_newer' => 10, 'exclude_path' => request.exclude_folders_in_check },
+          ssh_opts: request.ssh_opts,
+          no_prompt: 1
+        )
+        compare_remote_files(comparison_request)
+      end
+
+      def fetch_remote_md5sum(request, ssh_opts, path)
+        remote_md5sum = ''
+        Net::SSH.start(request.remote_server, request.remote_user, ssh_opts) do |ssh|
+          remote_md5sum = []
+          ssh.exec!("md5sum \"#{path}\"") do |_, stream, data|
+            remote_md5sum << data if stream == :stdout
+          end
+          remote_md5sum = remote_md5sum.first
+          remote_md5sum = remote_md5sum ? remote_md5sum.gsub(/(\w*)( .*\n)/, '\\1') : ''
+        end
+        remote_md5sum
+      end
+
+      def handle_comparison_result(request, path, local_md5sum, remote_md5sum)
+        if local_md5sum != remote_md5sum || local_md5sum.to_s == '' || remote_md5sum.to_s == ''
+          speaker.speak_up('Mismatch between the 2 files, the remote file might not exist or the local file is incorrectly downloaded')
+          delete_local = speaker.ask_if_needed('Delete the local file? (y/n)', request.no_prompt, 'n') == 'y'
+          file_system.rm_r(path) if delete_local && local_md5sum.to_s != '' && remote_md5sum.to_s != ''
+        else
+          speaker.speak_up('The 2 files are identical!')
+          delete_remote = speaker.ask_if_needed('Delete the remote file? (y/n)', request.no_prompt, 'y') == 'y'
+          if delete_remote
+            Net::SSH.start(request.remote_server, request.remote_user, Utils.recursive_typify_keys(request.ssh_opts)) do |ssh|
+              ssh.exec!("rm \"#{path}\"")
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/media_librarian/services/torrent_queue_service.rb
+++ b/app/services/media_librarian/services/torrent_queue_service.rb
@@ -1,0 +1,220 @@
+# frozen_string_literal: true
+
+module MediaLibrarian
+  module Services
+    class TorrentDownloadRequest
+      attr_reader :torrent_name, :torrent_type, :path, :options,
+                  :tracker, :nodl, :queue_file_handling
+
+      def initialize(torrent_name:, torrent_type:, path:, options:, tracker: '',
+                     nodl: 0, queue_file_handling: {})
+        @torrent_name = torrent_name
+        @torrent_type = torrent_type
+        @path = path
+        @options = options
+        @tracker = tracker
+        @nodl = nodl
+        @queue_file_handling = queue_file_handling
+      end
+    end
+
+    class TorrentQueueService < BaseService
+      def initialize(app: self.class.app, speaker: nil, file_system: nil, client:)
+        super(app: app, speaker: speaker, file_system: file_system)
+        @client = client
+      end
+
+      def parse_pending_downloads
+        speaker.speak_up('Downloading torrent(s) added during the session (if any)', 0)
+        app.db.get_rows('torrents', { status: 2 }).each do |torrent_row|
+          torrent = Cache.object_unpack(torrent_row[:tattributes])
+          log_torrent_details(torrent, torrent_row) if Env.debug?
+          tdid = (Time.now.to_f * 1000).to_i.to_s
+          url = torrent[:torrent_link] ? torrent[:torrent_link] : ''
+          magnet = torrent[:magnet_link]
+          options = build_download_options(torrent_row, torrent, tdid)
+          Cache.queue_state_add_or_update('deluge_options', options)
+          torrent_type = 1
+          success = false
+          tries = 5
+          nodl = TorrentSearch.get_tracker_config(torrent[:tracker], app: app)['no_download'].to_i
+          speaker.speak_up("Will download torrent '#{torrent_row[:name]}' on #{torrent[:tracker]}#{' (url = ' + url.to_s + ')' if url.to_s != ''}")
+          if url.to_s != '' && nodl.zero?
+            path = TorrentSearch.get_torrent_file(tdid, url)
+          elsif magnet.to_s != '' && nodl.zero?
+            path = magnet
+            torrent_type = 2
+          else
+            speaker.speak_up 'no_download setting is activated for this tracker, please download manually.'
+            path = 'nodl'
+          end
+          path = app.temp_dir + "/#{torrent_row[:name]}.torrent" if path.to_s == '' && File.exist?(app.temp_dir + "/#{torrent_row[:name]}.torrent")
+          next if path.nil?
+          while (tries -= 1) >= 0 && !success
+            request = TorrentDownloadRequest.new(
+              torrent_name: torrent_row[:name],
+              torrent_type: torrent_type,
+              path: path,
+              options: options[torrent_row[:name]],
+              tracker: torrent[:tracker],
+              nodl: nodl,
+              queue_file_handling: torrent[:files].is_a?(Array) && !torrent[:files].empty? ? { torrent_row[:identifier] => torrent[:files] } : {}
+            )
+            success = process_download_request(request)
+            speaker.speak_up "Download of torrent '#{torrent_row[:name]}' #{success ? 'succeeded' : 'failed'}" if (Env.debug? || !success) && nodl.zero?
+            FileUtils.rm(app.temp_dir + "/#{tdid}.torrent") rescue nil
+          end
+          client.delete_torrent(torrent_row[:name], 0, 1) unless success
+        end
+      end
+
+      def process_added_torrents
+        while Cache.queue_state_get('deluge_torrents_added').length != 0
+          tid = Cache.queue_state_shift('deluge_torrents_added')
+          tries = 10
+          begin
+            status = app.t_client.get_torrent_status(tid, ['name', 'files', 'total_size', 'progress'])
+            opts = Cache.queue_state_select('deluge_options') { |_, v| v && v[:info_hash] == tid }
+            opts = Cache.queue_state_select('deluge_options') { |torrent_name, _| torrent_name == status['name'] } if opts.nil? || opts.empty?
+            opts = Cache.queue_state_select('deluge_options') { |torrent_name, _| app.str_closeness.getDistance(torrent_name[0..30], status['name'][0..30]) > 0.9 } if opts.nil? || opts.empty?
+            speaker.speak_up("Processing added torrent #{status['name']} (tid '#{tid})'") unless (opts || {}).empty?
+            (opts || {}).each do |torrent_name, option|
+              torrent_cache = app.db.get_rows('torrents', { name: torrent_name }).first
+              app.db.update_rows('torrents', { torrent_id: tid, status: 3 }, { name: torrent_name }) if torrent_cache && torrent_cache[:torrent_id].nil?
+              set_options = {}
+              main_file = client.find_main_file(status, option[:whitelisted_extensions] || [])
+              if main_file.empty? && option[:expect_main_file].to_i > 0
+                speaker.speak_up "Torrent '#{torrent_cache[:name]}' (tid #{tid}) does not contain an archive or an acceptable file, removing" if Env.debug?
+                client.delete_torrent(torrent_name, tid)
+                next
+              end
+              torrent_qualities = Quality.qualities_merge(torrent_name, option[:assume_quality], '', option[:category]).split('.')
+              set_options = client.main_file_only(status, main_file) if option[:main_only] && !main_file.empty?
+              client.rename_torrent_files(tid, status['files'], option[:rename_main].to_s, torrent_qualities, option[:category])
+              unless set_options.empty?
+                speaker.speak_up("Will set options: #{set_options}")
+                app.t_client.set_torrent_options([tid], set_options)
+              end
+              app.t_client.queue_bottom([tid]) unless option[:queue].to_s == 'top'
+              if option[:add_paused].to_i > 0
+                app.t_client.pause_torrent([tid])
+              else
+                app.t_client.resume_torrent([tid])
+              end
+              Cache.queue_state_remove('deluge_options', torrent_name)
+            end
+          rescue StandardError => e
+            if !(tries -= 1).zero?
+              sleep 30
+              retry
+            else
+              speaker.tell_error(e, Utils.arguments_dump(binding))
+            end
+          end
+        end
+      end
+
+      def process_completed_torrents
+        speaker.speak_up('Will process completed torrents', 0) if Env.debug?
+        Cache.queue_state_get('deluge_torrents_completed').each do |tid, data|
+          torrent_record = app.db.get_rows('torrents', {}, { 'torrent_id like ' => tid }).first
+          remove_it = 0
+          begin
+            if torrent_record.nil?
+              app.t_client.remove_torrent(tid, true) if app.remove_torrent_on_completion
+            else
+              torrent = Cache.object_unpack(torrent_record[:tattributes])
+              speaker.speak_up("Processing torrent '#{torrent_record[:name]}' (tid '#{tid}')...", 0) if Env.debug?
+              target_seed_time = (TorrentSearch.get_tracker_config(torrent[:tracker], app: app)['seed_time'] || TorrentClient.get_config('deluge', 'default_seed_time') || 1).to_i
+              seed_time = app.t_client.get_torrent_status(tid, ['active_time'])['active_time'].to_i - data[:active_time].to_i
+              if seed_time.nil?
+                speaker.speak_up 'Torrent no longer exists, will remove now...' if Env.debug?
+                remove_it = 1
+              elsif target_seed_time <= seed_time.to_i / 3600
+                speaker.speak_up "Torrent has been seeding for #{seed_time.to_i / 3600} hours, more than the seed time set at #{target_seed_time} hour(s) for this tracker. Will remove now..." if Env.debug?
+                app.t_client.remove_torrent(tid, false) if app.remove_torrent_on_completion && torrent_record[:status].to_i < 5
+                app.db.update_rows('torrents', { status: [torrent_record[:status], 4].max }, { name: torrent_record[:name] })
+                remove_it = 1
+              elsif Env.debug?
+                speaker.speak_up("Torrent has been seeding for #{seed_time.to_i / 3600} hours, less than the seed time set at #{target_seed_time} hour(s) for this tracker. Skipping...", 0)
+              end
+            end
+          rescue StandardError => e
+            if e.to_s == 'InvalidTorrentError'
+              speaker.speak_up 'Torrent no longer exists, removing from database...' if Env.debug?
+              remove_it = 1
+            else
+              speaker.tell_error(e, Utils.arguments_dump(binding))
+            end
+          end
+          if remove_it > 0
+            Cache.queue_state_remove('deluge_torrents_completed', tid)
+            file_system.rm_r(data[:path]) if data[:path].to_s != '' && file_system.exist?(data[:path].to_s)
+          end
+        end
+      end
+
+      def process_download_request(request)
+        if request.torrent_type == 1 && request.nodl.zero?
+          file = File.open(request.path, 'r')
+          torrent = file.read
+          file.close
+          meta = BEncode.load(torrent, { ignore_trailing_junk: 1 })
+          meta_id = Digest::SHA1.hexdigest(meta['info'].bencode)
+          Cache.queue_state_add_or_update('deluge_options', { request.torrent_name => request.options.merge({ info_hash: meta_id }) })
+          download = { type: 1, type_str: 'file', file: torrent, filename: File.basename(request.path) }
+        elsif request.nodl.zero?
+          meta_id = request.options[:tdid]
+          download = { type: 2, type_str: 'magnet', url: request.path }
+        else
+          meta_id = Time.now.to_f
+        end
+        if request.nodl.zero?
+          if !app.db.get_rows('torrents', { torrent_id: meta_id }).empty? && meta_id.to_s != ''
+            speaker.speak_up "Torrent with TID '#{meta_id}' already exists, nothing to do" if Env.debug?
+            client.delete_torrent(request.torrent_name, 0, 1)
+            return true
+          end
+          speaker.speak_up "Adding #{download[:type_str]} torrent #{request.torrent_name}"
+          client.download_file(download, request.options.deep_dup, meta_id)
+          Cache.queue_state_add_or_update('deluge_torrents_added', meta_id) if meta_id.to_s != '' && request.torrent_type == 1
+        end
+        app.db.update_rows('torrents', { status: 3, torrent_id: meta_id }, { name: request.torrent_name })
+        Cache.queue_state_add_or_update('file_handling', request.queue_file_handling, 1, 1) unless request.queue_file_handling.empty?
+        true
+      rescue StandardError => e
+        Cache.queue_state_remove('deluge_options', request.torrent_name)
+        speaker.tell_error(
+          e,
+          "torrentclient.process_download_torrent('#{request.torrent_type}', '#{request.path}', '#{request.options}', '#{request.tracker}')"
+        )
+        false
+      end
+
+      private
+
+      attr_reader :client
+
+      def log_torrent_details(torrent, torrent_row)
+        speaker.speak_up "#{LINE_SEPARATOR}\nTorrent attributes:"
+        (torrent + torrent_row.select { |key, _| [:name, :identifiers].include?(key) }).each { |key, value| speaker.speak_up "#{key} = #{value}" }
+      end
+
+      def build_download_options(torrent_row, torrent, tdid)
+        {
+          torrent_row[:name] => {
+            tdid: tdid,
+            move_completed: Utils.parse_filename_template(torrent[:move_completed].to_s, torrent),
+            rename_main: Utils.parse_filename_template(torrent[:rename_main].to_s, torrent),
+            queue: torrent[:queue].to_s,
+            assume_quality: torrent[:assume_quality],
+            entry_id: torrent_row[:identifiers].join,
+            added_at: Time.now.to_i,
+            category: torrent[:category]
+          }.merge(torrent.select { |key, _| [:add_paused, :expect_main_file, :main_only, :whitelisted_extensions].include?(key) })
+        }
+      end
+
+    end
+  end
+end

--- a/app/services/media_librarian/services/tracker_query_service.rb
+++ b/app/services/media_librarian/services/tracker_query_service.rb
@@ -1,0 +1,194 @@
+# frozen_string_literal: true
+
+module MediaLibrarian
+  module Services
+    class TrackerSearchRequest
+      attr_reader :sources, :keyword, :limit, :category, :qualities,
+                  :filter_dead, :url, :sort_by, :filter_out, :strict,
+                  :download_criteria, :post_actions, :search_category
+
+      def initialize(sources:, keyword:, limit: 50, category:,
+                     qualities: {}, filter_dead: 1, url: nil,
+                     sort_by: [:tracker, :seeders], filter_out: [],
+                     strict: 0, download_criteria: {}, post_actions: {},
+                     search_category: nil)
+        @sources = sources
+        @keyword = keyword
+        @limit = limit
+        @category = category
+        @qualities = qualities
+        @filter_dead = filter_dead
+        @url = url
+        @sort_by = sort_by
+        @filter_out = filter_out
+        @strict = strict
+        @download_criteria = download_criteria
+        @post_actions = post_actions
+        @search_category = search_category
+      end
+    end
+
+    class TrackerQueryService < BaseService
+      def get_results(request)
+        tries ||= 3
+        results = []
+        r = {}
+        search_category = request.search_category.to_s == '' ? request.category : request.search_category
+        keyword = request.keyword.dup
+        keyword.gsub!(/[\(\)\:]/, '')
+        trackers = get_trackers(request.sources)
+        timeframe_trackers = parse_tracker_timeframes(request.sources || {})
+        trackers.each do |tracker|
+          speaker.speak_up("Looking for all torrents in category '#{search_category}' on '#{tracker}'") if keyword.to_s == '' && Env.debug?
+          keyword_with_site = (keyword + get_site_keywords(tracker, search_category)).strip
+          tracker_results = launch_search(tracker, search_category, keyword_with_site)
+          tracker_results = launch_search(tracker, search_category, keyword) if keyword_with_site != keyword && (tracker_results.nil? || tracker_results.empty?)
+          results += tracker_results
+        end
+        request.filter_out.each do |filter_key|
+          filter_results(results, filter_key, 1) { |torrent| torrent[filter_key.to_sym].to_i != 0 }
+        end
+        if request.filter_dead.to_i > 0
+          filter_results(results, 'seeders', request.filter_dead) { |torrent| torrent[:seeders].to_i >= request.filter_dead.to_i }
+        end
+        results.sort_by! { |torrent| request.sort_by.map { |field| field == :tracker ? trackers.index(torrent[field]) : -torrent[field].to_i } }
+        unless request.qualities.nil? || request.qualities.empty?
+          filter_results(results, 'size', "between #{request.qualities['min_size']}MB and #{request.qualities['max_size']}MB") do |torrent|
+            file_type = TvSeries.identify_file_type(torrent[:name])
+            (request.category == 'shows' && (file_type == 'season' || file_type == 'series')) ||
+              ((torrent[:size].to_f == 0 || request.qualities['min_size'].to_f == 0 || torrent[:size].to_f >= request.qualities['min_size'].to_f * 1024 * 1024) &&
+               (torrent[:size].to_f == 0 || request.qualities['max_size'].to_f == 0 || torrent[:size].to_f <= request.qualities['max_size'].to_f * 1024 * 1024))
+          end
+          if request.qualities['timeframe_size'].to_s != '' && (request.qualities['max_size'].to_s != '' || request.qualities['target_size'].to_s != '')
+            results.map! do |torrent|
+              if torrent[:size].to_f < (request.qualities['target_size'] || request.qualities['max_size']).to_f * 1024 * 1024
+                torrent[:timeframe_size] = Utils.timeperiod_to_sec(request.qualities['timeframe_size'].to_s).to_i
+              end
+              torrent
+            end
+          end
+        end
+        unless timeframe_trackers.nil?
+          results.map! do |torrent|
+            torrent[:timeframe_tracker] = Utils.timeperiod_to_sec(timeframe_trackers[torrent[:tracker]].to_s).to_i
+            torrent
+          end
+        end
+        results = results.first(request.limit.to_i) if request.limit.to_i > 0
+        download_criteria = prepare_download_criteria(request.download_criteria, request.category, request.post_actions)
+        results.each do |torrent|
+          torrent[:assume_quality] = TorrentSearch.get_tracker_config(torrent[:tracker])['assume_quality'].to_s + ' ' + request.qualities['assume_quality'].to_s
+          _, accept = Quality.filter_quality(torrent[:name], request.qualities, request.post_actions[:language], torrent[:assume_quality], request.category)
+          r = Library.parse_media({ type: 'torrent' }.merge(torrent), request.category, request.strict, r, {}, {}, download_criteria) if accept
+        end
+        r
+      rescue StandardError => e
+        speaker.tell_error(e, Utils.arguments_dump(binding))
+        retry unless (tries -= 1) <= 0
+        {}
+      end
+
+      def get_trackers(sources)
+        trackers = parse_tracker_sources(sources || [])
+        trackers = app.trackers.map { |tracker_name, _| tracker_name } if trackers.empty?
+        trackers
+      end
+
+      def get_site_keywords(type, category = '')
+        category && category != '' && app.config[type] && app.config[type]['site_specific_kw'] && app.config[type]['site_specific_kw'][category] ? " #{app.config[type]['site_specific_kw'][category]}" : ''
+      end
+
+      def get_torrent_file(did, url, destination_folder = app.temp_dir)
+        return did if Env.pretend?
+        path = "#{destination_folder}/#{did}.torrent"
+        FileUtils.rm(path) if File.exist?(path)
+        url = @base_url + '/' + url if url.start_with?('/')
+        begin
+          tries ||= 3
+          app.mechanizer.get(url).save(path)
+        rescue StandardError => e
+          if (tries -= 1) >= 0
+            sleep 1
+            retry
+          else
+            raise e
+          end
+        end
+        path
+      rescue StandardError => e
+        speaker.tell_error(e, Utils.arguments_dump(binding))
+        nil
+      end
+
+      def launch_search(tracker, search_category, keyword)
+        if app.trackers[tracker]
+          app.trackers[tracker].search(search_category, keyword)
+        else
+          TorrentRss.links(tracker)
+        end
+      end
+
+      def parse_tracker_sources(sources)
+        case sources
+        when String
+          [sources]
+        when Hash
+          sources.map do |tracker, nested|
+            if tracker == 'rss'
+              parse_tracker_sources(nested)
+            else
+              tracker
+            end
+          end
+        when Array
+          sources.map do |source|
+            parse_tracker_sources(source)
+          end
+        end.flatten
+      end
+
+      def parse_tracker_timeframes(sources, timeframe_trackers = {}, tracker_key = '')
+        if sources.is_a?(Hash)
+          sources.each do |key, value|
+            if key == 'timeframe' && tracker_key.to_s != ''
+              timeframe_trackers.merge!({ tracker_key => value })
+            elsif value.is_a?(Hash) || value.is_a?(Array)
+              timeframe_trackers = parse_tracker_timeframes(value, timeframe_trackers, key)
+            end
+          end
+        elsif sources.is_a?(Array)
+          sources.each do |value|
+            timeframe_trackers = parse_tracker_timeframes(value, timeframe_trackers, tracker_key)
+          end
+        end
+        timeframe_trackers
+      end
+
+      private
+
+      def filter_results(results, condition_name, required_value)
+        results.select! do |torrent|
+          if Env.debug? && !yield(torrent)
+            speaker.speak_up "Torrent '#{torrent[:name]}'[#{condition_name}] do not match requirements (required #{required_value}), removing from list"
+          end
+          yield(torrent)
+        end
+      end
+
+      def prepare_download_criteria(download_criteria, category, post_actions)
+        return {} if download_criteria.nil? || download_criteria.empty?
+
+        download_criteria = Utils.recursive_typify_keys(download_criteria)
+        download_criteria[:move_completed] = download_criteria[:destination][category.to_sym] if download_criteria[:destination]
+        download_criteria.delete(:destination)
+        begin
+          download_criteria[:whitelisted_extensions] = download_criteria[:whitelisted_extensions][Metadata.media_type_get(category)]
+        rescue StandardError
+          nil
+        end
+        download_criteria[:whitelisted_extensions] = FileUtils.get_valid_extensions(category) unless download_criteria[:whitelisted_extensions].is_a?(Array)
+        download_criteria.merge(post_actions)
+      end
+    end
+  end
+end

--- a/lib/media_librarian/container.rb
+++ b/lib/media_librarian/container.rb
@@ -2,6 +2,14 @@
 
 require 'yaml'
 
+require 'simple_args_dispatch' unless defined?(SimpleArgsDispatch)
+require 'simple_config_man' unless defined?(SimpleConfigMan)
+require 'simple_speaker' unless defined?(SimpleSpeaker)
+
+require_relative '../db' unless defined?(Storage::Db)
+require_relative '../torznab_tracker' unless defined?(TorznabTracker)
+require_relative '../utils' unless defined?(Utils)
+
 module MediaLibrarian
   # Container responsible for managing application wide service instances.
   # All services are instantiated once during boot and reused everywhere.

--- a/test/services/list_management_service_test.rb
+++ b/test/services/list_management_service_test.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require_relative 'service_test_helper'
+require_relative '../../app/services/media_librarian/services'
+require_relative '../../app/services/media_librarian/services/base_service'
+require_relative '../../app/services/media_librarian/services/list_management_service'
+
+class ListManagementServiceTest < Minitest::Test
+  def setup
+    @speaker = TestSupport::Fakes::Speaker.new
+    @service = MediaLibrarian::Services::ListManagementService.new(
+      app: nil,
+      speaker: @speaker,
+      file_system: Minitest::Mock.new
+    )
+  end
+
+  def test_get_search_list_returns_empty_when_source_invalid
+    request = MediaLibrarian::Services::SearchListRequest.new(
+      source_type: 'filesystem',
+      category: 'movies',
+      source: {}
+    )
+
+    existing_files, search_list = @service.get_search_list(request)
+
+    assert_equal({ 'movies' => {} }, existing_files)
+    assert_equal({}, search_list)
+    assert_includes @speaker.messages.first, 'get_search_list'
+  end
+
+  def test_get_search_list_uses_cached_results_when_source_valid
+    request = MediaLibrarian::Services::SearchListRequest.new(
+      source_type: 'filesystem',
+      category: 'movies',
+      source: {
+        'existing_folder' => { 'movies' => '/media/movies' },
+        'list_name' => 'watchlist'
+      }
+    )
+
+    cache_name = "filesystemmovies/media/movieswatchlist"
+    existing_files = { cache_name => ['/media/movies/file.mkv'] }
+    search_results = { cache_name => { 'file.mkv' => { size: 123 } } }
+
+    @service.stub(:build_search_list, [search_results, existing_files]) do
+      files, list = @service.get_search_list(request)
+
+      assert_equal(['/media/movies/file.mkv'], files[cache_name])
+      assert_equal({ 'file.mkv' => { size: 123 } }, list)
+    end
+  end
+end

--- a/test/services/media_conversion_service_test.rb
+++ b/test/services/media_conversion_service_test.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require_relative 'service_test_helper'
+require_relative '../../app/services/media_librarian/services'
+require_relative '../../app/services/media_librarian/services/base_service'
+require_relative '../../app/services/media_librarian/services/media_conversion_service'
+
+class MediaConversionServiceTest < Minitest::Test
+  class FakeFileSystem
+    attr_reader :checked_paths
+
+    def initialize
+      @checked_paths = []
+    end
+
+    def exist?(_path)
+      false
+    end
+
+    def directory?(_path)
+      false
+    end
+  end
+
+  def setup
+    @speaker = TestSupport::Fakes::Speaker.new
+    @file_system = FakeFileSystem.new
+    @service = MediaLibrarian::Services::MediaConversionService.new(
+      app: nil,
+      speaker: @speaker,
+      file_system: @file_system
+    )
+  end
+
+  def test_reports_missing_path
+    request = MediaLibrarian::Services::MediaConversionRequest.new(
+      path: '/missing.cbz',
+      input_format: 'cbz',
+      output_format: 'cbz'
+    )
+
+    @service.convert(request)
+
+    assert_includes @speaker.messages, '/missing.cbz does not exist!'
+  end
+
+  def test_unknown_format_triggers_warning
+    request = MediaLibrarian::Services::MediaConversionRequest.new(
+      path: '/tmp/file.xxx',
+      input_format: 'xxx',
+      output_format: 'cbz'
+    )
+
+    @service.convert(request)
+
+    assert_includes @speaker.messages, 'Unknown input format'
+  end
+end

--- a/test/services/remote_sync_service_test.rb
+++ b/test/services/remote_sync_service_test.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require_relative 'service_test_helper'
+require_relative '../../app/services/media_librarian/services'
+require_relative '../../app/services/media_librarian/services/base_service'
+require_relative '../../app/services/media_librarian/services/remote_sync_service'
+
+class RemoteSyncServiceTest < Minitest::Test
+  class FakeFileSystem
+    attr_reader :md5_calls, :removed_paths
+
+    def initialize
+      @md5_calls = []
+      @removed_paths = []
+    end
+
+    def directory?(_path)
+      false
+    end
+
+    def search_folder(_path, _criteria)
+      []
+    end
+
+    def md5sum(path)
+      @md5_calls << path
+      'abc123'
+    end
+
+    def rm_r(path)
+      @removed_paths << path
+    end
+
+    def exist?(_path)
+      true
+    end
+  end
+
+  class FakeSSH
+    def exec!(_command)
+      yield(nil, :stdout, "abc123  file\n") if block_given?
+    end
+  end
+
+  def setup
+    @speaker = TestSupport::Fakes::Speaker.new
+    @file_system = FakeFileSystem.new
+    @service = MediaLibrarian::Services::RemoteSyncService.new(
+      app: nil,
+      speaker: @speaker,
+      file_system: @file_system
+    )
+  end
+
+  def test_compare_remote_files_handles_matching_hashes
+    request = MediaLibrarian::Services::RemoteComparisonRequest.new(
+      path: '/tmp/file',
+      remote_server: 'remote',
+      remote_user: 'user'
+    )
+
+    net_ssh = Module.new do
+      def self.start(_server, _user, _opts = {})
+        yield RemoteSyncServiceTest::FakeSSH.new
+      end
+    end
+
+    unless defined?(Net)
+      Object.const_set(:Net, Module.new)
+      @net_defined = true
+    end
+    @original_ssh = Net.const_get(:SSH) if Net.const_defined?(:SSH)
+    Net.const_set(:SSH, net_ssh)
+
+    @service.compare_remote_files(request)
+
+    assert_includes @speaker.messages, 'The 2 files are identical!'
+  ensure
+    Net.send(:remove_const, :SSH)
+    Net.const_set(:SSH, @original_ssh) if @original_ssh
+    Object.send(:remove_const, :Net) if @net_defined
+  end
+end

--- a/test/services/service_test_helper.rb
+++ b/test/services/service_test_helper.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+
+require_relative '../support/dependency_stubs'
+require_relative '../support/container_helpers'
+require_relative '../../lib/media_librarian/app_container_support'
+
+unless defined?(EXTENSIONS_TYPE)
+  EXTENSIONS_TYPE = {
+    books: %w[cbz pdf cbr epub],
+    music: %w[flac mp3],
+    video: %w[mkv avi mp4]
+  }.freeze
+end
+
+unless defined?(VALID_CONVERSION_INPUTS)
+  VALID_CONVERSION_INPUTS = {
+    books: %w[cbz pdf cbr epub],
+    music: %w[flac],
+    video: %w[iso ts m2ts]
+  }.freeze
+end
+
+unless defined?(VALID_CONVERSION_OUTPUT)
+  VALID_CONVERSION_OUTPUT = {
+    books: %w[cbz],
+    music: %w[mp3],
+    video: %w[mkv]
+  }.freeze
+end
+
+module ServiceTestHelper
+  def build_service_environment
+    TestSupport::ContainerHelpers::StubbedEnvironment.new
+  end
+end
+
+Minitest::Test.include(ServiceTestHelper)

--- a/test/services/torrent_queue_service_test.rb
+++ b/test/services/torrent_queue_service_test.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require_relative 'service_test_helper'
+require_relative '../../app/services/media_librarian/services'
+require_relative '../../app/services/media_librarian/services/base_service'
+require_relative '../../app/services/media_librarian/services/torrent_queue_service'
+
+class TorrentQueueServiceTest < Minitest::Test
+  class FakeDB
+    attr_reader :updated_rows
+
+    def initialize
+      @updated_rows = []
+    end
+
+    def get_rows(*_args)
+      []
+    end
+
+    def update_rows(*args)
+      @updated_rows << args
+    end
+  end
+
+  class FakeClient
+    def delete_torrent(*); end
+    def download_file(*); end
+  end
+
+  class FakeApp
+    attr_accessor :db
+
+    def initialize(db:)
+      @db = db
+    end
+  end
+
+  def setup
+    @speaker = TestSupport::Fakes::Speaker.new
+    @db = FakeDB.new
+    @app = FakeApp.new(db: @db)
+    @service = MediaLibrarian::Services::TorrentQueueService.new(
+      app: @app,
+      speaker: @speaker,
+      client: FakeClient.new
+    )
+  end
+
+  def test_process_download_request_updates_database_when_no_download
+    request = MediaLibrarian::Services::TorrentDownloadRequest.new(
+      torrent_name: 'test',
+      torrent_type: 1,
+      path: 'nodl',
+      options: {},
+      tracker: 'tracker',
+      nodl: 1,
+      queue_file_handling: {}
+    )
+
+    Cache.stub(:queue_state_add_or_update, nil) do
+      Cache.stub(:queue_state_remove, nil) do
+        assert @service.process_download_request(request)
+      end
+    end
+
+    refute_empty @db.updated_rows
+    table, values, conditions = @db.updated_rows.first
+    assert_equal 'torrents', table
+    assert_equal({ name: 'test' }, conditions)
+    assert_equal 3, values[:status]
+    refute_nil values[:torrent_id]
+  end
+end

--- a/test/services/tracker_query_service_test.rb
+++ b/test/services/tracker_query_service_test.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require_relative 'service_test_helper'
+require_relative '../../app/services/media_librarian/services'
+require_relative '../../app/services/media_librarian/services/base_service'
+require_relative '../../app/services/media_librarian/services/tracker_query_service'
+
+class TrackerQueryServiceTest < Minitest::Test
+  class FakeApp
+    attr_accessor :trackers, :config
+
+    def initialize(trackers: {}, config: {})
+      @trackers = trackers
+      @config = config
+    end
+  end
+
+  def setup
+    @speaker = TestSupport::Fakes::Speaker.new
+    @app = FakeApp.new
+    @service = MediaLibrarian::Services::TrackerQueryService.new(
+      app: @app,
+      speaker: @speaker
+    )
+  end
+
+  def test_parse_tracker_sources_handles_nested_structures
+    sources = {
+      'tracker_a' => {},
+      'rss' => ['tracker_b', ['tracker_c']]
+    }
+
+    trackers = @service.parse_tracker_sources(sources)
+
+    assert_includes trackers, 'tracker_a'
+    assert_includes trackers, 'tracker_b'
+    assert_includes trackers, 'tracker_c'
+  end
+
+  def test_get_trackers_defaults_to_registered_trackers
+    trackers = { 'alpha' => Minitest::Mock.new }
+    @app.trackers = trackers
+
+    result = @service.get_trackers(nil)
+
+    assert_equal ['alpha'], result
+  end
+end

--- a/test/support/dependency_stubs.rb
+++ b/test/support/dependency_stubs.rb
@@ -101,6 +101,18 @@ if defined?(Utils)
       def arguments_dump(*)
         'arguments'
       end
+
+      def recursive_typify_keys(value)
+        value
+      end
+
+      def check_if_active(*)
+        true
+      end
+
+      def timeperiod_to_sec(*)
+        0
+      end
     end
   end
 else
@@ -120,6 +132,18 @@ else
 
       def arguments_dump(*)
         'arguments'
+      end
+
+      def recursive_typify_keys(value)
+        value
+      end
+
+      def check_if_active(*)
+        true
+      end
+
+      def timeperiod_to_sec(*)
+        0
       end
     end
   end
@@ -149,6 +173,10 @@ unless defined?(Env)
       def debug?(*_args)
         false
       end
+
+      def pretend?(*_args)
+        false
+      end
     end
   end
 end
@@ -163,6 +191,82 @@ unless defined?(ExecutionHooks)
 
     def alias_hook(sym)
       "__#{sym}__hooked__"
+    end
+  end
+end
+
+module SimpleConfigMan
+  module_function
+
+  def load_settings(*_args)
+    {
+      'preferred_languages' => ['en'],
+      'daemon' => {
+        'workers_pool_size' => 2,
+        'queue_slots' => 2
+      }
+    }
+  end
+
+  def reconfigure(*_args)
+    # no-op in tests
+  end
+end
+
+module Storage
+  class Db
+    def initialize(*); end
+
+    def method_missing(*)
+      nil
+    end
+
+    def respond_to_missing?(*_args)
+      true
+    end
+  end
+end
+
+module FuzzyStringMatch
+  class JaroWinkler
+    def self.create(*)
+      new
+    end
+
+    def distance(*)
+      1.0
+    end
+  end
+end
+
+module Cache
+  class << self
+    def queue_state_add_or_update(*)
+      # no-op in tests
+    end
+
+    def queue_state_remove(*)
+      # no-op in tests
+    end
+
+    def queue_state_get(*)
+      []
+    end
+  end
+end
+
+unless {}.respond_to?(:deep_dup)
+  class Hash
+    def deep_dup
+      each_with_object({}) do |(key, value), memo|
+        memo[key] = value.respond_to?(:deep_dup) ? value.deep_dup : value.dup rescue value
+      end
+    end
+  end
+
+  class Array
+    def deep_dup
+      map { |value| value.respond_to?(:deep_dup) ? value.deep_dup : value.dup rescue value }
     end
   end
 end


### PR DESCRIPTION
## Summary
- add a MediaLibrarian::Services namespace with a base adapter and dedicated service classes for conversion, remote sync, list management, torrent queueing, and tracker queries
- update existing entry points to delegate to the new services and harden container bootstrapping for injectable dependencies
- introduce a focused service test helper, enhanced dependency stubs, and unit tests covering the extracted services

## Testing
- bundle exec ruby -Itest test/services/media_conversion_service_test.rb
- bundle exec ruby -Itest test/services/remote_sync_service_test.rb
- bundle exec ruby -Itest test/services/tracker_query_service_test.rb
- bundle exec ruby -Itest test/services/torrent_queue_service_test.rb
- bundle exec ruby -Itest test/services/list_management_service_test.rb
- bundle exec ruby -Itest test/librarian_cli_test.rb
- bundle exec ruby -Itest test/daemon_integration_test.rb

------
https://chatgpt.com/codex/tasks/task_e_68f4b531b3c08327a3d5db8cba1eab3d