### PR TITLE
Fix daemon startup by loading bundled args dispatcher

### DIFF
--- a/lib/media_librarian/container.rb
+++ b/lib/media_librarian/container.rb
@@ -5,7 +5,7 @@ require 'yaml'
 require 'io/console'
 
 require_relative '../simple_speaker' unless defined?(SimpleSpeaker::Speaker)
-require 'simple_args_dispatch' unless defined?(SimpleArgsDispatch)
+require_relative '../simple_args_dispatch' unless defined?(SimpleArgsDispatch)
 require 'simple_config_man' unless defined?(SimpleConfigMan)
 
 require_relative '../storage/db' unless defined?(Storage::Db)


### PR DESCRIPTION
## Summary
- ensure the container loads the bundled SimpleArgsDispatch implementation with a relative require so the daemon can boot

## Testing
- bundle exec ruby librarian.rb daemon start --config ~/.medialibrarian/conf.yml

------
https://chatgpt.com/codex/tasks/task_e_68f8d1b5700c832797ab90da5529585b