### PR TITLE
Avoid redundant Trakt release lookups when year known

### DIFF
--- a/app/movie.rb
+++ b/app/movie.rb
@@ -88,6 +88,8 @@ class Movie
     elsif @release_date
       Time.parse(@release_date) rescue nil
     else
+      return nil if @year.to_i.zero?
+
       Time.new(@year.to_i)
     end
   end
@@ -97,6 +99,7 @@ class Movie
 
     release_time = release_date
     release_year = release_time&.year
+    release_year = nil if release_year&.zero?
     extracted_year = nil
     if name
       identified_year = Metadata.identify_release_year(name)

--- a/test/app/movie_test.rb
+++ b/test/app/movie_test.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'time'
+require_relative '../../app/movie'
+require_relative '../../app/languages'
+require_relative '../../lib/metadata'
+require_relative '../../lib/trakt_agent'
+
+class MovieTest < Minitest::Test
+  unless Numeric.method_defined?(:years)
+    class ::Numeric
+      def years
+        self * 365 * 24 * 60 * 60
+      end
+    end
+  end
+
+  def setup
+    @environment = build_stubbed_environment
+    MediaLibrarian.application = @environment.application
+  end
+
+  def teardown
+    MediaLibrarian.application = nil
+    @environment.cleanup if @environment
+  end
+
+  def test_year_uses_release_date_without_trakt_lookup
+    TraktAgent.define_singleton_method(:movie__releases) do |*_args|
+      flunk 'TraktAgent.movie__releases should not be called when a release date is available'
+    end
+
+    movie = Movie.new(
+      {
+        'title' => String.new('Example (2024)'),
+        'release_date' => '2024-05-01',
+        'ids' => { 'imdb' => 'tt1234567' }
+      },
+      app: @environment.application
+    )
+
+    assert_equal 2024, movie.year
+  ensure
+    if defined?(TraktAgent) && TraktAgent.singleton_class.method_defined?(:movie__releases)
+      TraktAgent.singleton_class.send(:remove_method, :movie__releases)
+    end
+  end
+end

--- a/test/support/dependency_stubs.rb
+++ b/test/support/dependency_stubs.rb
@@ -273,6 +273,10 @@ module Cache
     def queue_state_get(*)
       []
     end
+
+    def object_pack(value, *_args)
+      value
+    end
   end
 end
 


### PR DESCRIPTION
## Summary
- short-circuit `Movie#year` so release metadata provides the year before contacting Trakt
- add a regression test that asserts the release-date path skips `movie__releases`
- extend the cache test stub with `object_pack` to support the new assertions

## Testing
- bundle exec ruby -Itest test/app/movie_test.rb

------
https://chatgpt.com/codex/tasks/task_e_68f9396e8f6483278fa2e81fab085e34