### PR TITLE
Load required dependencies for titleize and Torznab tracker

### DIFF
--- a/lib/string_utils.rb
+++ b/lib/string_utils.rb
@@ -1,3 +1,5 @@
+require 'titleize'
+
 class StringUtils
 
   def self.accents_clear(str)

--- a/lib/torznab_tracker.rb
+++ b/lib/torznab_tracker.rb
@@ -1,3 +1,5 @@
+require 'torznab/client'
+
 class TorznabTracker
   attr_accessor :config, :tracker, :name, :limit
 


### PR DESCRIPTION
## Summary
- ensure the titleize gem is loaded so String#titleize is available in production code
- require the torznab client library before instantiating the tracker

## Testing
- bundle exec ruby -c lib/utils.rb
- bundle exec ruby -c lib/torznab_tracker.rb

------
https://chatgpt.com/codex/tasks/task_e_68f76ffe9d8c8327b01013a59e6b1a61