### PR TITLE
Load API configuration from YAML files

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,42 +12,36 @@ Le démon expose un serveur HTTP léger (WEBrick) permettant de piloter les jobs
 ### Lancement
 
 1. Démarrer le démon (ex. `bundle exec ruby librarian.rb daemon start`).
-2. Par défaut le serveur écoute sur `127.0.0.1:8888` (configurable via `MediaLibrarian.application.api_option`).
+2. Par défaut le serveur écoute sur `127.0.0.1:8888` (configurable via `~/.medialibrarian/api.yml`).
 3. Ouvrir un navigateur sur `http://127.0.0.1:8888/` (ou `https://127.0.0.1:8888/` si TLS est activé) pour accéder au tableau de bord.
 
 ### Authentification et sessions
 
-La consultation et la modification du démon HTTP nécessitent désormais une session authentifiée. Configurez un nom d'utilisateur et un mot de passe haché (BCrypt) avant le démarrage :
+La consultation et la modification du démon HTTP nécessitent désormais une session authentifiée. Configurez un nom d'utilisateur et un mot de passe haché (BCrypt) dans `~/.medialibrarian/api.yml` avant le démarrage :
 
-```ruby
-MediaLibrarian.application.api_option = {
-  'bind_address' => '127.0.0.1',
-  'listen_port' => 8888,
-  'auth' => {
-    'username' => 'admin',
-    'password_hash' => BCrypt::Password.create('mot-de-passe').to_s
-  }
-}
+```yaml
+bind_address: 127.0.0.1
+listen_port: 8888
+auth:
+  username: admin
+  password_hash: "$2a$12$REPLACE_WITH_BCRYPT_HASH"
 ```
 
-Pour exposer l'interface via HTTPS, ajoutez les paramètres TLS :
+Pour exposer l'interface via HTTPS, complétez le même fichier YAML avec les paramètres TLS :
 
-```ruby
-MediaLibrarian.application.api_option = {
-  'bind_address' => '0.0.0.0',
-  'listen_port' => 8443,
-  'auth' => {
-    'username' => 'admin',
-    'password_hash' => BCrypt::Password.create('mot-de-passe').to_s
-  },
-  'ssl_enabled' => true,
-  'ssl_certificate_path' => '/chemin/vers/cert.pem',
-  'ssl_private_key_path' => '/chemin/vers/cle.pem',
-  # Optionnel : chaîne de confiance et vérification côté client
-  'ssl_ca_path' => '/chemin/vers/ca.pem',
-  'ssl_verify_mode' => 'peer',
-  'ssl_client_verify_mode' => 'none'
-}
+```yaml
+bind_address: 0.0.0.0
+listen_port: 8443
+auth:
+  username: admin
+  password_hash: "$2a$12$REPLACE_WITH_BCRYPT_HASH"
+ssl_enabled: true
+ssl_certificate_path: /chemin/vers/cert.pem
+ssl_private_key_path: /chemin/vers/cle.pem
+# Optionnel : chaîne de confiance et vérification côté client
+ssl_ca_path: /chemin/vers/ca.pem
+ssl_verify_mode: peer
+ssl_client_verify_mode: none
 ```
 
 Si aucune paire clé/certificat n'est fournie, le démon génère un certificat auto-signé éphémère : le navigateur et le client CLI devront alors explicitement faire confiance au certificat (accepter l'exception de sécurité en développement ou installer la CA). Le client CLI détecte automatiquement la configuration HTTPS (`ssl_enabled`) et ajuste la vérification selon `ssl_verify_mode`. Les valeurs acceptées pour `ssl_verify_mode` sont `none`, `peer`, `fail_if_no_peer_cert` / `force_peer` / `require`.
@@ -56,7 +50,7 @@ Le serveur d'administration continue d'autoriser les connexions sans certificat 
 
 Depuis l'interface web, un formulaire de connexion envoie les identifiants à `POST /session` et un cookie sécurisé (`Secure`, `HttpOnly`) est retourné lorsque l'authentification réussit. La déconnexion s'effectue via `DELETE /session`.
 
-Pour la rétrocompatibilité (clients CLI, automatisations, etc.), il reste possible de définir un jeton d'API qui autorise les requêtes munies de l'en-tête `X-Control-Token` (ou du paramètre `token`). Le jeton peut être fourni via `MediaLibrarian.application.api_option['api_token']`, `['control_token']` (hérité) ou les variables d'environnement `MEDIA_LIBRARIAN_API_TOKEN` / `MEDIA_LIBRARIAN_CONTROL_TOKEN`.
+Pour la rétrocompatibilité (clients CLI, automatisations, etc.), il reste possible de définir un jeton d'API qui autorise les requêtes munies de l'en-tête `X-Control-Token` (ou du paramètre `token`). Le jeton peut être fourni via les clés `api_token`/`control_token` du fichier `~/.medialibrarian/api.yml` ou, à défaut, les variables d'environnement `MEDIA_LIBRARIAN_API_TOKEN` / `MEDIA_LIBRARIAN_CONTROL_TOKEN`.
 
 ### Limites actuelles
 

--- a/config/api.yml.example
+++ b/config/api.yml.example
@@ -1,0 +1,14 @@
+---
+bind_address: 127.0.0.1
+listen_port: 8888
+auth:
+  username: admin
+  password_hash: "$2a$12$REPLACE_WITH_BCRYPT_HASH"
+ssl_enabled: false
+ssl_certificate_path:
+ssl_private_key_path:
+ssl_ca_path:
+ssl_verify_mode: none
+ssl_client_verify_mode: none
+api_token:
+control_token:

--- a/lib/media_librarian/application.rb
+++ b/lib/media_librarian/application.rb
@@ -12,6 +12,8 @@ module MediaLibrarian
                 :config_dir,
                 :config_file,
                 :config_example,
+                :api_config_file,
+                :api_config_example,
                 :temp_dir,
                 :template_dir,
                 :tracker_dir,
@@ -143,6 +145,8 @@ module MediaLibrarian
       @config_dir = File.join(Dir.home, '.medialibrarian')
       @config_file = File.join(@config_dir, 'conf.yml')
       @config_example = File.join(root, 'config', 'conf.yml.example')
+      @api_config_file = File.join(@config_dir, 'api.yml')
+      @api_config_example = File.join(root, 'config', 'api.yml.example')
       @temp_dir = File.join(@config_dir, 'tmp')
       @template_dir = File.join(@config_dir, 'templates')
       @tracker_dir = File.join(@config_dir, 'trackers')


### PR DESCRIPTION
## Summary
- load the control API configuration from `~/.medialibrarian/api.yml` and reload it on demand
- add a sample `api.yml` template, update documentation, and adapt test helpers to the new configuration flow
- adjust integration tests to write API settings via YAML instead of Ruby setters

## Testing
- `bundle exec ruby -I test test/daemon_integration_test.rb` *(fails: repository dependencies not installed; Bundler requests `bundle install`)*

------
https://chatgpt.com/codex/tasks/task_e_68f55478a6608327998c2f7b4491a105