### PR TITLE
Require io/console to enable configuration password prompts

### DIFF
--- a/lib/media_librarian/container.rb
+++ b/lib/media_librarian/container.rb
@@ -2,6 +2,8 @@
 
 require 'yaml'
 
+require 'io/console'
+
 require 'simple_args_dispatch' unless defined?(SimpleArgsDispatch)
 require 'simple_config_man' unless defined?(SimpleConfigMan)
 require 'simple_speaker' unless defined?(SimpleSpeaker)


### PR DESCRIPTION
## Summary
- require the standard io/console extension during container bootstrap so STDIN#getpass is available

## Testing
- not run (bundle exec ruby librarian.rb --config ~/.medialibrarian/conf.yml requires archive-zip checkout)


------
https://chatgpt.com/codex/tasks/task_e_68f7caa381e483278c279778153a8f70