### PR TITLE
Fix Zeitwerk autoload for version constant

### DIFF
--- a/lib/media_librarian/version.rb
+++ b/lib/media_librarian/version.rb
@@ -1,0 +1,11 @@
+module MediaLibrarian
+  module Version
+    STRING = "0.1".freeze
+
+    def self.to_s
+      STRING
+    end
+  end
+
+  VERSION = Version::STRING
+end

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,0 @@
-module MediaLibrarian
-  VERSION = "0.1"
-end


### PR DESCRIPTION
## Summary
- replace the top-level version file with a namespaced implementation that matches Zeitwerk's autoload expectations
- expose both MediaLibrarian::Version and MediaLibrarian::VERSION so existing callers continue to work

## Testing
- bundle exec ruby librarian.rb --help *(fails: https://github.com/raphyduck/archive-zip.git is not yet checked out. Run `bundle install` first.)*

------
https://chatgpt.com/codex/tasks/task_e_68f78555ac508327baa8dfe19ebe4372