### PR TITLE
Add extensive utility test coverage

### DIFF
--- a/test/lib/data_utils_test.rb
+++ b/test/lib/data_utils_test.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+# Provide minimal stubs for dependencies that DataUtils relies on.
+unless defined?(Vash)
+  class Vash < Hash; end
+end
+
+Cache ||= Module.new
+
+Cache.define_singleton_method(:object_pack) do |value, *_args|
+  value
+end unless Cache.respond_to?(:object_pack)
+
+require_relative '../../lib/data_utils'
+
+class DataUtilsTest < Minitest::Test
+  def test_dump_variable_limits_depth_within_hash
+    value = { foo: { bar: 'baz', nested: [1, 2] } }
+
+    output = DataUtils.dump_variable(value, 1)
+
+    assert_includes output, ':foo=>'
+    assert_includes output, '<2 element(s)>'
+  end
+
+  def test_dump_variable_formats_arrays_and_hashes
+    value = { foo: ['bar', 2], flag: nil }
+
+    output = DataUtils.dump_variable(value, 3)
+
+    assert_includes output, '['
+    assert_includes output, "'bar'"
+    assert_includes output, '2'
+    assert_includes output, 'nil'
+  end
+
+  def test_dump_variable_respects_maximum_key_threshold
+    value = { a: 1, b: 2, c: 3 }
+
+    output = DataUtils.dump_variable(value, 2, 0, 1, 2)
+
+    assert_includes output, ':a=>'
+    assert_includes output, ':b=>'
+    refute_includes output, ':c=>'
+  end
+
+  def test_format_string_handles_various_inputs
+    assert_equal 'nil', DataUtils.format_string(nil)
+    assert_equal "'sample'", DataUtils.format_string('sample')
+    assert_equal ['1', "'two'"], DataUtils.format_string([1, 'two'])
+
+    hash_input = { a: 1, b: 'two' }
+    result = DataUtils.format_string(hash_input)
+
+    assert_equal %i[a b], result
+    assert_equal({ a: '1', b: "'two'" }, hash_input)
+  end
+end

--- a/test/lib/string_utils_test.rb
+++ b/test/lib/string_utils_test.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+require 'titleize'
+
+SPACE_SUBSTITUTE = '\\.
+ _\\-' unless defined?(SPACE_SUBSTITUTE)
+
+module Metadata
+  def self.identify_release_year(str)
+    (str[/\((\d{4})\)$/, 1] || 0).to_i
+  end
+end unless defined?(Metadata)
+
+require_relative '../../lib/string_utils'
+
+class StringUtilsTest < Minitest::Test
+  def test_accents_clear_transliterates_nested_structures
+    assert_equal 'AaEeIiOoUu', StringUtils.accents_clear('ÀaÊeÎiÔoÛu')
+    assert_equal ['Cafe'], StringUtils.accents_clear(['Café'])
+    assert_equal({ 'Cafe' => 'Resume' }, StringUtils.accents_clear({ 'Café' => 'Résumé' }))
+  end
+
+  def test_fix_encoding_removes_invalid_sequences
+    invalid = +"caf\xE9"
+    invalid.force_encoding('ISO-8859-1').force_encoding('UTF-8')
+
+    fixed = StringUtils.fix_encoding(invalid)
+
+    assert_equal 'caf', fixed
+    assert fixed.valid_encoding?
+  end
+
+  def test_clean_search_normalizes_titles
+    assert_equal 'Office', StringUtils.clean_search('The Office (US)')
+    assert_equal 'Planete Terre', StringUtils.clean_search('Planète Terre')
+  end
+
+  def test_commatize_adds_separator_only_when_needed
+    assert_equal '', StringUtils.commatize('')
+    assert_equal ', ', StringUtils.commatize('value')
+  end
+
+  def test_gsub_accepts_array_of_patterns
+    assert_equal 'x x', StringUtils.gsub('Hello World', ['hello', 'world'], 'x')
+  end
+
+  def test_intersection_returns_common_prefix
+    assert_equal 'lock_time', StringUtils.intersection('lock_timer', 'lock_time_record')
+    assert_equal '', StringUtils.intersection('alpha', 'beta')
+  end
+
+  def test_pluralize_adds_suffix_when_quantity_greater_than_one
+    assert_equal '', StringUtils.pluralize(1)
+    assert_equal 's', StringUtils.pluralize(2)
+  end
+
+  def test_regexify_builds_pattern_for_compound_titles
+    pattern = StringUtils.regexify('Les Misérables')
+
+    assert_includes pattern, 'Misérab'
+    assert_includes pattern, '(le)?'
+  end
+
+  def test_regularise_media_filename_applies_requested_formatting
+    result = StringUtils.regularise_media_filename('My Movie: Extra', 'titleize|nospace')
+    assert_equal 'My.Movie.Extra', result
+
+    downcased = StringUtils.regularise_media_filename('Another Movie', 'downcase')
+    assert_equal 'another movie', downcased
+  end
+
+  def test_title_match_string_includes_year_range_and_regex_suffix
+    pattern = StringUtils.title_match_string('Example (2020)')
+
+    assert_includes pattern, '2019|2020|2021'
+    assert pattern.end_with?('.{0,7}$')
+  end
+end
+

--- a/test/lib/time_utils_test.rb
+++ b/test/lib/time_utils_test.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+require 'titleize'
+
+SPACE_SUBSTITUTE = '\\.
+ _\\-' unless defined?(SPACE_SUBSTITUTE)
+
+Object.send(:remove_const, :TimeUtils) if defined?(TimeUtils) && !TimeUtils.is_a?(Class)
+
+require_relative '../../lib/string_utils'
+require_relative '../../lib/time_utils'
+
+class TimeUtilsTest < Minitest::Test
+  def test_seconds_in_words_handles_mixed_units
+    assert_equal '1 hour, 1 minute, 1 second', TimeUtils.seconds_in_words(3661)
+  end
+
+  def test_seconds_in_words_formats_fractional_seconds
+    assert_equal '0.5 second', TimeUtils.seconds_in_words(0.5)
+  end
+
+  def test_seconds_in_words_returns_empty_string_for_zero
+    assert_equal '', TimeUtils.seconds_in_words(0)
+  end
+end
+

--- a/test/lib/utils_test.rb
+++ b/test/lib/utils_test.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+require 'titleize'
+
+SPACE_SUBSTITUTE = '\\.
+ _\\-' unless defined?(SPACE_SUBSTITUTE)
+FILENAME_NAMING_TEMPLATE = %w[
+  full_name
+  destination_folder
+  movies_name
+  series_name
+  episode_season
+  episode_numbering
+  episode_name
+  quality
+  proper
+  part
+] unless defined?(FILENAME_NAMING_TEMPLATE)
+
+Object.send(:remove_const, :TimeUtils) if defined?(TimeUtils) && !TimeUtils.is_a?(Class)
+
+require_relative '../../lib/string_utils'
+require_relative '../../lib/time_utils'
+require_relative '../../lib/utils'
+
+class UtilsTest < Minitest::Test
+  def setup
+    @thread = Thread.current
+    @original_lock_time = @thread[:lock_time]
+    @thread[:lock_time] = nil
+  end
+
+  def teardown
+    @thread[:lock_time] = @original_lock_time
+  end
+
+  def test_lock_block_allows_reentrant_execution
+    calls = []
+
+    Utils.lock_block('sample'.dup) do
+      calls << :outer
+      Utils.lock_block('sample'.dup) { calls << :inner }
+    end
+
+    assert_equal %i[outer inner], calls
+  end
+
+  def test_lock_block_serializes_threads
+    calls = Queue.new
+
+    t1 = Thread.new do
+      Utils.lock_block('parallel'.dup) do
+        calls << :start_first
+        sleep 0.05
+        calls << :end_first
+      end
+    end
+
+    sleep 0.01 until t1.status == 'sleep'
+
+    t2 = Thread.new do
+      Utils.lock_block('parallel'.dup) do
+        calls << :start_second
+        calls << :end_second
+      end
+    end
+
+    [t1, t2].each(&:join)
+
+    assert_equal %i[start_first end_first start_second end_second], Array.new(4) { calls.pop }
+  end
+
+  def test_lock_timer_register_merges_similar_prefixes
+    Utils.lock_timer_register('processA', 1.0, @thread)
+    Utils.lock_timer_register('processB', 2.0, @thread)
+
+    assert_equal({ "process*" => 3.0 }, @thread[:lock_time])
+  end
+
+  def test_lock_time_get_formats_elapsed_time
+    @thread[:lock_time] = {
+      'outer' => 1.2,
+      'inner' => 0.002
+    }
+
+    message = Utils.lock_time_get(@thread)
+
+    assert_includes message, "1.2 seconds locked for 'outer'"
+    assert_includes message, "0.002 second locked for 'inner'"
+  ensure
+    @thread[:lock_time] = nil
+  end
+
+  def test_lock_time_merge_accumulates_values
+    source = { lock_time: { 'work' => 0.5 } }
+
+    Utils.lock_time_merge(source, @thread)
+
+    assert_includes @thread[:lock_time].keys, 'work'
+    assert_includes Utils.lock_time_get(@thread), "0.5 second locked for 'work'"
+  end
+
+  def test_check_if_active_respects_daily_schedule
+    active_hours = { 'start' => 8, 'end' => 17 }
+
+    Time.stub(:now, Time.new(2024, 1, 1, 9, 0, 0)) do
+      assert Utils.check_if_active(active_hours)
+    end
+
+    Time.stub(:now, Time.new(2024, 1, 1, 7, 0, 0)) do
+      refute Utils.check_if_active(active_hours)
+    end
+  end
+
+  def test_check_if_active_handles_overnight_windows
+    hours = { 'start' => '22', 'end' => '6' }
+
+    Time.stub(:now, Time.new(2024, 1, 1, 23, 0, 0)) do
+      assert Utils.check_if_active(hours)
+    end
+
+    Time.stub(:now, Time.new(2024, 1, 1, 12, 0, 0)) do
+      refute Utils.check_if_active(hours)
+    end
+  end
+
+  def test_check_if_active_returns_true_for_invalid_input
+    assert Utils.check_if_active(nil)
+  end
+
+  def test_match_release_year_allows_off_by_one
+    assert Utils.match_release_year(2020, 2021)
+    refute Utils.match_release_year(2020, 2025)
+  end
+
+  def test_recursive_typify_keys_symbolizes_by_default
+    value = { 'foo' => { 'bar' => 1 }, 'list' => [{ 'baz' => 2 }] }
+
+    result = Utils.recursive_typify_keys(value)
+
+    assert_equal({ foo: { bar: 1 }, list: [{ baz: 2 }] }, result)
+  end
+
+  def test_recursive_typify_keys_can_preserve_strings
+    value = { foo: { bar: 1 }, list: [{ baz: 2 }] }
+
+    result = Utils.recursive_typify_keys(value, 0)
+
+    assert_equal({ 'foo' => { 'bar' => 1 }, 'list' => [{ 'baz' => 2 }] }, result)
+  end
+
+  def test_parse_filename_template_substitutes_metadata
+    metadata = {
+      'full_name' => 'My Movie',
+      'quality' => '1080P',
+      'episode_name' => 'pilot'
+    }
+
+    template = '{{ full_name }} - {{ quality|downcase }} - {{ episode_name|titleize }}'
+
+    parsed = Utils.parse_filename_template(template, metadata)
+
+    assert_equal 'My Movie - 1080p - Pilot', parsed
+  end
+end
+

--- a/test/services/service_test_helper.rb
+++ b/test/services/service_test_helper.rb
@@ -8,19 +8,22 @@ require_relative '../../lib/media_librarian/app_container_support'
 
 unless defined?(EXTENSIONS_TYPE)
   EXTENSIONS_TYPE = {
-    video: %w[mkv avi mp4]
+    video: %w[mkv avi mp4],
+    audio: %w[flac mp3]
   }.freeze
 end
 
 unless defined?(VALID_CONVERSION_INPUTS)
   VALID_CONVERSION_INPUTS = {
-    video: %w[iso ts m2ts]
+    video: %w[iso ts m2ts],
+    audio: %w[flac]
   }.freeze
 end
 
 unless defined?(VALID_CONVERSION_OUTPUT)
   VALID_CONVERSION_OUTPUT = {
-    video: %w[mkv]
+    video: %w[mkv],
+    audio: %w[mp3]
   }.freeze
 end
 


### PR DESCRIPTION
## Summary
- add focused unit tests for the DataUtils, StringUtils, TimeUtils, and Utils helpers
- extend the service test helper constants so audio conversion scenarios can be exercised

## Testing
- bundle exec ruby -Itest -e "Dir['test/**/*_test.rb'].sort.each { |f| require File.expand_path(f) }"

------
https://chatgpt.com/codex/tasks/task_e_68f4dd7001908327ab5e5f820c9e3a5b