### PR TITLE
Fix unmatched end in Library class

### DIFF
--- a/app/library.rb
+++ b/app/library.rb
@@ -537,6 +537,7 @@ class Library
     rescue => e
       app.speaker.tell_error(e, Utils.arguments_dump(binding), 0) rescue nil
       0
+    end
   end
 
   class << self
@@ -554,6 +555,4 @@ class Library
       MediaLibrarian::Services::ListManagementService.new(app: app)
     end
   end
-end
-
 end


### PR DESCRIPTION
## Summary
- add the missing `end` for the import_list_csv rescue block
- remove the extra trailing `end` so the Library class closes correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f4c243ca588327b645a625217e0765