### PR TITLE
Fix Storage::Db autoload path for Zeitwerk

### DIFF
--- a/lib/media_librarian/container.rb
+++ b/lib/media_librarian/container.rb
@@ -6,7 +6,7 @@ require 'simple_args_dispatch' unless defined?(SimpleArgsDispatch)
 require 'simple_config_man' unless defined?(SimpleConfigMan)
 require 'simple_speaker' unless defined?(SimpleSpeaker)
 
-require_relative '../db' unless defined?(Storage::Db)
+require_relative '../storage/db' unless defined?(Storage::Db)
 require_relative '../torznab_tracker' unless defined?(TorznabTracker)
 require_relative '../utils' unless defined?(Utils)
 

--- a/lib/storage/db.rb
+++ b/lib/storage/db.rb
@@ -157,7 +157,7 @@ module Storage
     end
 
     def default_migrations_path
-      File.expand_path('db/migrations', __dir__)
+      File.expand_path('../db/migrations', __dir__)
     end
 
     def deserialize_row(row)

--- a/test/lib/storage_db_test.rb
+++ b/test/lib/storage_db_test.rb
@@ -7,7 +7,7 @@ require 'ostruct'
 require_relative '../test_helper'
 
 Storage.send(:remove_const, :Db) if Storage.const_defined?(:Db)
-load File.expand_path('../../lib/db.rb', __dir__)
+load File.expand_path('../../lib/storage/db.rb', __dir__)
 
 class StorageDbTest < Minitest::Test
   def setup


### PR DESCRIPTION
## Summary
- move the Storage::Db implementation under lib/storage to align with Zeitwerk's conventions
- adjust requires and migration path logic to reference the relocated file
- update the Storage::Db test harness to load the new location

## Testing
- bundle exec ruby -Itest test/lib/storage_db_test.rb

------
https://chatgpt.com/codex/tasks/task_e_68f77c9de2e08327908cf66df9e84543