### PR TITLE
Add static control dashboard and protect write endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,35 @@ WARNING: This is beta software. It might not work as intended.
 What is it?
 This program is made to answer my various needs for automation in the management of video media collections.
 
+## Contrôle HTTP et interface web
+
+Le démon expose un serveur HTTP léger (WEBrick) permettant de piloter les jobs, consulter les logs et éditer les fichiers de configuration YAML. Une interface web statique est disponible à l'adresse racine `/` et consomme les endpoints JSON (`/status`, `/logs`, `/config`, `/scheduler`).
+
+### Lancement
+
+1. Démarrer le démon (ex. `bundle exec ruby librarian.rb daemon start`).
+2. Par défaut le serveur écoute sur `127.0.0.1:8888` (configurable via `MediaLibrarian.application.api_option`).
+3. Ouvrir un navigateur sur `http://127.0.0.1:8888/` pour accéder au tableau de bord.
+
+### Protection des écritures
+
+Les opérations d'écriture (`PUT /config`, `PUT /scheduler`, `POST /config/reload`, `POST /scheduler/reload`, `POST /jobs`) acceptent un jeton via l'en-tête `X-Control-Token` (ou le paramètre `token`). Le tableau de bord propose un champ "Jeton de contrôle" qui enregistre localement la valeur et l'envoie automatiquement lors des sauvegardes.
+
+Définir le jeton en amont via :
+
+```bash
+export MEDIA_LIBRARIAN_CONTROL_TOKEN="super-secret"
+bundle exec ruby librarian.rb daemon start
+```
+
+Il est également possible de fournir `control_token` dans `MediaLibrarian.application.api_option` avant le démarrage du serveur.
+
+### Limites actuelles
+
+* Le serveur HTTP n'implémente pas d'authentification avancée ni de chiffrement TLS.
+* Les logs sont affichés en lecture seule et limités aux derniers ~4 Ko de chaque fichier.
+* L'édition YAML s'appuie sur la validation syntaxique côté serveur (erreur renvoyée si invalide).
+
 Requirements:
 * Linux
 * jackett: https://github.com/Jackett/Jackett

--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -490,7 +490,9 @@ class Daemon
         json_response(res, body: status_snapshot[:jobs].map(&:to_h))
       end
 
-      @control_server.mount_proc('/stop') do |_req, res|
+      @control_server.mount_proc('/stop') do |req, res|
+        next unless require_control_token(req, res)
+
         json_response(res, body: { 'status' => 'stopping' })
         Thread.new { stop }
       end

--- a/app/web/app.css
+++ b/app/web/app.css
@@ -1,0 +1,242 @@
+:root {
+  color-scheme: light dark;
+  --bg: #111827;
+  --panel-bg: rgba(255, 255, 255, 0.04);
+  --text: #f9fafb;
+  --muted: #9ca3af;
+  --accent: #2563eb;
+  --danger: #f87171;
+  font-family: "Inter", "Segoe UI", system-ui, sans-serif;
+}
+
+body {
+  margin: 0;
+  padding: 0 1.5rem 4rem;
+  background: radial-gradient(circle at top, rgba(37, 99, 235, 0.25), transparent 45%),
+    var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+}
+
+header {
+  padding: 2rem 0 1rem;
+  text-align: center;
+}
+
+header h1 {
+  margin: 0;
+  font-size: 2.5rem;
+}
+
+.subtitle {
+  margin: 0.25rem 0 0;
+  color: var(--muted);
+}
+
+.token {
+  max-width: 640px;
+  margin: 0 auto 2rem;
+  padding: 1rem 1.5rem;
+  border-radius: 1rem;
+  background: var(--panel-bg);
+  display: grid;
+  gap: 0.5rem;
+}
+
+.token label {
+  font-weight: 600;
+}
+
+.token input {
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(17, 24, 39, 0.6);
+  color: inherit;
+}
+
+.token button {
+  justify-self: start;
+}
+
+main {
+  display: grid;
+  gap: 2rem;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.panel {
+  padding: 1.5rem;
+  border-radius: 1.5rem;
+  background: var(--panel-bg);
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.4);
+  backdrop-filter: blur(12px);
+}
+
+.panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.panel-header h2 {
+  margin: 0;
+}
+
+.actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+button {
+  padding: 0.55rem 1.25rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(37, 99, 235, 0.12);
+  color: inherit;
+  cursor: pointer;
+  font-weight: 600;
+  transition: transform 0.15s ease, background 0.15s ease;
+}
+
+button:hover {
+  transform: translateY(-1px);
+  background: rgba(37, 99, 235, 0.24);
+}
+
+button.primary {
+  background: var(--accent);
+  border-color: transparent;
+  color: #f8fafc;
+}
+
+button.primary:hover {
+  background: #1d4ed8;
+}
+
+.jobs-columns {
+  display: grid;
+  gap: 1.5rem;
+}
+
+@media (min-width: 900px) {
+  .jobs-columns {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.job-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.job-item {
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 1rem;
+  padding: 0.75rem 1rem;
+  background: rgba(15, 23, 42, 0.6);
+}
+
+.job-item header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-size: 0.95rem;
+  margin-bottom: 0.5rem;
+  padding: 0;
+}
+
+.job-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.logs {
+  display: grid;
+  gap: 1rem;
+}
+
+.log-entry {
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 1rem;
+  padding: 1rem;
+  background: rgba(15, 23, 42, 0.6);
+}
+
+.log-entry header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5rem;
+  padding: 0;
+}
+
+.log-content {
+  margin: 0;
+  max-height: 18rem;
+  overflow: auto;
+  background: rgba(0, 0, 0, 0.3);
+  padding: 1rem;
+  border-radius: 0.75rem;
+  font-family: "SFMono-Regular", ui-monospace, SFMono, "Fira Code", monospace;
+  font-size: 0.85rem;
+  white-space: pre-wrap;
+}
+
+textarea {
+  width: 100%;
+  min-height: 16rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(15, 23, 42, 0.65);
+  color: inherit;
+  padding: 1rem;
+  font-size: 0.95rem;
+  line-height: 1.45;
+  resize: vertical;
+  font-family: "SFMono-Regular", ui-monospace, SFMono, "Fira Code", monospace;
+}
+
+.hint {
+  color: var(--muted);
+  font-size: 0.85rem;
+  margin-top: 0.75rem;
+}
+
+#notification {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  padding: 0.75rem 1.25rem;
+  border-radius: 999px;
+  background: rgba(17, 24, 39, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.35);
+  opacity: 0;
+  transform: translateY(10px);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  pointer-events: none;
+}
+
+#notification.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.error {
+  border-color: rgba(248, 113, 113, 0.6);
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}

--- a/app/web/app.js
+++ b/app/web/app.js
@@ -1,0 +1,249 @@
+const state = {
+  token: '',
+  autoRefresh: null,
+};
+
+function applyToken(headers = new Headers()) {
+  const result = new Headers(headers);
+  if (state.token) {
+    result.set('X-Control-Token', state.token);
+  }
+  return result;
+}
+
+function showNotification(message, kind = 'info') {
+  const container = document.getElementById('notification');
+  container.textContent = message;
+  container.className = kind === 'error' ? 'visible error' : 'visible';
+  window.clearTimeout(container._hideTimer);
+  container._hideTimer = window.setTimeout(() => {
+    container.className = '';
+  }, 3500);
+}
+
+async function fetchJson(path, options = {}) {
+  const init = { ...options };
+  init.headers = applyToken(options.headers);
+  const response = await fetch(path, init);
+  if (!response.ok) {
+    const text = await response.text();
+    let message = text;
+    try {
+      const parsed = JSON.parse(text);
+      message = parsed.error || JSON.stringify(parsed);
+    } catch (error) {
+      // ignore JSON errors, fall back to text
+    }
+    throw new Error(message || `Requête échouée (${response.status})`);
+  }
+  if (response.status === 204) {
+    return null;
+  }
+  return response.json();
+}
+
+function formatDate(value) {
+  if (!value) return '—';
+  try {
+    const date = new Date(value);
+    return new Intl.DateTimeFormat('fr-FR', {
+      dateStyle: 'short',
+      timeStyle: 'medium',
+    }).format(date);
+  } catch (error) {
+    return value;
+  }
+}
+
+function renderJobs(jobs = []) {
+  const running = jobs.filter((job) => job.status !== 'finished');
+  const finished = jobs.filter((job) => job.status === 'finished');
+
+  const runningList = document.getElementById('jobs-running');
+  const finishedList = document.getElementById('jobs-finished');
+
+  const buildItem = (job) => {
+    const li = document.createElement('li');
+    li.className = 'job-item';
+    const header = document.createElement('header');
+    header.innerHTML = `<span>${job.queue || '—'}</span><span>${job.status}</span>`;
+    const meta = document.createElement('div');
+    meta.className = 'job-meta';
+    meta.innerHTML = [
+      job.id ? `<span>ID: <code>${job.id}</code></span>` : null,
+      job.task ? `<span>Tâche: ${job.task}</span>` : null,
+      job.result ? `<span>Résultat: ${job.result}</span>` : null,
+      job.error ? `<span class="error">Erreur: ${job.error}</span>` : null,
+      `<span>Créé: ${formatDate(job.created_at)}</span>`,
+      `<span>Démarré: ${formatDate(job.started_at)}</span>`,
+      `<span>Terminé: ${formatDate(job.finished_at)}</span>`,
+    ]
+      .filter(Boolean)
+      .join('');
+    li.append(header, meta);
+    return li;
+  };
+
+  runningList.replaceChildren(...running.map(buildItem));
+  finishedList.replaceChildren(...finished.map(buildItem));
+}
+
+function renderLogs(logs = {}) {
+  const container = document.getElementById('logs-container');
+  const template = document.getElementById('log-entry-template');
+  container.innerHTML = '';
+
+  Object.entries(logs).forEach(([name, content]) => {
+    const fragment = template.content.cloneNode(true);
+    fragment.querySelector('.log-name').textContent = name;
+    fragment.querySelector('.log-content').textContent = content || '—';
+    fragment.querySelector('.copy-log').addEventListener('click', async () => {
+      try {
+        await navigator.clipboard.writeText(content || '');
+        showNotification(`Log « ${name} » copié dans le presse-papiers.`);
+      } catch (error) {
+        showNotification(`Impossible de copier le log « ${name} ».`, 'error');
+      }
+    });
+    container.appendChild(fragment);
+  });
+}
+
+async function loadStatus() {
+  try {
+    const data = await fetchJson('/status');
+    renderJobs(Array.isArray(data) ? data : data?.jobs || []);
+  } catch (error) {
+    showNotification(error.message, 'error');
+  }
+}
+
+async function loadLogs() {
+  try {
+    const data = await fetchJson('/logs');
+    renderLogs(data.logs || {});
+  } catch (error) {
+    showNotification(error.message, 'error');
+  }
+}
+
+async function loadConfig() {
+  try {
+    const data = await fetchJson('/config');
+    document.getElementById('config-editor').value = data.content || '';
+  } catch (error) {
+    showNotification(error.message, 'error');
+  }
+}
+
+async function loadScheduler() {
+  const editor = document.getElementById('scheduler-editor');
+  const hint = document.getElementById('scheduler-hint');
+  try {
+    const data = await fetchJson('/scheduler');
+    editor.disabled = false;
+    document.getElementById('save-scheduler').disabled = false;
+    document.getElementById('reload-scheduler').disabled = false;
+    editor.value = data.content || '';
+    hint.textContent = 'Modifiez le fichier du scheduler si un planificateur est configuré.';
+  } catch (error) {
+    editor.value = '';
+    editor.disabled = true;
+    document.getElementById('save-scheduler').disabled = true;
+    document.getElementById('reload-scheduler').disabled = true;
+    hint.textContent = "Aucun scheduler configuré ou erreur lors du chargement.";
+  }
+}
+
+async function saveConfig() {
+  const content = document.getElementById('config-editor').value;
+  try {
+    await fetchJson('/config', {
+      method: 'PUT',
+      headers: new Headers({ 'Content-Type': 'application/json' }),
+      body: JSON.stringify({ content }),
+    });
+    showNotification('Configuration sauvegardée.');
+  } catch (error) {
+    showNotification(error.message, 'error');
+  }
+}
+
+async function saveScheduler() {
+  const content = document.getElementById('scheduler-editor').value;
+  try {
+    await fetchJson('/scheduler', {
+      method: 'PUT',
+      headers: new Headers({ 'Content-Type': 'application/json' }),
+      body: JSON.stringify({ content }),
+    });
+    showNotification('Scheduler sauvegardé.');
+  } catch (error) {
+    showNotification(error.message, 'error');
+  }
+}
+
+async function reloadConfig() {
+  try {
+    await fetchJson('/config/reload', { method: 'POST' });
+    showNotification('Configuration rechargée.');
+  } catch (error) {
+    showNotification(error.message, 'error');
+  }
+}
+
+async function reloadScheduler() {
+  try {
+    await fetchJson('/scheduler/reload', { method: 'POST' });
+    showNotification('Scheduler rechargé.');
+  } catch (error) {
+    showNotification(error.message, 'error');
+  }
+}
+
+function setupTokenHandling() {
+  const input = document.getElementById('control-token');
+  const clear = document.getElementById('clear-token');
+  const stored = window.localStorage.getItem('ml-control-token');
+  if (stored) {
+    state.token = stored;
+    input.value = stored;
+  }
+  input.addEventListener('input', (event) => {
+    const value = event.target.value.trim();
+    state.token = value;
+    if (value) {
+      window.localStorage.setItem('ml-control-token', value);
+    } else {
+      window.localStorage.removeItem('ml-control-token');
+    }
+  });
+  clear.addEventListener('click', () => {
+    state.token = '';
+    input.value = '';
+    window.localStorage.removeItem('ml-control-token');
+    showNotification('Jeton effacé.');
+  });
+}
+
+function setupEventListeners() {
+  document.getElementById('refresh-status').addEventListener('click', loadStatus);
+  document.getElementById('refresh-logs').addEventListener('click', loadLogs);
+  document.getElementById('save-config').addEventListener('click', saveConfig);
+  document.getElementById('save-scheduler').addEventListener('click', saveScheduler);
+  document.getElementById('reload-config').addEventListener('click', reloadConfig);
+  document.getElementById('reload-scheduler').addEventListener('click', reloadScheduler);
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  setupTokenHandling();
+  setupEventListeners();
+  loadStatus();
+  loadLogs();
+  loadConfig();
+  loadScheduler();
+  state.autoRefresh = window.setInterval(() => {
+    loadStatus();
+    loadLogs();
+  }, 10000);
+});

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="utf-8" />
+    <title>Media Librarian - Tableau de bord</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="app.css" />
+  </head>
+  <body>
+    <header>
+      <h1>Media Librarian</h1>
+      <p class="subtitle">Tableau de bord du serveur de contrôle</p>
+    </header>
+
+    <section class="token">
+      <label for="control-token">Jeton de contrôle</label>
+      <input id="control-token" type="password" placeholder="Optionnel" />
+      <button id="clear-token" type="button">Effacer</button>
+      <p class="hint">Le jeton est envoyé avec les requêtes d'écriture (POST/PUT). Il est conservé localement dans votre navigateur.</p>
+    </section>
+
+    <main>
+      <section class="panel" id="jobs-panel">
+        <div class="panel-header">
+          <h2>Jobs</h2>
+          <div class="actions">
+            <button id="refresh-status" type="button">Actualiser</button>
+          </div>
+        </div>
+        <div class="jobs-columns">
+          <div>
+            <h3>En cours</h3>
+            <ul id="jobs-running" class="job-list"></ul>
+          </div>
+          <div>
+            <h3>Terminés</h3>
+            <ul id="jobs-finished" class="job-list"></ul>
+          </div>
+        </div>
+      </section>
+
+      <section class="panel" id="logs-panel">
+        <div class="panel-header">
+          <h2>Logs</h2>
+          <div class="actions">
+            <button id="refresh-logs" type="button">Actualiser</button>
+          </div>
+        </div>
+        <div id="logs-container" class="logs"></div>
+      </section>
+
+      <section class="panel" id="config-panel">
+        <div class="panel-header">
+          <h2>Configuration</h2>
+          <div class="actions">
+            <button id="reload-config" type="button">Recharger</button>
+            <button id="save-config" type="button" class="primary">Sauvegarder</button>
+          </div>
+        </div>
+        <textarea id="config-editor" spellcheck="false" placeholder="Configuration YAML"></textarea>
+        <p class="hint">Les modifications sont validées côté serveur (syntaxe YAML) avant d'être enregistrées.</p>
+      </section>
+
+      <section class="panel" id="scheduler-panel">
+        <div class="panel-header">
+          <h2>Planificateur</h2>
+          <div class="actions">
+            <button id="reload-scheduler" type="button">Recharger</button>
+            <button id="save-scheduler" type="button" class="primary">Sauvegarder</button>
+          </div>
+        </div>
+        <textarea id="scheduler-editor" spellcheck="false" placeholder="Modèle YAML du scheduler"></textarea>
+        <p class="hint" id="scheduler-hint">Modifiez le fichier du scheduler si un planificateur est configuré.</p>
+      </section>
+    </main>
+
+    <template id="log-entry-template">
+      <article class="log-entry">
+        <header>
+          <h3 class="log-name"></h3>
+          <button type="button" class="copy-log">Copier</button>
+        </header>
+        <pre class="log-content"></pre>
+      </article>
+    </template>
+
+    <div id="notification" role="status" aria-live="polite"></div>
+
+    <script src="app.js" defer></script>
+  </body>
+</html>

--- a/test/daemon_integration_test.rb
+++ b/test/daemon_integration_test.rb
@@ -148,6 +148,17 @@ class DaemonIntegrationTest < Minitest::Test
     assert_equal new_template, fetched[:body].fetch('content')
   end
 
+  def test_dashboard_interface_is_served_at_root
+    boot_daemon_environment
+
+    response = control_get_raw('/')
+    assert_equal '200', response.code
+    content_type = response['content-type'].to_s
+    assert_includes content_type, 'text/html'
+    assert_includes response.body, '<!DOCTYPE html>'
+    assert_includes response.body, 'Media Librarian'
+  end
+
   private
 
   def boot_daemon_environment(scheduler: nil)
@@ -272,6 +283,14 @@ class DaemonIntegrationTest < Minitest::Test
 
   def control_post(path, body: nil)
     perform_control_request(Net::HTTP::Post, path, body: body)
+  end
+
+  def control_get_raw(path)
+    uri = control_uri(path)
+    request = Net::HTTP::Get.new(uri)
+    Net::HTTP.start(uri.hostname, uri.port) do |http|
+      http.request(request)
+    end
   end
 
   def perform_control_request(klass, path, body: nil)


### PR DESCRIPTION
## Summary
- add a static dashboard that consumes the existing control endpoints
- serve the dashboard from the control server and protect write routes with an optional token
- document the workflow in the README and cover the homepage with a system test

## Testing
- bundle exec ruby -Itest test/daemon_integration_test.rb

------
https://chatgpt.com/codex/tasks/task_e_68f507dfda988327a486b5e4141bd196