### PR TITLE
Wrap log entries to fit viewport

### DIFF
--- a/app/web/app.css
+++ b/app/web/app.css
@@ -262,6 +262,8 @@ button.primary:hover {
   font-family: "SFMono-Regular", ui-monospace, SFMono, "Fira Code", monospace;
   font-size: 0.85rem;
   white-space: pre-wrap;
+  max-width: 100%;
+  overflow-wrap: anywhere;
 }
 
 .log-hint {


### PR DESCRIPTION
## Summary
- ensure log content stays within the viewport by limiting width and allowing long tokens to wrap

## Testing
- ruby -Itest test/lib/string_utils_test.rb

------
https://chatgpt.com/codex/tasks/task_e_68fa1a541ee88327af1f87c6b7b0b1dd