### PR TITLE
Fix CLI daemon status to query active daemon

### DIFF
--- a/test/daemon_integration_test.rb
+++ b/test/daemon_integration_test.rb
@@ -36,7 +36,8 @@ class DaemonIntegrationTest < Minitest::Test
 
     status = Client.new.status
     assert_equal 200, status['status_code']
-    jobs = status.fetch('body')
+    body = status.fetch('body')
+    jobs = body.is_a?(Array) ? body : Array(body['jobs'])
     assert_equal 1, jobs.size
     assert_equal job['id'], jobs.first['id']
   end


### PR DESCRIPTION
## Summary
- call the control API when checking the daemon status from a non-daemon process and report authorization or availability errors
- include lock time metadata in the /status response so the CLI output remains consistent with local runs
- update the daemon integration test to accept the richer status payload

## Testing
- bundle exec ruby -Itest test/daemon_integration_test.rb

------
https://chatgpt.com/codex/tasks/task_e_68f889e7af208327a4dd727ea536f648