### PR TITLE
Increase server log tail to last 10000 lines

### DIFF
--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -73,7 +73,7 @@ class Daemon
   end
 
   CONTROL_CONTENT_TYPE = 'application/json'
-  LOG_TAIL_BYTES = 4096
+  LOG_TAIL_LINES = 10_000
   SESSION_COOKIE_NAME = 'ml_session'
 
   class << self
@@ -1166,18 +1166,25 @@ class Daemon
       }
     end
 
-    def tail_file(path)
+    def tail_file(path, max_lines: LOG_TAIL_LINES)
       return nil unless File.exist?(path)
 
-      File.open(path, 'r') do |file|
-        size = file.size
-        if size > LOG_TAIL_BYTES
-          file.seek(-LOG_TAIL_BYTES, IO::SEEK_END)
-          file.gets
-        else
-          file.seek(0, IO::SEEK_SET)
-        end
-        file.read
+      buffer = Array.new(max_lines)
+      line_count = 0
+
+      File.foreach(path) do |line|
+        buffer[line_count % max_lines] = line
+        line_count += 1
+      end
+
+      return '' if line_count.zero?
+
+      if line_count < max_lines
+        buffer.first(line_count).join
+      else
+        start = line_count % max_lines
+        tail = (buffer[start, max_lines - start] || []) + buffer[0, start]
+        tail.join
       end
     end
 

--- a/app/web/app.css
+++ b/app/web/app.css
@@ -222,6 +222,12 @@ button.primary:hover {
   white-space: pre-wrap;
 }
 
+.log-hint {
+  margin: 0.75rem 0 0;
+  color: var(--muted);
+  font-size: 0.8rem;
+}
+
 textarea {
   width: 100%;
   min-height: 16rem;


### PR DESCRIPTION
## Summary
- update the daemon log tail helper to return the last 10 000 lines rather than a fixed byte window
- use a ring buffer to avoid unbounded memory while iterating through large log files

## Testing
- ruby -c app/daemon.rb

------
https://chatgpt.com/codex/tasks/task_e_68f8d70835788327a070797d21c75bb5