### PR TITLE
Fix MKV mux autoload constant mismatch

### DIFF
--- a/lib/mkv_mux.rb
+++ b/lib/mkv_mux.rb
@@ -1,4 +1,4 @@
-class MkvMuxer
+class MkvMux
   attr_reader :command
 
   def initialize(path, output = nil, force = false)
@@ -58,7 +58,7 @@ class MkvMuxer
   end
 
   def apply_crc32!
-    crc32 = MkvMuxer.crc32_of @output
+    crc32 = MkvMux.crc32_of @output
     FileUtils.mv(@output, @output.gsub(/CRC32/, crc32)[0..-2])
   end
 

--- a/lib/video_utils.rb
+++ b/lib/video_utils.rb
@@ -4,9 +4,9 @@ class VideoUtils
     destination = dest_file.gsub(/(.*)\.[\w\d]{1,4}/, '\1' + ".#{output_format}")
     skipping = 0
     if output_format == 'mkv' && ['m2ts', 'ts'].include?(input_format)
-      mkvmuxer = MkvMuxer.new path, destination
-      mkvmuxer.prepare
-      mkvmuxer.merge!(1)
+      mkv_mux = MkvMux.new path, destination
+      mkv_mux.prepare
+      mkv_mux.merge!(1)
     elsif output_format == 'mkv' && input_format == 'iso'
       cd = MediaLibrarian.app.temp_dir + '/' + File.basename(dest_file)
       FileUtils.mkdir_p(cd) unless File.exist?(cd)


### PR DESCRIPTION
## Summary
- rename the MKV mux helper constant to `MkvMux` to match its file name for Zeitwerk autoloading
- update callers to use the new class name

## Testing
- bundle exec ruby librarian.rb --config ~/.medialibrarian/settings.yml *(fails: https://github.com/raphyduck/archive-zip.git is not yet checked out. Run `bundle install` first.)*

------
https://chatgpt.com/codex/tasks/task_e_68f78146fbe88327aec1983e9fa96399