### PR TITLE
Ensure daemon and CLI honor control token when API token blank

### DIFF
--- a/app/client.rb
+++ b/app/client.rb
@@ -11,12 +11,7 @@ class Client
   def initialize(control_token: nil)
     options = app.api_option || {}
     @api_options = options
-    resolved_token = control_token
-    resolved_token ||= ENV['MEDIA_LIBRARIAN_API_TOKEN']
-    resolved_token ||= options['api_token']
-    resolved_token ||= options['control_token']
-    resolved_token ||= ENV['MEDIA_LIBRARIAN_CONTROL_TOKEN']
-    @control_token = resolved_token unless resolved_token.to_s.empty?
+    @control_token = resolve_control_token(control_token, options)
   end
 
   def enqueue(command, wait: true, queue: nil, task: nil, internal: 0, capture_output: wait)
@@ -79,6 +74,36 @@ class Client
   def attach_control_token(request)
     return unless control_token
     request['X-Control-Token'] = control_token
+  end
+
+  def resolve_control_token(explicit_token, options)
+    select_token(
+      explicit_token,
+      ENV['MEDIA_LIBRARIAN_API_TOKEN'],
+      options['api_token'],
+      options['control_token'],
+      ENV['MEDIA_LIBRARIAN_CONTROL_TOKEN']
+    )
+  end
+
+  def select_token(*candidates)
+    candidates.each do |candidate|
+      value = normalize_token(candidate)
+      return value if value
+    end
+    nil
+  end
+
+  def normalize_token(candidate)
+    case candidate
+    when nil
+      nil
+    when String
+      token = candidate.strip
+      token.empty? ? nil : token
+    else
+      candidate
+    end
   end
 
   def ssl_enabled?

--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -1008,9 +1008,34 @@ class Daemon
     def resolve_api_token(opts)
       return nil unless opts
 
-      opts['api_token'] || opts[:api_token] ||
-        opts['control_token'] || opts[:control_token] ||
-        ENV['MEDIA_LIBRARIAN_API_TOKEN'] || ENV['MEDIA_LIBRARIAN_CONTROL_TOKEN']
+      select_token(
+        opts['api_token'],
+        opts[:api_token],
+        opts['control_token'],
+        opts[:control_token],
+        ENV['MEDIA_LIBRARIAN_API_TOKEN'],
+        ENV['MEDIA_LIBRARIAN_CONTROL_TOKEN']
+      )
+    end
+
+    def select_token(*candidates)
+      candidates.each do |candidate|
+        value = normalize_token(candidate)
+        return value if value
+      end
+      nil
+    end
+
+    def normalize_token(candidate)
+      case candidate
+      when nil
+        nil
+      when String
+        token = candidate.strip
+        token.empty? ? nil : token
+      else
+        candidate
+      end
     end
 
     def ssl_enabled?(opts)

--- a/librarian.rb
+++ b/librarian.rb
@@ -179,6 +179,9 @@ class Librarian
         elsif status_code >= 400
           error_detail = body.is_a?(Hash) ? body['error'] || body['message'] : nil
           message = error_detail ? "#{error_detail} (HTTP #{status_code})" : "HTTP #{status_code}"
+          if [401, 403].include?(status_code)
+            message = "#{message}. Check the control token configuration for the daemon."
+          end
           app.speaker.speak_up("Daemon rejected the job: #{message}")
         elsif body && body['job']
           job = body['job']

--- a/test/daemon_integration_test.rb
+++ b/test/daemon_integration_test.rb
@@ -226,6 +226,18 @@ class DaemonIntegrationTest < Minitest::Test
     assert_equal 204, reload[:status_code]
   end
 
+  def test_cli_uses_control_token_when_api_token_blank
+    boot_daemon_environment(control_token: 'control-secret',
+                            authenticate: false,
+                            api_overrides: { 'api_token' => '' })
+
+    client = Client.new
+    assert_equal 'control-secret', client.instance_variable_get(:@control_token)
+
+    response = client.enqueue(['daemon', 'status'], wait: false)
+    assert_equal 200, response['status_code']
+  end
+
   def test_logout_revokes_session
     boot_daemon_environment
 

--- a/test/librarian_cli_test.rb
+++ b/test/librarian_cli_test.rb
@@ -82,7 +82,7 @@ class LibrarianCliTest < Minitest::Test
     end
 
     assert_includes env.application.speaker.messages,
-                    'Daemon rejected the job: forbidden (HTTP 403)'
+                    'Daemon rejected the job: forbidden (HTTP 403). Check the control token configuration for the daemon.'
     refute_includes env.application.speaker.messages, 'Command dispatched to daemon'
   end
 


### PR DESCRIPTION
## Summary
- treat blank API token values as missing so the control token can be used
- normalize token values consistently between the client and daemon to prevent unintended 403 responses
- add an integration test covering CLI access when only a control token is configured

## Testing
- bundle exec ruby -Itest test/librarian_cli_test.rb
- bundle exec ruby -Itest test/daemon_integration_test.rb

------
https://chatgpt.com/codex/tasks/task_e_68f914bfccd08327ab39841e40442f33