### PR TITLE
Add auto-refreshing tabbed dashboard

### DIFF
--- a/app/web/app.css
+++ b/app/web/app.css
@@ -91,9 +91,51 @@ header h1 {
 
 main {
   display: grid;
-  gap: 2rem;
+  gap: 1.5rem;
   max-width: 1200px;
   margin: 0 auto;
+}
+
+.tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.tab-button {
+  padding: 0.5rem 1.35rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  background: rgba(15, 23, 42, 0.65);
+  color: inherit;
+  font-weight: 600;
+  transition: background 0.2s ease, transform 0.2s ease, border 0.2s ease;
+}
+
+.tab-button:hover {
+  transform: translateY(-1px);
+  background: rgba(37, 99, 235, 0.18);
+}
+
+.tab-button.active,
+.tab-button[aria-selected="true"] {
+  background: var(--accent);
+  border-color: transparent;
+  color: #f8fafc;
+}
+
+.tab-contents {
+  display: block;
+}
+
+.tab-panel {
+  display: none;
+  gap: 2rem;
+}
+
+.tab-panel.active {
+  display: grid;
 }
 
 .panel {
@@ -240,6 +282,11 @@ textarea {
   line-height: 1.45;
   resize: vertical;
   font-family: "SFMono-Regular", ui-monospace, SFMono, "Fira Code", monospace;
+}
+
+textarea[data-dirty="true"] {
+  border-color: rgba(248, 113, 113, 0.6);
+  box-shadow: 0 0 0 1px rgba(248, 113, 113, 0.3);
 }
 
 .hint {

--- a/app/web/app.js
+++ b/app/web/app.js
@@ -272,15 +272,19 @@ async function loadLogs() {
 }
 
 async function loadConfig({ force = false } = {}) {
+  const editor = document.getElementById('config-editor');
+  if (!editor) {
+    return;
+  }
   if (!force && isEditorDirty('config')) {
     return;
   }
   try {
     const data = await fetchJson('/config');
-    const editor = document.getElementById('config-editor');
-    if (editor) {
-      editor.value = data.content || '';
+    if (!force && isEditorDirty('config')) {
+      return;
     }
+    editor.value = data.content || '';
     setEditorDirty('config', false);
   } catch (error) {
     if (state.authenticated) {
@@ -292,6 +296,9 @@ async function loadConfig({ force = false } = {}) {
 async function loadScheduler({ force = false } = {}) {
   const editor = document.getElementById('scheduler-editor');
   const hint = document.getElementById('scheduler-hint');
+  if (!editor || !hint) {
+    return;
+  }
   if (!force && isEditorDirty('scheduler')) {
     return;
   }
@@ -300,6 +307,9 @@ async function loadScheduler({ force = false } = {}) {
     editor.disabled = false;
     document.getElementById('save-scheduler').disabled = false;
     document.getElementById('reload-scheduler').disabled = false;
+    if (!force && isEditorDirty('scheduler')) {
+      return;
+    }
     editor.value = data.content || '';
     hint.textContent = 'Modifiez le fichier du scheduler si un planificateur est configuré.';
     setEditorDirty('scheduler', false);

--- a/app/web/app.js
+++ b/app/web/app.js
@@ -2,6 +2,12 @@ const state = {
   authenticated: false,
   username: '',
   autoRefresh: null,
+  activeTab: 'jobs',
+  dirty: {
+    config: false,
+    scheduler: false,
+  },
+  isRefreshing: false,
 };
 
 const LOG_MAX_LINES = 10000;
@@ -41,6 +47,19 @@ function showNotification(message, kind = 'info') {
   }, 3500);
 }
 
+function setEditorDirty(editorKey, dirty) {
+  state.dirty[editorKey] = dirty;
+  const elementId = editorKey === 'config' ? 'config-editor' : 'scheduler-editor';
+  const editor = document.getElementById(elementId);
+  if (editor) {
+    editor.dataset.dirty = dirty ? 'true' : 'false';
+  }
+}
+
+function isEditorDirty(editorKey) {
+  return Boolean(state.dirty[editorKey]);
+}
+
 async function parseErrorMessage(response) {
   const text = await response.text();
   if (!text) {
@@ -70,8 +89,7 @@ function startAutoRefresh() {
     if (!state.authenticated) {
       return;
     }
-    loadStatus();
-    loadLogs();
+    refreshAll();
   }, 10000);
 }
 
@@ -96,6 +114,17 @@ function setAuthenticated(authenticated, username = '') {
     status.hidden = true;
     usernameLabel.textContent = '';
     stopAutoRefresh();
+    setActiveTab('jobs', { skipLoad: true });
+    setEditorDirty('config', false);
+    setEditorDirty('scheduler', false);
+    const configEditor = document.getElementById('config-editor');
+    const schedulerEditor = document.getElementById('scheduler-editor');
+    if (configEditor) {
+      configEditor.value = '';
+    }
+    if (schedulerEditor) {
+      schedulerEditor.value = '';
+    }
   }
 }
 
@@ -242,10 +271,17 @@ async function loadLogs() {
   }
 }
 
-async function loadConfig() {
+async function loadConfig({ force = false } = {}) {
+  if (!force && isEditorDirty('config')) {
+    return;
+  }
   try {
     const data = await fetchJson('/config');
-    document.getElementById('config-editor').value = data.content || '';
+    const editor = document.getElementById('config-editor');
+    if (editor) {
+      editor.value = data.content || '';
+    }
+    setEditorDirty('config', false);
   } catch (error) {
     if (state.authenticated) {
       showNotification(error.message, 'error');
@@ -253,9 +289,12 @@ async function loadConfig() {
   }
 }
 
-async function loadScheduler() {
+async function loadScheduler({ force = false } = {}) {
   const editor = document.getElementById('scheduler-editor');
   const hint = document.getElementById('scheduler-hint');
+  if (!force && isEditorDirty('scheduler')) {
+    return;
+  }
   try {
     const data = await fetchJson('/scheduler');
     editor.disabled = false;
@@ -263,16 +302,26 @@ async function loadScheduler() {
     document.getElementById('reload-scheduler').disabled = false;
     editor.value = data.content || '';
     hint.textContent = 'Modifiez le fichier du scheduler si un planificateur est configuré.';
+    setEditorDirty('scheduler', false);
   } catch (error) {
     editor.value = '';
     editor.disabled = true;
     document.getElementById('save-scheduler').disabled = true;
     document.getElementById('reload-scheduler').disabled = true;
     hint.textContent = "Aucun scheduler configuré ou erreur lors du chargement.";
+    setEditorDirty('scheduler', false);
     if (state.authenticated) {
       showNotification(error.message, 'error');
     }
   }
+}
+
+async function loadConfigTab(options = {}) {
+  await loadConfig(options);
+  if (!state.authenticated) {
+    return;
+  }
+  await loadScheduler(options);
 }
 
 async function saveConfig() {
@@ -284,6 +333,8 @@ async function saveConfig() {
       body: JSON.stringify({ content }),
     });
     showNotification('Configuration sauvegardée.');
+    setEditorDirty('config', false);
+    await loadConfig({ force: true });
   } catch (error) {
     if (state.authenticated) {
       showNotification(error.message, 'error');
@@ -300,6 +351,8 @@ async function saveScheduler() {
       body: JSON.stringify({ content }),
     });
     showNotification('Scheduler sauvegardé.');
+    setEditorDirty('scheduler', false);
+    await loadScheduler({ force: true });
   } catch (error) {
     if (state.authenticated) {
       showNotification(error.message, 'error');
@@ -311,6 +364,8 @@ async function reloadConfig() {
   try {
     await fetchJson('/config/reload', { method: 'POST' });
     showNotification('Configuration rechargée.');
+    setEditorDirty('config', false);
+    await loadConfig({ force: true });
   } catch (error) {
     if (state.authenticated) {
       showNotification(error.message, 'error');
@@ -322,6 +377,8 @@ async function reloadScheduler() {
   try {
     await fetchJson('/scheduler/reload', { method: 'POST' });
     showNotification('Scheduler rechargé.');
+    setEditorDirty('scheduler', false);
+    await loadScheduler({ force: true });
   } catch (error) {
     if (state.authenticated) {
       showNotification(error.message, 'error');
@@ -329,23 +386,40 @@ async function reloadScheduler() {
   }
 }
 
-async function refreshAll() {
+const TAB_LOADERS = {
+  jobs: () => loadStatus(),
+  logs: () => loadLogs(),
+  config: (options = {}) => loadConfigTab(options),
+};
+
+async function refreshActiveTab(options = {}) {
   if (!state.authenticated) {
     return;
   }
-  await loadStatus();
-  if (!state.authenticated) {
+  const loader = TAB_LOADERS[state.activeTab];
+  if (typeof loader === 'function') {
+    await loader(options);
+  }
+}
+
+async function refreshAll(options = {}) {
+  if (!state.authenticated || state.isRefreshing) {
     return;
   }
-  await loadLogs();
-  if (!state.authenticated) {
-    return;
+  state.isRefreshing = true;
+  try {
+    await loadStatus();
+    if (!state.authenticated) {
+      return;
+    }
+    await loadLogs();
+    if (!state.authenticated) {
+      return;
+    }
+    await loadConfigTab(options);
+  } finally {
+    state.isRefreshing = false;
   }
-  await loadConfig();
-  if (!state.authenticated) {
-    return;
-  }
-  await loadScheduler();
 }
 
 async function handleLogin(event) {
@@ -396,7 +470,42 @@ async function bootstrapSession() {
   }
 }
 
+function setActiveTab(tabName, { skipLoad = false } = {}) {
+  const resolved = TAB_LOADERS[tabName] ? tabName : 'jobs';
+  state.activeTab = resolved;
+
+  const buttons = document.querySelectorAll('.tab-button');
+  buttons.forEach((button) => {
+    const isActive = button.dataset.tab === resolved;
+    button.classList.toggle('active', isActive);
+    button.setAttribute('aria-selected', String(isActive));
+    button.setAttribute('tabindex', isActive ? '0' : '-1');
+  });
+
+  const panels = document.querySelectorAll('.tab-panel');
+  panels.forEach((panel) => {
+    const isActive = panel.dataset.tab === resolved;
+    panel.classList.toggle('active', isActive);
+    panel.hidden = !isActive;
+  });
+
+  if (!skipLoad) {
+    refreshActiveTab();
+  }
+}
+
+function setupTabs() {
+  const buttons = document.querySelectorAll('.tab-button');
+  buttons.forEach((button) => {
+    button.addEventListener('click', () => {
+      const { tab } = button.dataset;
+      setActiveTab(tab);
+    });
+  });
+}
+
 function setupEventListeners() {
+  setupTabs();
   document.getElementById('refresh-status').addEventListener('click', loadStatus);
   document.getElementById('refresh-logs').addEventListener('click', loadLogs);
   document.getElementById('save-config').addEventListener('click', saveConfig);
@@ -405,10 +514,22 @@ function setupEventListeners() {
   document.getElementById('reload-scheduler').addEventListener('click', reloadScheduler);
   document.getElementById('login-form').addEventListener('submit', handleLogin);
   document.getElementById('logout-button').addEventListener('click', logout);
+
+  const configEditor = document.getElementById('config-editor');
+  const schedulerEditor = document.getElementById('scheduler-editor');
+  if (configEditor) {
+    configEditor.addEventListener('input', () => setEditorDirty('config', true));
+  }
+  if (schedulerEditor) {
+    schedulerEditor.addEventListener('input', () => setEditorDirty('scheduler', true));
+  }
 }
 
 document.addEventListener('DOMContentLoaded', () => {
   setupEventListeners();
+  setEditorDirty('config', false);
+  setEditorDirty('scheduler', false);
+  setActiveTab(state.activeTab, { skipLoad: true });
   updateConnectionHint();
   bootstrapSession();
 });

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -29,58 +29,116 @@
     </section>
 
     <main id="dashboard" class="hidden">
-      <section class="panel" id="jobs-panel">
-        <div class="panel-header">
-          <h2>Jobs</h2>
-          <div class="actions">
-            <button id="refresh-status" type="button">Actualiser</button>
-          </div>
-        </div>
-        <div class="jobs-columns">
-          <div>
-            <h3>En cours</h3>
-            <ul id="jobs-running" class="job-list"></ul>
-          </div>
-          <div>
-            <h3>Terminés</h3>
-            <ul id="jobs-finished" class="job-list"></ul>
-          </div>
-        </div>
-      </section>
+      <div class="tabs" role="tablist">
+        <button
+          id="tab-jobs"
+          class="tab-button active"
+          type="button"
+          role="tab"
+          aria-selected="true"
+          data-tab="jobs"
+        >
+          Jobs
+        </button>
+        <button
+          id="tab-logs"
+          class="tab-button"
+          type="button"
+          role="tab"
+          aria-selected="false"
+          data-tab="logs"
+        >
+          Logs
+        </button>
+        <button
+          id="tab-config"
+          class="tab-button"
+          type="button"
+          role="tab"
+          aria-selected="false"
+          data-tab="config"
+        >
+          Configuration
+        </button>
+      </div>
 
-      <section class="panel" id="logs-panel">
-        <div class="panel-header">
-          <h2>Logs</h2>
-          <div class="actions">
-            <button id="refresh-logs" type="button">Actualiser</button>
-          </div>
-        </div>
-        <div id="logs-container" class="logs"></div>
-      </section>
+      <div class="tab-contents">
+        <section
+          class="tab-panel active"
+          data-tab="jobs"
+          role="tabpanel"
+          aria-labelledby="tab-jobs"
+        >
+          <section class="panel" id="jobs-panel">
+            <div class="panel-header">
+              <h2>Jobs</h2>
+              <div class="actions">
+                <button id="refresh-status" type="button">Actualiser</button>
+              </div>
+            </div>
+            <div class="jobs-columns">
+              <div>
+                <h3>En cours</h3>
+                <ul id="jobs-running" class="job-list"></ul>
+              </div>
+              <div>
+                <h3>Terminés</h3>
+                <ul id="jobs-finished" class="job-list"></ul>
+              </div>
+            </div>
+          </section>
+        </section>
 
-      <section class="panel" id="config-panel">
-        <div class="panel-header">
-          <h2>Configuration</h2>
-          <div class="actions">
-            <button id="reload-config" type="button">Recharger</button>
-            <button id="save-config" type="button" class="primary">Sauvegarder</button>
-          </div>
-        </div>
-        <textarea id="config-editor" spellcheck="false" placeholder="Configuration YAML"></textarea>
-        <p class="hint">Les modifications sont validées côté serveur (syntaxe YAML) avant d'être enregistrées.</p>
-      </section>
+        <section
+          class="tab-panel"
+          data-tab="logs"
+          role="tabpanel"
+          aria-labelledby="tab-logs"
+          hidden
+        >
+          <section class="panel" id="logs-panel">
+            <div class="panel-header">
+              <h2>Logs</h2>
+              <div class="actions">
+                <button id="refresh-logs" type="button">Actualiser</button>
+              </div>
+            </div>
+            <div id="logs-container" class="logs"></div>
+          </section>
+        </section>
 
-      <section class="panel" id="scheduler-panel">
-        <div class="panel-header">
-          <h2>Planificateur</h2>
-          <div class="actions">
-            <button id="reload-scheduler" type="button">Recharger</button>
-            <button id="save-scheduler" type="button" class="primary">Sauvegarder</button>
-          </div>
-        </div>
-        <textarea id="scheduler-editor" spellcheck="false" placeholder="Modèle YAML du scheduler"></textarea>
-        <p class="hint" id="scheduler-hint">Modifiez le fichier du scheduler si un planificateur est configuré.</p>
-      </section>
+        <section
+          class="tab-panel"
+          data-tab="config"
+          role="tabpanel"
+          aria-labelledby="tab-config"
+          hidden
+        >
+          <section class="panel" id="config-panel">
+            <div class="panel-header">
+              <h2>Configuration</h2>
+              <div class="actions">
+                <button id="reload-config" type="button">Recharger</button>
+                <button id="save-config" type="button" class="primary">Sauvegarder</button>
+              </div>
+            </div>
+            <textarea id="config-editor" spellcheck="false" placeholder="Configuration YAML"></textarea>
+            <p class="hint">Les modifications sont validées côté serveur (syntaxe YAML) avant d'être enregistrées.</p>
+          </section>
+
+          <section class="panel" id="scheduler-panel">
+            <div class="panel-header">
+              <h2>Planificateur</h2>
+              <div class="actions">
+                <button id="reload-scheduler" type="button">Recharger</button>
+                <button id="save-scheduler" type="button" class="primary">Sauvegarder</button>
+              </div>
+            </div>
+            <textarea id="scheduler-editor" spellcheck="false" placeholder="Modèle YAML du scheduler"></textarea>
+            <p class="hint" id="scheduler-hint">Modifiez le fichier du scheduler si un planificateur est configuré.</p>
+          </section>
+        </section>
+      </div>
     </main>
 
     <template id="log-entry-template">


### PR DESCRIPTION
## Summary
- add tab navigation to split the dashboard into Jobs, Logs, and Configuration views
- implement automatic refresh that keeps data up to date while respecting in-progress config edits
- refresh the web styling to support tabs and surface unsaved-editor state

## Testing
- no automated tests were run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68f8e75870b48327af8893b838db8122