### PR TITLE
Fix daemon status when app container is unset

### DIFF
--- a/lib/media_librarian/app_container_support.rb
+++ b/lib/media_librarian/app_container_support.rb
@@ -18,6 +18,12 @@ module MediaLibrarian
       end
 
       def app
+        return @app if defined?(@app) && @app
+
+        if defined?(MediaLibrarian) && MediaLibrarian.respond_to?(:application)
+          self.app = MediaLibrarian.application
+        end
+
         @app || raise(ArgumentError, "#{name} requires an application container")
       end
     end


### PR DESCRIPTION
## Summary
- allow classes that include AppContainerSupport to lazily attach the global MediaLibrarian application when no container was preconfigured
- restore the daemon status command by ensuring the HTTP Client can resolve its application container outside of eager loading

## Testing
- bundle exec ruby -Itest test/daemon_integration_test.rb

------
https://chatgpt.com/codex/tasks/task_e_68f8961d82d88327b03442d590321d2e