### PR TITLE
Handle missing media conversion paths before format validation

### DIFF
--- a/app/services/media_librarian/services/media_conversion_service.rb
+++ b/app/services/media_librarian/services/media_conversion_service.rb
@@ -25,6 +25,12 @@ module MediaLibrarian
       def convert(request)
         last_name = ''
         results = []
+        missing_path = false
+        unless file_system.exist?(request.path)
+          speaker.speak_up("#{request.path} does not exist!")
+          missing_path = true
+        end
+
         type_pair = EXTENSIONS_TYPE.find { |_type, values| values.include?(request.input_format) }
         return speaker.speak_up('Unknown input format') unless type_pair
 
@@ -43,9 +49,7 @@ module MediaLibrarian
           return unless continue == 'y'
         end
 
-        unless file_system.exist?(request.path)
-          return speaker.speak_up("#{request.path} does not exist!")
-        end
+        return [] if missing_path
 
         if file_system.directory?(request.path)
           directory_results, last_name = convert_directory(request)


### PR DESCRIPTION
## Summary
- log a missing path message before validating conversion formats
- avoid processing conversion requests once the input path is known to be absent

## Testing
- bundle exec ruby -Itest test/services/media_conversion_service_test.rb
- bundle exec ruby -Itest test/services/list_management_service_test.rb
- bundle exec ruby -Itest test/services/remote_sync_service_test.rb
- bundle exec ruby -Itest test/services/torrent_queue_service_test.rb
- bundle exec ruby -Itest test/services/tracker_query_service_test.rb

------
https://chatgpt.com/codex/tasks/task_e_68f4dd395eec832784db4f5cfa36e572