### PR TITLE
Ignore migrations directory for Zeitwerk

### DIFF
--- a/lib/media_librarian/application.rb
+++ b/lib/media_librarian/application.rb
@@ -132,6 +132,7 @@ module MediaLibrarian
       @loader.push_dir(File.join(root, 'lib'))
       @loader.push_dir(File.join(root, 'min_lib'))
       @loader.ignore(__FILE__)
+      @loader.ignore(File.join(root, 'lib', 'db', 'migrations'))
       register_loader_hooks
       @loader.setup
     end


### PR DESCRIPTION
## Summary
- prevent Zeitwerk from autoloading the Sequel migrations directory that uses numeric filenames

## Testing
- bundle exec ruby librarian.rb --config ~/.medialibrarian/settings.yml *(fails: https://github.com/raphyduck/archive-zip.git is not yet checked out. Run `bundle install` first.)*

------
https://chatgpt.com/codex/tasks/task_e_68f786b6bd20832790ce60ecc9f21176