### PR TITLE
Replace custom SQLite layer with Sequel

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,3 +37,4 @@ gem 'tvmaze', :git => 'https://github.com/raphyduck/tvmaze.git', :require => fal
 gem 'unrar', :git => 'https://github.com/raphyduck/unrar.git', :require => false
 gem 'xbmc-client', :git => 'https://github.com/raphyduck/xbmc-client.git', :require => false
 gem 'zeitwerk'
+gem 'sequel', :require => false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -245,6 +245,8 @@ GEM
       base64
     sax-machine (1.3.2)
     securerandom (0.4.1)
+    sequel (5.97.0)
+      bigdecimal
     simple_args_dispatch (0.4.5)
       simple_speaker (~> 0.3.0)
     simple_config_man (0.3.9)
@@ -305,6 +307,7 @@ DEPENDENCIES
   rexml
   rsync!
   ruby-mp3info!
+  sequel
   simple_args_dispatch (~> 0.4.0)
   simple_config_man (~> 0.3.8)
   simple_speaker (~> 0.3.0)

--- a/lib/db/migrations/001_initial_schema.rb
+++ b/lib/db/migrations/001_initial_schema.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    create_table?(:queues_state) do
+      String :queue_name, size: 200, primary_key: true
+      Text :value
+      DateTime :created_at
+    end
+
+    create_table?(:media_lists) do
+      Text :list_name, null: false
+      Text :type
+      Text :title
+      Integer :year
+      Text :alt_titles
+      Text :url
+      Text :imdb
+      Text :tmdb
+      DateTime :created_at
+
+      index [:list_name, :title, :year, :imdb], unique: true, name: :idx_media_lists_unique
+    end
+
+    create_table?(:metadata_search) do
+      Text :keywords, null: false
+      Integer :type
+      Text :result
+      DateTime :created_at
+
+      index [:keywords, :type], unique: true, name: :idx_metadata_search_keywords_type
+    end
+
+    create_table?(:torrents) do
+      String :name, size: 500, primary_key: true
+      Text :identifier
+      Text :identifiers
+      Text :tattributes
+      DateTime :created_at
+      DateTime :updated_at
+      DateTime :waiting_until
+      Text :torrent_id
+      Integer :status
+
+      index :torrent_id, unique: true, name: :idx_torrents_torrent_id
+    end
+
+    create_table?(:trakt_auth) do
+      String :account, size: 30, primary_key: true
+      String :access_token, size: 200
+      String :token_type, size: 200
+      String :refresh_token, size: 200
+      String :scope, size: 200
+      Integer :created_at
+      Integer :expires_in
+    end
+  end
+end

--- a/lib/utils.rb
+++ b/lib/utils.rb
@@ -74,7 +74,7 @@ class Utils
   end
 
   def self.list_db(table:, entry: '')
-    return [] unless DB_SCHEMA.map { |k, _| k.to_s }.include?(table)
+    return [] unless MediaLibrarian.app.db.table_exists?(table)
     column = MediaLibrarian.app.db.get_main_column(table)
     r = if entry.to_s == ''
           MediaLibrarian.app.db.get_rows(table)

--- a/test/lib/storage_db_test.rb
+++ b/test/lib/storage_db_test.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require 'tmpdir'
+require 'fileutils'
+require 'ostruct'
+
+require_relative '../test_helper'
+
+Storage.send(:remove_const, :Db) if Storage.const_defined?(:Db)
+load File.expand_path('../../lib/db.rb', __dir__)
+
+class StorageDbTest < Minitest::Test
+  def setup
+    @tmp_dir = Dir.mktmpdir('storage-db-test')
+    @db_path = File.join(@tmp_dir, 'test.db')
+    @speaker = TestSupport::Fakes::Speaker.new
+    @app_stub = OpenStruct.new(speaker: @speaker, env_flags: {})
+  end
+
+  def teardown
+    FileUtils.remove_entry(@tmp_dir) if @tmp_dir && Dir.exist?(@tmp_dir)
+  end
+
+  def test_migrations_create_expected_schema
+    with_stubbed_app do
+      db = Storage::Db.new(@db_path)
+      assert db.table_exists?(:torrents)
+      schema = db.dump_schema
+      assert_includes schema[:torrents].keys, :name
+      assert_includes schema[:metadata_search].keys, :keywords
+      db.database.disconnect
+    end
+  end
+
+  def test_crud_operations_and_json_serialization
+    with_stubbed_app do
+      db = Storage::Db.new(@db_path)
+      attributes = { tracker: 'tracker', f_type: 'movie' }
+      db.insert_row('torrents', {
+        name: 'example.torrent',
+        identifier: 'foo',
+        tattributes: attributes,
+        status: 1
+      })
+
+      rows = db.get_rows('torrents', { name: 'example.torrent' })
+      refute_empty rows
+      row = rows.first
+      assert_equal 'foo', row[:identifier]
+      assert_equal attributes, row[:tattributes]
+      refute_nil row[:created_at]
+      refute_nil row[:updated_at]
+
+      db.update_rows('torrents', { status: 4 }, { name: 'example.torrent' })
+      updated = db.get_rows('torrents', { name: 'example.torrent' }).first
+      assert_equal 4, updated[:status]
+
+      db.delete_rows('torrents', { name: 'example.torrent' })
+      assert_empty db.get_rows('torrents', { name: 'example.torrent' })
+      db.database.disconnect
+    end
+  end
+
+  def test_touch_rows_updates_timestamp
+    with_stubbed_app do
+      db = Storage::Db.new(@db_path)
+      db.insert_row('torrents', { name: 'touch-me', status: 0 })
+      initial = db.get_rows('torrents', { name: 'touch-me' }).first
+
+      db.stub(:current_timestamp, '2024-01-01T00:00:00Z') do
+        db.touch_rows('torrents', { name: 'touch-me' })
+      end
+
+      touched = db.get_rows('torrents', { name: 'touch-me' }).first
+      assert_equal '2024-01-01T00:00:00Z', touched[:updated_at]
+      assert_equal initial[:created_at], touched[:created_at]
+      db.database.disconnect
+    end
+  end
+
+  def test_schema_evolution_runs_new_migrations
+    migration_dir = File.join(@tmp_dir, 'migrations')
+    FileUtils.mkdir_p(migration_dir)
+    FileUtils.cp(File.join(__dir__, '../../lib/db/migrations/001_initial_schema.rb'),
+                 File.join(migration_dir, '001_initial_schema.rb'))
+
+    with_stubbed_app do
+      db = Storage::Db.new(@db_path, 0, migrations_path: migration_dir)
+      db.database.disconnect
+    end
+
+    File.write(File.join(migration_dir, '002_add_test_flag.rb'), <<~RUBY)
+      Sequel.migration do
+        change do
+          alter_table(:torrents) do
+            add_column :test_flag, Integer
+          end
+        end
+      end
+    RUBY
+
+    with_stubbed_app do
+      db = Storage::Db.new(@db_path, 0, migrations_path: migration_dir)
+      columns = db.database.schema(:torrents).map(&:first)
+      assert_includes columns, :test_flag
+      db.database.disconnect
+    end
+  end
+
+  private
+
+  def with_stubbed_app(&block)
+    MediaLibrarian.stub(:app, @app_stub, &block)
+  end
+end


### PR DESCRIPTION
## Summary
- add Sequel as a dependency and introduce migrations for the existing SQLite schema
- rewrite Storage::Db to delegate CRUD operations through Sequel datasets with safe JSON handling
- backfill unit tests that exercise migrations, CRUD helpers, and timestamp updates

## Testing
- bundle exec ruby -Itest -e "Dir['test/**/*_test.rb'].each { |f| require_relative f }"

------
https://chatgpt.com/codex/tasks/task_e_68f4bdc3e0248327b91e56b99a44eecd