### PR TITLE
Default to conf.yml configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This program is made to answer my various needs for automation in the management
 
    ```bash
    mkdir -p ~/.medialibrarian
-   cp config/conf.yml.example ~/.medialibrarian/settings.yml
+   cp config/conf.yml.example ~/.medialibrarian/conf.yml
    cp config/api.yml.example ~/.medialibrarian/api.yml
    ```
 
@@ -45,7 +45,7 @@ This program is made to answer my various needs for automation in the management
 * Run the daemon with your configuration file:
 
   ```bash
-  bundle exec ruby librarian.rb daemon start --config ~/.medialibrarian/settings.yml
+  bundle exec ruby librarian.rb daemon start --config ~/.medialibrarian/conf.yml
   ```
 
 * Stop it when needed:
@@ -57,10 +57,10 @@ This program is made to answer my various needs for automation in the management
 * You can also execute a one-shot command without the daemon by pointing directly at the configuration file:
 
   ```bash
-  bundle exec ruby librarian.rb --config ~/.medialibrarian/settings.yml
+  bundle exec ruby librarian.rb --config ~/.medialibrarian/conf.yml
   ```
 
-The daemon logs to `~/.medialibrarian/logs/` by default, and jobs are queued according to the values configured in `settings.yml`.
+The daemon logs to `~/.medialibrarian/logs/` by default, and jobs are queued according to the values configured in `conf.yml`.
 
 ## Contrôle HTTP et interface web
 

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 CONFIG_DIR="${HOME}/.medialibrarian"
-SETTINGS_FILE="${CONFIG_DIR}/settings.yml"
+CONF_FILE="${CONFIG_DIR}/conf.yml"
 API_FILE="${CONFIG_DIR}/api.yml"
 
 log() {
@@ -179,9 +179,9 @@ generate_bcrypt_hash() {
 configure_web_interface() {
   log "==> Configuring web interface"
   mkdir -p "$CONFIG_DIR"
-  if [[ ! -f "$SETTINGS_FILE" ]]; then
-    cp "$REPO_ROOT/config/conf.yml.example" "$SETTINGS_FILE"
-    echo "→ Created $SETTINGS_FILE from template"
+  if [[ ! -f "$CONF_FILE" ]]; then
+    cp "$REPO_ROOT/config/conf.yml.example" "$CONF_FILE"
+    echo "→ Created $CONF_FILE from template"
   fi
 
   local bind_address listen_port username password_hash ssl_enabled cert_path key_path ca_path verify_mode client_verify_mode api_token control_token
@@ -241,7 +241,7 @@ main() {
   configure_web_interface
   log "✅  Installation complete"
   echo "You can start the daemon with:"
-  echo "  bundle exec ruby librarian.rb daemon start --config $SETTINGS_FILE"
+  echo "  bundle exec ruby librarian.rb daemon start --config $CONF_FILE"
 }
 
 main "$@"

--- a/lib/media_librarian/application.rb
+++ b/lib/media_librarian/application.rb
@@ -146,7 +146,7 @@ module MediaLibrarian
       }
 
       @config_dir = File.join(Dir.home, '.medialibrarian')
-      @config_file = File.join(@config_dir, 'settings.yml')
+      @config_file = File.join(@config_dir, 'conf.yml')
       @config_example = File.join(root, 'config', 'conf.yml.example')
       @api_config_file = File.join(@config_dir, 'api.yml')
       @api_config_example = File.join(root, 'config', 'api.yml.example')

--- a/test/support/container_helpers.rb
+++ b/test/support/container_helpers.rb
@@ -42,8 +42,8 @@ module TestSupport
         @env_flags = {}
         @config_dir = File.join(root, 'config')
         FileUtils.mkdir_p(@config_dir)
-        @config_file = File.join(@config_dir, 'settings.yml')
-        @config_example = File.join(@config_dir, 'conf.example.yml')
+        @config_file = File.join(@config_dir, 'conf.yml')
+        @config_example = File.join(@config_dir, 'conf.yml.example')
         @api_config_file = File.join(@config_dir, 'api.yml')
         @template_dir = File.join(root, 'templates')
         FileUtils.mkdir_p(@template_dir)


### PR DESCRIPTION
## Summary
- update the application and installer to look for `conf.yml`
- refresh documentation to instruct users to manage `conf.yml`
- align test support helpers with the new configuration filename

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f888d8ce248327af0f7b7de92de9aa