### PR TITLE
Require Hanami mailer before loading Report

### DIFF
--- a/app/report.rb
+++ b/app/report.rb
@@ -1,3 +1,5 @@
+require 'hanami/mailer'
+
 class Report
   include MediaLibrarian::AppContainerSupport
 


### PR DESCRIPTION
## Summary
- ensure the Report class explicitly requires the Hanami mailer before including it

## Testing
- bundle exec ruby librarian.rb --config ~/.medialibrarian/settings.yml *(fails: https://github.com/raphyduck/archive-zip.git is not yet checked out. Run `bundle install` first.)*

------
https://chatgpt.com/codex/tasks/task_e_68f7781753fc83279682086d77153db3