### PR TITLE
Handle blank API token values when resolving control credentials

### DIFF
--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -1008,9 +1008,14 @@ class Daemon
     def resolve_api_token(opts)
       return nil unless opts
 
-      opts['api_token'] || opts[:api_token] ||
-        opts['control_token'] || opts[:control_token] ||
-        ENV['MEDIA_LIBRARIAN_API_TOKEN'] || ENV['MEDIA_LIBRARIAN_CONTROL_TOKEN']
+      pick_token(
+        opts['api_token'],
+        opts[:api_token],
+        opts['control_token'],
+        opts[:control_token],
+        ENV['MEDIA_LIBRARIAN_API_TOKEN'],
+        ENV['MEDIA_LIBRARIAN_CONTROL_TOKEN']
+      )
     end
 
     def ssl_enabled?(opts)
@@ -1075,6 +1080,27 @@ class Daemon
         OpenSSL::SSL::VERIFY_PEER | OpenSSL::SSL::VERIFY_FAIL_IF_NO_PEER_CERT
       else
         OpenSSL::SSL::VERIFY_NONE
+      end
+    end
+
+    def pick_token(*candidates)
+      candidates.each do |candidate|
+        value = normalize_token(candidate)
+        return value if value
+      end
+
+      nil
+    end
+
+    def normalize_token(candidate)
+      case candidate
+      when nil
+        nil
+      when String
+        token = candidate.strip
+        token.empty? ? nil : token
+      else
+        candidate
       end
     end
 

--- a/test/daemon_integration_test.rb
+++ b/test/daemon_integration_test.rb
@@ -226,6 +226,18 @@ class DaemonIntegrationTest < Minitest::Test
     assert_equal 204, reload[:status_code]
   end
 
+  def test_cli_falls_back_to_control_token_when_api_token_blank
+    boot_daemon_environment(control_token: 'control-secret',
+                            authenticate: false,
+                            api_overrides: { 'api_token' => '' })
+
+    client = Client.new
+    assert_equal 'control-secret', client.instance_variable_get(:@control_token)
+
+    response = client.enqueue(['daemon', 'status'], wait: false)
+    assert_equal 200, response['status_code']
+  end
+
   def test_logout_revokes_session
     boot_daemon_environment
 


### PR DESCRIPTION
## Summary
- revert the previous control-token normalization changes that failed to address the 403 errors
- centralize token selection in the client and daemon so blank API/control tokens are ignored when choosing credentials
- add an integration test proving the CLI still works when the API token is blank but a control token is configured

## Testing
- bundle exec ruby -Itest test/librarian_cli_test.rb
- bundle exec ruby -Itest test/daemon_integration_test.rb

------
https://chatgpt.com/codex/tasks/task_e_68f914bfccd08327ab39841e40442f33