### PR TITLE
Fix missing Deluge client loading and frozen string crash

### DIFF
--- a/app/media_librarian/services/base_service.rb
+++ b/app/media_librarian/services/base_service.rb
@@ -22,7 +22,12 @@ module MediaLibrarian
       end
 
       def speak_up(message, *args)
-        delegate&.speak_up(message, *args)
+        mutable_message = if message.is_a?(String) && message.frozen?
+                            message.dup
+                          else
+                            message
+                          end
+        delegate&.speak_up(mutable_message, *args)
       end
 
       def ask_if_needed(question, no_prompt = 0, default = nil)

--- a/app/torrent_client.rb
+++ b/app/torrent_client.rb
@@ -188,7 +188,8 @@ class TorrentClient
 
   def self.monitor_torrent_client
     app.speaker.speak_up("Checking free space remaining on torrent server", 0)
-    free_space = app.t_client.get_free_space / 1024 / 1024 / 1024
+    free_space_bytes = app.t_client.get_free_space
+    free_space = free_space_bytes.to_f / 1024 / 1024 / 1024
     app.speaker.speak_up("Free space remaining: #{free_space}GB", 0)
     if free_space <= get_config('deluge', 'min_torrent_free_space').to_i && !@throttled
       app.speaker.speak_up "There is only #{free_space}GB of free space on torrent server, will throttle download rate now!"

--- a/lib/media_librarian/application.rb
+++ b/lib/media_librarian/application.rb
@@ -124,6 +124,8 @@ module MediaLibrarian
       Bundler.require(:default)
       require 'fuzzystringmatch' unless defined?(FuzzyStringMatch)
       require 'mechanize' unless defined?(Mechanize)
+      require 'deluge/rpc/client' unless defined?(Deluge::Rpc::Client)
+      require_relative '../file_utils'
       load File.expand_path('../simple_speaker.rb', __dir__)
     end
 


### PR DESCRIPTION
## Summary
- explicitly require the Deluge RPC client and the local FileUtils extensions during application boot
- prevent frozen string errors when delegating speaker messages
- ensure free space calculations handle Deluge string responses safely

## Testing
- ruby -c lib/media_librarian/application.rb
- ruby -c app/torrent_client.rb
- ruby -c app/media_librarian/services/base_service.rb

------
https://chatgpt.com/codex/tasks/task_e_68f8e61593f88327a16509ae959a8bc6