### PR TITLE
Fix cache cleanup and torrent logging errors

### DIFF
--- a/app/media_librarian/services/torrent_queue_service.rb
+++ b/app/media_librarian/services/torrent_queue_service.rb
@@ -197,7 +197,9 @@ module MediaLibrarian
 
       def log_torrent_details(torrent, torrent_row)
         speaker.speak_up "#{LINE_SEPARATOR}\nTorrent attributes:"
-        (torrent + torrent_row.select { |key, _| [:name, :identifiers].include?(key) }).each { |key, value| speaker.speak_up "#{key} = #{value}" }
+        torrent.merge(torrent_row.select { |key, _| [:name, :identifiers].include?(key) }).each do |key, value|
+          speaker.speak_up "#{key} = #{value}"
+        end
       end
 
       def build_download_options(torrent_row, torrent, tdid)

--- a/lib/vash.rb
+++ b/lib/vash.rb
@@ -57,7 +57,7 @@ class Vash < Hash
   def [](key)
     sterilize(key)
     clear(key) if expired?(key)
-    cleanup! if Time.now > @last_cleanup + 1.hour
+    cleanup! if Time.now > @last_cleanup + 3600
     regular_reader(key)
   end
 


### PR DESCRIPTION
## Summary
- replace the Vash cleanup interval calculation to avoid relying on ActiveSupport extensions
- fix torrent detail logging by merging hash data before iterating

## Testing
- bundle exec rake test *(fails: rake not bundled)*

------
https://chatgpt.com/codex/tasks/task_e_68f9307c52e08327b8852d3457cc1048