### PR TITLE
Ensure required runtime dependencies are loaded

### DIFF
--- a/lib/media_librarian/application.rb
+++ b/lib/media_librarian/application.rb
@@ -122,6 +122,8 @@ module MediaLibrarian
 
     def setup_dependencies
       Bundler.require(:default)
+      require 'fuzzystringmatch' unless defined?(FuzzyStringMatch)
+      require 'mechanize' unless defined?(Mechanize)
     end
 
     def setup_loader


### PR DESCRIPTION
## Summary
- make sure the application requires fuzzystringmatch and mechanize during boot so the constants are available

## Testing
- bundle exec ruby -c lib/media_librarian/application.rb

------
https://chatgpt.com/codex/tasks/task_e_68f7752ffe6c8327972e65711221e0c0