### PR TITLE
Add session-based authentication to control server

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem 'bencode', :require => false
 gem 'deluge-rpc', :git => 'https://github.com/raphyduck/deluge-rpc.git', :require => false
 gem 'concurrent-ruby', :require => false
 gem 'feedjira', :require => false
+gem 'bcrypt', :require => false
 gem 'fuzzy-string-match', :require => false
 gem 'get_process_mem', :require => false
 gem 'hanami-mailer', :require => false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,7 @@ GEM
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     base64 (0.3.0)
+    bcrypt (3.1.20)
     benchmark (0.4.1)
     bencode (1.0.0)
     bigdecimal (3.2.2)
@@ -248,6 +249,7 @@ PLATFORMS
 DEPENDENCIES
   activesupport
   archive-zip!
+  bcrypt
   bencode
   concurrent-ruby
   deluge-rpc!

--- a/app/client.rb
+++ b/app/client.rb
@@ -9,7 +9,13 @@ class Client
 
   def initialize(control_token: nil)
     options = app.api_option
-    resolved_token = control_token || (options && options['control_token']) || ENV['MEDIA_LIBRARIAN_CONTROL_TOKEN']
+    resolved_token = control_token || ENV['MEDIA_LIBRARIAN_API_TOKEN']
+    unless resolved_token
+      if options
+        resolved_token = options['api_token'] || options['control_token']
+      end
+      resolved_token ||= ENV['MEDIA_LIBRARIAN_CONTROL_TOKEN']
+    end
     @control_token = resolved_token unless resolved_token.to_s.empty?
   end
 
@@ -69,8 +75,6 @@ class Client
 
   def attach_control_token(request)
     return unless control_token
-    return unless %w[POST PUT PATCH DELETE].include?(request.method)
-
     request['X-Control-Token'] = control_token
   end
 end

--- a/app/web/app.css
+++ b/app/web/app.css
@@ -33,7 +33,7 @@ header h1 {
   color: var(--muted);
 }
 
-.token {
+.session {
   max-width: 640px;
   margin: 0 auto 2rem;
   padding: 1rem 1.5rem;
@@ -43,11 +43,16 @@ header h1 {
   gap: 0.5rem;
 }
 
-.token label {
+.session h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1.25rem;
+}
+
+.session label {
   font-weight: 600;
 }
 
-.token input {
+.session input {
   padding: 0.5rem 0.75rem;
   border-radius: 0.75rem;
   border: 1px solid rgba(255, 255, 255, 0.2);
@@ -55,8 +60,33 @@ header h1 {
   color: inherit;
 }
 
-.token button {
+.session button {
   justify-self: start;
+}
+
+.session form {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.session-status {
+  margin-top: 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.session-status p {
+  margin: 0;
+}
+
+.hidden {
+  display: none !important;
 }
 
 main {

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -12,14 +12,23 @@
       <p class="subtitle">Tableau de bord du serveur de contrôle</p>
     </header>
 
-    <section class="token">
-      <label for="control-token">Jeton de contrôle</label>
-      <input id="control-token" type="password" placeholder="Optionnel" />
-      <button id="clear-token" type="button">Effacer</button>
-      <p class="hint">Le jeton est envoyé avec les requêtes d'écriture (POST/PUT). Il est conservé localement dans votre navigateur.</p>
+    <section class="session" id="session-panel">
+      <form id="login-form" autocomplete="off">
+        <h2>Connexion</h2>
+        <label for="login-username">Nom d'utilisateur</label>
+        <input id="login-username" name="username" type="text" required autocomplete="username" />
+        <label for="login-password">Mot de passe</label>
+        <input id="login-password" name="password" type="password" required autocomplete="current-password" />
+        <button type="submit" class="primary">Se connecter</button>
+      </form>
+      <div class="session-status" id="session-status" hidden>
+        <p>Connecté en tant que <span id="session-username"></span></p>
+        <button id="logout-button" type="button">Se déconnecter</button>
+      </div>
+      <p class="hint">Les identifiants sont définis dans la configuration du démon (`api_option.auth`).</p>
     </section>
 
-    <main>
+    <main id="dashboard" class="hidden">
       <section class="panel" id="jobs-panel">
         <div class="panel-header">
           <h2>Jobs</h2>

--- a/lib/media_librarian/container.rb
+++ b/lib/media_librarian/container.rb
@@ -125,7 +125,10 @@ module MediaLibrarian
       store(:tracker_client, {}, freeze: false)
       store(:tracker_client_last_login, {}, freeze: false)
 
-      store(:api_option, 'bind_address' => '127.0.0.1', 'listen_port' => '8888')
+      store(:api_option,
+            'bind_address' => '127.0.0.1',
+            'listen_port' => '8888',
+            'auth' => {})
 
       daemon_config = config.fetch('daemon', {})
       store(:workers_pool_size, daemon_config['workers_pool_size'] || 4, freeze: true)


### PR DESCRIPTION
## Summary
- add bcrypt support and document how to configure username/password authentication for the control API
- implement session login/logout with cookie handling, while preserving API token access and updating the Ruby client
- refresh the dashboard UI and integration tests to work with session-based authentication

## Testing
- bundle exec ruby -Itest test/daemon_integration_test.rb

------
https://chatgpt.com/codex/tasks/task_e_68f5195e43f08327916bfd455ec6e87a