### PR TITLE
Route CLI stop command through control endpoint

### DIFF
--- a/app/client.rb
+++ b/app/client.rb
@@ -97,15 +97,10 @@ class Client
   end
 
   def normalize_token(candidate)
-    case candidate
-    when nil
-      nil
-    when String
-      token = candidate.strip
-      token.empty? ? nil : token
-    else
-      candidate
-    end
+    return nil if candidate.nil?
+
+    token = candidate.to_s.strip
+    token.empty? ? nil : token
   end
 
   def ssl_enabled?

--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -1027,15 +1027,10 @@ class Daemon
     end
 
     def normalize_token(candidate)
-      case candidate
-      when nil
-        nil
-      when String
-        token = candidate.strip
-        token.empty? ? nil : token
-      else
-        candidate
-      end
+      return nil if candidate.nil?
+
+      token = candidate.to_s.strip
+      token.empty? ? nil : token
     end
 
     def ssl_enabled?(opts)

--- a/librarian.rb
+++ b/librarian.rb
@@ -170,6 +170,8 @@ class Librarian
         return if args.nil? || args.empty?
 
         app.speaker.speak_up('A daemon is already running, sending execution there and waiting to get an execution slot')
+        return Daemon.stop if stop_command?(args)
+
         response = Client.new.enqueue(args, wait: true, queue: queue, task: task, internal: internal)
         status_code = response['status_code'].to_i
         body = response['body']
@@ -268,6 +270,13 @@ class Librarian
       else
         app.speaker.speak_up('No command provided, showing help instead.')
       end
+    end
+
+    def stop_command?(args)
+      command, subcommand = Array(args).first(2)
+      command && subcommand &&
+        command.to_s.casecmp('daemon').zero? &&
+        subcommand.to_s.casecmp('stop').zero?
     end
 
     def run_termination(thread, thread_value, object = nil)

--- a/test/daemon_integration_test.rb
+++ b/test/daemon_integration_test.rb
@@ -260,6 +260,16 @@ class DaemonIntegrationTest < Minitest::Test
     end
   end
 
+  def test_cli_accepts_numeric_control_token
+    boot_daemon_environment(control_token: 12_345, authenticate: false)
+
+    client = Client.new
+    assert_equal '12345', client.instance_variable_get(:@control_token)
+
+    response = client.enqueue(['daemon', 'status'], wait: false)
+    assert_equal 200, response['status_code']
+  end
+
   def test_logout_revokes_session
     boot_daemon_environment
 

--- a/test/librarian_cli_test.rb
+++ b/test/librarian_cli_test.rb
@@ -2,6 +2,7 @@
 
 require_relative 'test_helper'
 require_relative '../app/client'
+require_relative '../app/daemon'
 
 class LibrarianCliTest < Minitest::Test
   def setup
@@ -37,6 +38,24 @@ class LibrarianCliTest < Minitest::Test
     dispatches = env.application.args_dispatch.dispatched_commands
     assert_equal 1, dispatches.length
     assert_equal ['daemon', 'status'], dispatches.first[:command]
+  end
+
+  def test_daemon_stop_uses_control_endpoint
+    env = use_environment
+    librarian = Librarian.new(container: env.container, args: ['daemon', 'stop'])
+
+    called = false
+
+    Client.stub(:new, ->(*) { raise 'Client.enqueue should not be used for daemon stop' }) do
+      Daemon.stub(:stop, -> { called = true; env.application.speaker.speak_up('Stop command sent to daemon'); true }) do
+        librarian.stub(:pid_status, ->(*) { :running }) do
+          librarian.run!
+        end
+      end
+    end
+
+    assert called
+    assert_includes env.application.speaker.messages, 'Stop command sent to daemon'
   end
 
   def test_dependencies_are_isolated_per_container


### PR DESCRIPTION
## Summary
- short-circuit remote `daemon stop` CLI commands to call the control endpoint instead of queueing a job, avoiding HTTP timeouts during shutdown
- add a CLI test to guard that the stop command never enqueues work when a daemon is already running

## Testing
- bundle exec ruby -Itest test/librarian_cli_test.rb
- bundle exec ruby -Itest test/daemon_integration_test.rb

------
https://chatgpt.com/codex/tasks/task_e_68f94fb98b9483279ca6609bbe59c4da