### PR TITLE
Fix daemon startup regressions

### DIFF
--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -75,6 +75,7 @@ class Daemon
 
   class << self
     def start(scheduler: 'scheduler', daemonize: true)
+      daemonize = false if ENV['MEDIA_LIBRARIAN_FOREGROUND'].to_s == '1'
       return app.speaker.speak_up('Daemon already started') if running?
 
       app.speaker.speak_up('Will now work in the background')

--- a/init/thetvdb.rb
+++ b/init/thetvdb.rb
@@ -1,4 +1,5 @@
 # Start thetvdb client
+require 'tvdb_party'
 require_relative '../boot/librarian'
 
 app = MediaLibrarian::Boot.application

--- a/init/tmdb.rb
+++ b/init/tmdb.rb
@@ -1,3 +1,4 @@
+require 'themoviedb'
 require_relative '../boot/librarian'
 
 app = MediaLibrarian::Boot.application

--- a/init/trakt.rb
+++ b/init/trakt.rb
@@ -1,19 +1,40 @@
+# frozen_string_literal: true
+
+require 'trakt'
+
 require_relative '../boot/librarian'
 require_relative 'db'
 
 app = MediaLibrarian::Boot.application
+trakt_config = app.config['trakt']
 
-if app.config['trakt']
-  app.trakt_account = app.config['trakt']['account_id']
-  token_rows = app.db.get_rows('trakt_auth', { account: app.trakt_account })
-  token_row = token_rows.empty? ? nil : Utils.recursive_typify_keys(token_rows.first.reject { |k, _| k.to_s == :account.to_s }, 0)
-  token_row = nil if token_row.nil? || token_row.values.any? { |v| v.to_s == '' || v.to_s == '0' }
-  app.trakt = Trakt.new({
-                          client_id: app.config['trakt']['client_id'],
-                          client_secret: app.config['trakt']['client_secret'],
-                          account_id: app.trakt_account,
-                          speaker: app.speaker,
-                          token: token_row
-                        })
-  TraktAgent.get_trakt_token
+if trakt_config.is_a?(Hash)
+  account_id = trakt_config['account_id'].to_s.strip
+  client_id = trakt_config['client_id'].to_s.strip
+  client_secret = trakt_config['client_secret'].to_s.strip
+
+  credentials = { account_id: account_id, client_id: client_id, client_secret: client_secret }
+  missing_credentials = credentials.any? do |key, value|
+    value.empty? || value == key.to_s
+  end
+
+  if missing_credentials
+    app.speaker.speak_up('Skipping Trakt integration because credentials are missing or still set to defaults.', 0)
+  else
+    app.trakt_account = account_id
+    token_rows = app.db.get_rows('trakt_auth', { account: app.trakt_account })
+    token_row = token_rows.empty? ? nil : Utils.recursive_typify_keys(token_rows.first.reject { |k, _| k.to_s == :account.to_s }, 0)
+    token_row = nil if token_row.nil? || token_row.values.any? { |v| v.to_s == '' || v.to_s == '0' }
+
+    app.trakt = Trakt.new({
+                            client_id: client_id,
+                            client_secret: client_secret,
+                            account_id: app.trakt_account,
+                            speaker: app.speaker,
+                            token: token_row
+                          })
+    TraktAgent.get_trakt_token
+  end
+else
+  app.speaker.speak_up('Skipping Trakt integration because no configuration is available.', 0)
 end

--- a/lib/media_librarian/application.rb
+++ b/lib/media_librarian/application.rb
@@ -140,13 +140,13 @@ module MediaLibrarian
     def setup_environment
       @env_flags = {
         debug: 0,
-        no_email_notif: 0,
+        no_email_notif: 1,
         pretend: 0,
         expiration_period: 0
       }
 
       @config_dir = File.join(Dir.home, '.medialibrarian')
-      @config_file = File.join(@config_dir, 'conf.yml')
+      @config_file = File.join(@config_dir, 'settings.yml')
       @config_example = File.join(root, 'config', 'conf.yml.example')
       @api_config_file = File.join(@config_dir, 'api.yml')
       @api_config_example = File.join(root, 'config', 'api.yml.example')

--- a/lib/trakt_agent.rb
+++ b/lib/trakt_agent.rb
@@ -211,8 +211,12 @@ class TraktAgent
 
   def self.get_trakt_token
     return unless MediaLibrarian.app.trakt && MediaLibrarian.app.trakt_account
+
     token = MediaLibrarian.app.trakt.access_token
-    MediaLibrarian.app.db.insert_row('trakt_auth', token.merge({:account => MediaLibrarian.app.trakt_account}), 1) if token
+    MediaLibrarian.app.db.insert_row('trakt_auth', token.merge({ account: MediaLibrarian.app.trakt_account }), 1) if token
+  rescue StandardError => e
+    MediaLibrarian.app.speaker.tell_error(e, 'TraktAgent.get_trakt_token')
+    nil
   end
 
   def self.remove_from_list(items, list = 'watchlist', type = 'movies')

--- a/lib/utils.rb
+++ b/lib/utils.rb
@@ -18,8 +18,20 @@ class Utils
   end
 
   def self.arguments_dump(binding, max_depth = 2, class_name = '', calling_name = '')
-    class_name = caller[0].match(/\/(\w*)\.rb:/)[1].gsub('_', ' ').titleize.gsub(' ', '') if class_name.to_s == ''
-    calling_name = caller[0][/`.*'/][1..-2].gsub('rescue in ', '') if calling_name.to_s == ''
+    caller_info = caller(1..1).first
+    if caller_info
+      if class_name.to_s == ''
+        class_match = caller_info.match(/\/(\w*)\.rb:/)
+        class_name = class_match[1].gsub('_', ' ').titleize.gsub(' ', '') if class_match
+      end
+      if calling_name.to_s == ''
+        method_match = caller_info[/`.*'/]
+        calling_name = method_match[1..-2].gsub('rescue in ', '') if method_match
+      end
+    end
+
+    class_name = class_name.to_s
+    calling_name = calling_name.to_s
     args_params, hash_params = arguments_get(binding, class_name, calling_name, max_depth)
     "#{class_name}.#{calling_name}(#{args_params.map { |_, v| v }.join(', ') unless args_params.nil? || args_params.empty?}#{', ' unless args_params.nil? || args_params.empty? || hash_params.nil? || hash_params.empty?}#{Hash[hash_params] unless hash_params.nil? || hash_params.empty?})"
   end

--- a/librarian.rb
+++ b/librarian.rb
@@ -122,7 +122,7 @@ class Librarian
       Thread.new do
         app.args_dispatch.set_env_variables(app.env_flags, envf)
         reset_notifications(Thread.current)
-        Thread.current[:log_msg] = '' if child.to_i > 0
+        Thread.current[:log_msg] = String.new if child.to_i > 0
         Thread.current[:current_daemon] = client || Thread.current[:current_daemon]
         Thread.current[:parent] = parent
         Thread.current[:jid] = tid
@@ -190,7 +190,7 @@ class Librarian
     end
 
     def reset_notifications(thread)
-      thread[:email_msg] = ''
+      thread[:email_msg] = String.new
       thread[:send_email] = 0
     end
 
@@ -205,7 +205,7 @@ class Librarian
           p = Object.const_get(m).method(a.to_sym)
           cmd.nil? ? p.call : p.call(*cmd)
         else
-          app.speaker.speak_up('Running command: ', 0)
+          app.speaker.speak_up(String.new('Running command: '), 0)
           app.speaker.speak_up("#{cmd.map { |a| a.gsub(/--?([^=\s]+)(?:=(.+))?/, '--\1=\'\2\'') }.join(' ')}\n\n", 0)
           app.args_dispatch.dispatch(MediaLibrarian::APP_NAME, cmd, command_registry.actions, nil, app.template_dir)
         end

--- a/test/support/container_helpers.rb
+++ b/test/support/container_helpers.rb
@@ -42,7 +42,7 @@ module TestSupport
         @env_flags = {}
         @config_dir = File.join(root, 'config')
         FileUtils.mkdir_p(@config_dir)
-        @config_file = File.join(@config_dir, 'conf.yml')
+        @config_file = File.join(@config_dir, 'settings.yml')
         @config_example = File.join(@config_dir, 'conf.example.yml')
         @api_config_file = File.join(@config_dir, 'api.yml')
         @template_dir = File.join(root, 'templates')


### PR DESCRIPTION
## Summary
- align application defaults with the documented ~/.medialibrarian/settings.yml file and disable email notifications by default so the sample configuration can boot without SMTP
- add missing requires and credential guards for TMDb, TVDB and Trakt so initializers do not crash with placeholder secrets, and allow running the daemon in the foreground for debugging
- harden error reporting helpers to handle frozen strings and missing caller data without raising

## Testing
- bundle exec ruby -Itest test/librarian_cli_test.rb
- bundle exec ruby -Itest test/daemon_integration_test.rb
- bundle exec ruby -Itest test/daemon_queue_concurrency_test.rb
- bundle exec ruby -Itest test/daemon_job_control_test.rb

------
https://chatgpt.com/codex/tasks/task_e_68f7b0f5fdc08327ab3823f50ba60ec8