### PR TITLE
Respect queue concurrency limits when scheduling continuous jobs

### DIFF
--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -246,6 +246,8 @@ class Daemon
         next unless @template_cache[type]
 
         @template_cache[type].each do |task, params|
+          limit = determine_queue_limit(params)
+          queue_limits[task] = limit
           args = params['command'].split('.')
           if params['args'].is_a?(Hash)
             args += params['args'].map { |a, v| "--#{a}=#{v}" }
@@ -258,9 +260,11 @@ class Daemon
             frequency = Utils.timeperiod_to_sec(params['every']).to_i
             next unless should_run_periodic?(task, frequency)
 
+            queue_name = fetch_function_config(args)[1] || task
+            queue_limits[queue_name] = limit
             enqueue(
               args: args,
-              queue: fetch_function_config(args)[1] || task,
+              queue: queue_name,
               task: task,
               internal: 0,
               client: Thread.current[:current_daemon],
@@ -294,6 +298,7 @@ class Daemon
       @last_execution = {}
       @last_email_report = {}
       @template_cache = nil
+      @queue_limits = Concurrent::Hash.new
       @jobs = Concurrent::Hash.new
       @job_children = Concurrent::Hash.new { |h, k| h[k] = Concurrent::Array.new }
       @executor = Concurrent::ThreadPoolExecutor.new(
@@ -489,7 +494,66 @@ class Daemon
     end
 
     def queue_busy?(queue)
-      job_registry.values.any? { |job| job.queue == queue && job.running? }
+      return false if queue.to_s.empty?
+
+      active_jobs_for_queue(queue).size >= queue_limit(queue)
+    end
+
+    def active_jobs_for_queue(queue)
+      return [] if queue.to_s.empty?
+
+      job_registry.values.select { |job| job.queue == queue && job.running? }
+    end
+
+    def queue_limit(queue)
+      return 1 if queue.to_s.empty?
+
+      limit = queue_limits[queue]
+      unless limit
+        limit = queue_limit_from_template(queue)
+        limit = 1 if limit.nil? || limit <= 0
+        queue_limits[queue] = limit
+      end
+      limit
+    end
+
+    def queue_limit_from_template(queue)
+      return unless @template_cache
+
+      %w[continuous periodic].each do |type|
+        params = @template_cache[type] && @template_cache[type][queue]
+        next unless params
+
+        return determine_queue_limit(params)
+      end
+
+      nil
+    end
+
+    def queue_limits
+      @queue_limits ||= Concurrent::Hash.new
+    end
+
+    def determine_queue_limit(params)
+      limit = extract_configured_limit(params)
+      limit = 1 if limit.nil? || limit <= 0
+      limit
+    end
+
+    def extract_configured_limit(params)
+      return unless params.is_a?(Hash)
+
+      limit = params['max_concurrency'] || params['max_pool_size']
+      limit = limit.to_i if limit
+      return limit if limit && limit.positive?
+
+      command = params['command']
+      return unless command
+
+      config = fetch_function_config(command.split('.'))
+      limit = config[0]
+      limit = limit.to_i if limit
+      limit if limit && limit.positive?
     end
 
     def should_run_periodic?(task, frequency)
@@ -534,6 +598,7 @@ class Daemon
       @control_server = nil
       @executor = nil
       @template_cache = nil
+      @queue_limits = nil
       @running = nil
       @stop_event = nil
       @is_daemon = false

--- a/test/daemon_queue_concurrency_test.rb
+++ b/test/daemon_queue_concurrency_test.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require_relative '../app/daemon'
+
+class DaemonQueueConcurrencyTest < Minitest::Test
+  def setup
+    reset_librarian_state!
+    @environment = build_stubbed_environment
+    MediaLibrarian.application = @environment.application
+    Daemon.configure(app: @environment.application)
+    Daemon.instance_variable_set(:@queue_limits, Concurrent::Hash.new)
+    Daemon.instance_variable_set(:@jobs, {})
+    Daemon.instance_variable_set(:@template_cache, nil)
+  end
+
+  def teardown
+    Daemon.instance_variable_set(:@queue_limits, nil)
+    Daemon.instance_variable_set(:@jobs, nil)
+    Daemon.instance_variable_set(:@template_cache, nil)
+    MediaLibrarian.application = nil
+    @environment.cleanup if @environment
+  end
+
+  def test_queue_busy_respects_configured_concurrency
+    queue = 'continuous-task'
+    Daemon.send(:queue_limits)[queue] = 2
+
+    refute Daemon.send(:queue_busy?, queue), 'queues should allow scheduling when under the limit'
+
+    job1 = build_running_job(queue)
+    Daemon.instance_variable_set(:@jobs, { '1' => job1 })
+    refute Daemon.send(:queue_busy?, queue), 'queues with capacity should not be busy'
+
+    job2 = build_running_job(queue)
+    Daemon.instance_variable_set(:@jobs, { '1' => job1, '2' => job2 })
+    assert Daemon.send(:queue_busy?, queue), 'queue should report busy once limit is reached'
+  end
+
+  def test_queue_busy_defaults_to_single_worker
+    queue = 'default'
+    job = build_running_job(queue)
+    Daemon.instance_variable_set(:@jobs, { '1' => job })
+
+    assert Daemon.send(:queue_busy?, queue), 'queues without configuration should default to 1'
+  end
+
+  private
+
+  def build_running_job(queue)
+    Daemon::Job.new(id: 'job', queue: queue, status: :running, finished_at: nil)
+  end
+end


### PR DESCRIPTION
## Summary
- ensure queue busy checks honor each queue's configured concurrency limit before scheduling continuous jobs
- cache queue limits derived from scheduler templates and command configuration
- add regression coverage for queue concurrency handling in the daemon

## Testing
- bundle exec ruby -Itest -e "Dir['test/**/*_test.rb'].sort.each { |f| require File.expand_path(f) }"

------
https://chatgpt.com/codex/tasks/task_e_68f4c2b7a18c832796f3ca312519f4d6