### PR TITLE
Fix Deluge client loading and prevent frozen string speaker crashes

### DIFF
--- a/init/simple_speaker_patch.rb
+++ b/init/simple_speaker_patch.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# SimpleSpeaker expects mutable strings so it can adjust encodings when
+# assembling email notifications.  Ruby 3 freezes string literals by
+# default in many files across the project which resulted in
+# `FrozenError: can't modify frozen String` exceptions whenever
+# `Speaker#speak_up` forwarded such literals to the gem.  To keep the
+# behaviour intact we duplicate string arguments before the gem mutates
+# them.
+if defined?(SimpleSpeaker::Speaker)
+  module SimpleSpeaker
+    class Speaker
+      unless method_defined?(:medialibrarian_email_msg_add)
+        alias_method :medialibrarian_email_msg_add, :email_msg_add
+
+        def email_msg_add(message, type = nil)
+          mutable_message = message.is_a?(String) ? message.dup : message
+          medialibrarian_email_msg_add(mutable_message, type)
+        end
+      end
+    end
+  end
+end

--- a/lib/media_librarian/application.rb
+++ b/lib/media_librarian/application.rb
@@ -1,6 +1,13 @@
 require 'bundler/setup'
 require 'zeitwerk'
 require 'fileutils'
+require_relative '../file_utils'
+
+begin
+  require 'deluge/rpc/client'
+rescue LoadError
+  warn 'deluge-rpc client library is not available. Deluge integration will be disabled until the gem is installed.'
+end
 require_relative 'container'
 
 module MediaLibrarian


### PR DESCRIPTION
## Summary
- ensure the custom FileUtils helpers and the Deluge RPC client are loaded during application boot
- add a SimpleSpeaker patch that duplicates string arguments to avoid frozen string errors under Ruby 3

## Testing
- bundle exec rake test *(fails: archive-zip dependency not checked out in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f8b872ef08832796ced62bca3d2f2f