### PR TITLE
Wrap Kodi initialization in begin-rescue

### DIFF
--- a/init/kodi.rb
+++ b/init/kodi.rb
@@ -5,10 +5,12 @@ app = MediaLibrarian::Boot.application
 app.kodi = nil
 
 if app.config['kodi']
-  app.kodi = 1
-  Xbmc.base_uri app.config['kodi']['host']
-  Xbmc.basic_auth app.config['kodi']['username'], app.config['kodi']['password']
-  Xbmc.load_api!
-rescue StandardError
-  app.kodi = nil
+  begin
+    app.kodi = 1
+    Xbmc.base_uri app.config['kodi']['host']
+    Xbmc.basic_auth app.config['kodi']['username'], app.config['kodi']['password']
+    Xbmc.load_api!
+  rescue StandardError
+    app.kodi = nil
+  end
 end


### PR DESCRIPTION
## Summary
- wrap Kodi initialization in a begin/rescue block to fix syntax error when loading Kodi configuration

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f7a85064c88327be6b04f5e2a0ae47