### PR TITLE
Fix Vash cleanup interval without ActiveSupport

### DIFF
--- a/lib/vash.rb
+++ b/lib/vash.rb
@@ -57,7 +57,7 @@ class Vash < Hash
   def [](key)
     sterilize(key)
     clear(key) if expired?(key)
-    cleanup! if Time.now > @last_cleanup + 1.hour
+    cleanup! if Time.now - @last_cleanup > 3600
     regular_reader(key)
   end
 


### PR DESCRIPTION
## Summary
- replace the use of ActiveSupport's Integer#hour in Vash with a simple numeric comparison to avoid missing dependency errors
- ensure the file ends with a newline to satisfy tooling expectations

## Testing
- bundle exec rake test *(fails: rake is not included in the bundle)*
- bundle exec ruby -Ilib -e "require 'utils'; require 'vash'; v=Vash.new; v[:foo]=:bar; v.instance_variable_set(:@last_cleanup, Time.now - 3601); v[:foo]; puts 'ok'"

------
https://chatgpt.com/codex/tasks/task_e_68f930346c548327bc64c5f53346d42b