### PR TITLE
Limit web log view to last 10000 lines

### DIFF
--- a/app/web/app.css
+++ b/app/web/app.css
@@ -222,6 +222,12 @@ button.primary:hover {
   white-space: pre-wrap;
 }
 
+.log-hint {
+  margin: 0.75rem 0 0;
+  color: var(--muted);
+  font-size: 0.8rem;
+}
+
 textarea {
   width: 100%;
   min-height: 16rem;


### PR DESCRIPTION
## Summary
- display only the last 10 000 lines of each log entry in the dashboard
- show a hint when logs are truncated and update clipboard copy to match the display
- add styling for the truncation hint in the log panel

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f8d70835788327a070797d21c75bb5