### PR TITLE
Trim whitespace when normalizing DB keys

### DIFF
--- a/lib/storage/db.rb
+++ b/lib/storage/db.rb
@@ -268,7 +268,7 @@ module Storage
     end
 
     def normalize_key(key)
-      key.is_a?(String) ? key.to_sym : key
+      key.is_a?(String) ? key.strip.to_sym : key
     end
 
     def run_write(table, sql)


### PR DESCRIPTION
## Summary
- trim whitespace from string keys before symbolizing them in `Storage::Db#normalize_key`

## Testing
- bundle exec ruby -Itest test/lib/storage_db_test.rb

------
https://chatgpt.com/codex/tasks/task_e_68fa1a2befe08327b2e4a5f831ffbf37