### PR TITLE
Handle missing daemon config values

### DIFF
--- a/lib/media_librarian/container.rb
+++ b/lib/media_librarian/container.rb
@@ -106,7 +106,7 @@ module MediaLibrarian
     def reload_config!(new_settings)
       store(:config, new_settings)
 
-      daemon_config = config.fetch('daemon', {})
+      daemon_config = config.fetch('daemon', {}) || {}
       store(:workers_pool_size, daemon_config['workers_pool_size'] || 4, freeze: true)
       store(:queue_slots, daemon_config['queue_slots'] || 4, freeze: true)
 
@@ -137,7 +137,7 @@ module MediaLibrarian
 
       reload_api_option!
 
-      daemon_config = config.fetch('daemon', {})
+      daemon_config = config.fetch('daemon', {}) || {}
       store(:workers_pool_size, daemon_config['workers_pool_size'] || 4, freeze: true)
       store(:queue_slots, daemon_config['queue_slots'] || 4, freeze: true)
     end


### PR DESCRIPTION
## Summary
- default daemon configuration to an empty hash when settings leave it nil
- prevent workers pool initialization from crashing when daemon config is missing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f77728cc488327a16a350cfcf77e46