### PR TITLE
Vendor simple_config_man library

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,6 @@ gem 'nokogiri', :require => false
 gem 'poltergeist', :require => false
 gem 'rexml', :require => false
 gem 'rsync', :git => 'https://github.com/raphyduck/ruby-rsync.git', :require => false
-gem 'simple_config_man', '~>0.3.8', :require => false
 gem 'simple_speaker', '~>0.3.0', :require => false
 #gem "selenium-webdriver", :require => false
 gem 'sqlite3', '1.5.3', :require => false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -215,8 +215,6 @@ GEM
     sequel (5.97.0)
       bigdecimal
       simple_speaker (~> 0.3.0)
-    simple_config_man (0.3.9)
-      simple_speaker (~> 0.3.0)
     simple_speaker (0.3.0.8)
     sqlite3 (1.5.3)
       mini_portile2 (~> 2.8.0)
@@ -265,7 +263,6 @@ DEPENDENCIES
   rexml
   rsync!
   sequel
-  simple_config_man (~> 0.3.8)
   simple_speaker (~> 0.3.0)
   sqlite3 (= 1.5.3)
   streamio-ffmpeg

--- a/lib/media_librarian/container.rb
+++ b/lib/media_librarian/container.rb
@@ -6,7 +6,7 @@ require 'io/console'
 
 require_relative '../simple_speaker' unless defined?(SimpleSpeaker::Speaker)
 require 'simple_args_dispatch' unless defined?(SimpleArgsDispatch)
-require 'simple_config_man' unless defined?(SimpleConfigMan)
+require_relative '../simple_config_man' unless defined?(SimpleConfigMan)
 
 require_relative '../storage/db' unless defined?(Storage::Db)
 require_relative '../torznab_tracker' unless defined?(TorznabTracker)

--- a/lib/simple_config_man.rb
+++ b/lib/simple_config_man.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'yaml'
+require 'io/console'
+require_relative 'simple_speaker'
+
+module SimpleConfigMan
+  module_function
+
+  def configure_node(node, name = '', current = nil, remove_existing = 0)
+    if name == '' || speaker.ask_if_needed("Do you want to configure #{name}? (y/n)", 0, 'y') == 'y'
+      node.each do |key, value|
+        current_value = current ? current[key] : nil
+        if value.is_a?(Hash)
+          node[key] = configure_node(value, [name, key].reject(&:empty?).join(' '), current_value, remove_existing)
+        elsif %w[password client_secret].include?(key)
+          node[key] = STDIN.getpass("What is your #{name} #{key}? ")
+        else
+          speaker.speak_up "What is your #{name} #{key}? [#{current_value}] "
+          node[key] = STDIN.gets&.strip
+        end
+
+        node[key] = current_value if (node[key].nil? || node[key] == '') && !value.is_a?(Hash) && remove_existing == 0
+      end
+    else
+      node = remove_existing > 0 ? nil : current
+    end
+    node
+  end
+
+  def load_settings(config_dir, config_file, config_example)
+    Dir.mkdir(config_dir) unless File.exist?(config_dir)
+    reconfigure(config_file, config_example) unless File.exist?(config_file)
+    YAML.load_file(config_file)
+  end
+
+  def reconfigure(config_file, config_example)
+    remove_existing = 0
+    config = begin
+      YAML.load_file(config_file)
+    rescue StandardError
+      remove_existing = 1
+      YAML.load_file(config_example)
+    end
+
+    default_config = YAML.load_file(config_example)
+    speaker.speak_up 'The configuration file needs to be initialized.'
+    config = configure_node(default_config, '', config, remove_existing)
+    speaker.speak_up 'All set!'
+    File.write(config_file, YAML.dump(config))
+  end
+
+  def speaker
+    @speaker ||= SimpleSpeaker::Speaker.new
+  end
+end

--- a/lib/simple_config_man.rb
+++ b/lib/simple_config_man.rb
@@ -31,7 +31,10 @@ module SimpleConfigMan
   def load_settings(config_dir, config_file, config_example)
     Dir.mkdir(config_dir) unless File.exist?(config_dir)
     reconfigure(config_file, config_example) unless File.exist?(config_file)
-    YAML.load_file(config_file)
+    default_config = YAML.load_file(config_example) || {}
+    user_config = YAML.load_file(config_file) || {}
+
+    deep_merge(default_config, user_config)
   end
 
   def reconfigure(config_file, config_example)
@@ -52,5 +55,15 @@ module SimpleConfigMan
 
   def speaker
     @speaker ||= SimpleSpeaker::Speaker.new
+  end
+
+  def deep_merge(defaults, overrides)
+    if defaults.is_a?(Hash) && overrides.is_a?(Hash)
+      defaults.merge(overrides) do |_key, default_val, override_val|
+        deep_merge(default_val, override_val)
+      end
+    else
+      overrides.nil? ? defaults : overrides
+    end
   end
 end


### PR DESCRIPTION
## Summary
- vendor the simple_config_man code directly into the repository
- remove the gem dependency and load the vendored code from the container

## Testing
- bundle exec ruby -Ilib -e "require 'simple_config_man'; puts SimpleConfigMan.respond_to?(:load_settings)"

------
https://chatgpt.com/codex/tasks/task_e_68f8d3e8f6348327859bfb75803c2fd4