### PR TITLE
Implement daemon configuration reload flow

### DIFF
--- a/lib/media_librarian/container.rb
+++ b/lib/media_librarian/container.rb
@@ -95,6 +95,16 @@ module MediaLibrarian
       services.fetch(:queue_slots)
     end
 
+    def reload_config!(new_settings)
+      store(:config, new_settings)
+
+      daemon_config = config.fetch('daemon', {})
+      store(:workers_pool_size, daemon_config['workers_pool_size'] || 4, freeze: true)
+      store(:queue_slots, daemon_config['queue_slots'] || 4, freeze: true)
+
+      store(:trackers, build_trackers)
+    end
+
     private
 
     attr_reader :services


### PR DESCRIPTION
## Summary
- add a container helper to refresh configuration, derived daemon limits, and tracker definitions
- implement `Daemon.reload` to re-read configuration, reset caches, and restart scheduling
- extend test support and add an integration test that verifies queue slots and scheduled work update after reload

## Testing
- bundle exec ruby -Itest test/daemon_integration_test.rb

------
https://chatgpt.com/codex/tasks/task_e_68f4f40d222c832790348cc884b2451d