### PR TITLE
Stop clearing entire queues when killing single jobs

### DIFF
--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -136,7 +136,6 @@ class Daemon < EventMachine::Connection
 
   def self.kill_job(w)
     queue_name = w[:queue_name]
-    @queues[queue_name][:clearing] = 1 if queue_name && @queues[queue_name]
     waiter = 0
     while w[:jid].to_i > 0 && get_children_count(w[:jid]).to_i > 0 && waiter < 10
       $speaker.speak_up "Waiting for child jobs to clear up..."


### PR DESCRIPTION
## Summary
- remove the queue-clearing flag set when kill_job is invoked so individual job termination does not wipe the queue

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f3c7426eb0832799712b40c261964d