### PR TITLE
Fix Deluge RPC initialization error

### DIFF
--- a/lib/media_librarian/application.rb
+++ b/lib/media_librarian/application.rb
@@ -124,7 +124,7 @@ module MediaLibrarian
       Bundler.require(:default)
       require 'fuzzystringmatch' unless defined?(FuzzyStringMatch)
       require 'mechanize' unless defined?(Mechanize)
-      require 'deluge/rpc/client' unless defined?(Deluge::Rpc::Client)
+      require 'deluge/rpc' unless defined?(Deluge::Rpc::Client)
       require_relative '../file_utils'
       load File.expand_path('../simple_speaker.rb', __dir__)
     end


### PR DESCRIPTION
## Summary
- require the top-level Deluge RPC library so the Connection constant is defined during application boot

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f908bbb18c8327806a58b808e5c101