### PR TITLE
Fix CLI control token precedence to match daemon

### DIFF
--- a/app/client.rb
+++ b/app/client.rb
@@ -79,9 +79,11 @@ class Client
   def resolve_control_token(explicit_token, options)
     select_token(
       explicit_token,
-      ENV['MEDIA_LIBRARIAN_API_TOKEN'],
       options['api_token'],
+      options[:api_token],
       options['control_token'],
+      options[:control_token],
+      ENV['MEDIA_LIBRARIAN_API_TOKEN'],
       ENV['MEDIA_LIBRARIAN_CONTROL_TOKEN']
     )
   end

--- a/test/daemon_integration_test.rb
+++ b/test/daemon_integration_test.rb
@@ -238,6 +238,28 @@ class DaemonIntegrationTest < Minitest::Test
     assert_equal 200, response['status_code']
   end
 
+  def test_cli_prefers_config_control_token_over_env_api_token
+    boot_daemon_environment(control_token: 'control-secret',
+                            authenticate: false,
+                            api_overrides: { 'api_token' => '' })
+
+    previous_api = ENV['MEDIA_LIBRARIAN_API_TOKEN']
+    previous_api_exists = ENV.key?('MEDIA_LIBRARIAN_API_TOKEN')
+    ENV['MEDIA_LIBRARIAN_API_TOKEN'] = 'stale-token'
+
+    client = Client.new
+    assert_equal 'control-secret', client.instance_variable_get(:@control_token)
+
+    response = client.enqueue(['daemon', 'status'], wait: false)
+    assert_equal 200, response['status_code']
+  ensure
+    if previous_api_exists
+      ENV['MEDIA_LIBRARIAN_API_TOKEN'] = previous_api
+    else
+      ENV.delete('MEDIA_LIBRARIAN_API_TOKEN')
+    end
+  end
+
   def test_logout_revokes_session
     boot_daemon_environment
 


### PR DESCRIPTION
## Summary
- align the CLI client control token lookup order with the daemon so stale API token environment variables no longer override the configured control token
- add an integration test ensuring the CLI prefers the configured control token when an API token environment variable is present

## Testing
- bundle exec ruby -Itest test/daemon_integration_test.rb --name test_cli_prefers_config_control_token_over_env_api_token

------
https://chatgpt.com/codex/tasks/task_e_68f92f00d2748327802f969796b45311