### PR TITLE
Improve CLI guidance on control token failures

### DIFF
--- a/librarian.rb
+++ b/librarian.rb
@@ -179,6 +179,9 @@ class Librarian
         elsif status_code >= 400
           error_detail = body.is_a?(Hash) ? body['error'] || body['message'] : nil
           message = error_detail ? "#{error_detail} (HTTP #{status_code})" : "HTTP #{status_code}"
+          if [401, 403].include?(status_code)
+            message = "#{message}. Check the control token configuration for the daemon."
+          end
           app.speaker.speak_up("Daemon rejected the job: #{message}")
         elsif body && body['job']
           job = body['job']

--- a/test/librarian_cli_test.rb
+++ b/test/librarian_cli_test.rb
@@ -82,7 +82,7 @@ class LibrarianCliTest < Minitest::Test
     end
 
     assert_includes env.application.speaker.messages,
-                    'Daemon rejected the job: forbidden (HTTP 403)'
+                    'Daemon rejected the job: forbidden (HTTP 403). Check the control token configuration for the daemon.'
     refute_includes env.application.speaker.messages, 'Command dispatched to daemon'
   end
 


### PR DESCRIPTION
## Summary
- expand the librarian CLI error handling when the daemon returns 401/403
- add guidance directing users to verify the daemon control token configuration
- update CLI test to cover the new messaging

## Testing
- bundle exec ruby -Itest test/librarian_cli_test.rb
- bundle exec ruby -Itest test/daemon_integration_test.rb

------
https://chatgpt.com/codex/tasks/task_e_68f914bfccd08327ab39841e40442f33