### PR TITLE
Fix CLI usage output when no actions match

### DIFF
--- a/lib/simple_args_dispatch.rb
+++ b/lib/simple_args_dispatch.rb
@@ -93,7 +93,13 @@ module SimpleArgsDispatch
     end
 
     def show_available(app_name, available, prepend = nil, join='|', separator = new_line, extra_info = '')
-      @speaker.speak_up("Usage: #{app_name} #{prepend + ' ' if prepend}#{available[0..1].map { |k, v| "#{'[' if v == :key}#{k.to_s}#{']' if v == :key}" }.join(join)}")
+      entries = available.is_a?(Hash) ? available.to_a : (available ? Array(available) : [])
+      display = entries.first(2).map do |item|
+        key, flag = Array(item).values_at(0, 1)
+        key = key.to_s
+        flag == :key ? "[#{key}]" : key
+      end.join(join)
+      @speaker.speak_up("Usage: #{app_name} #{prepend + ' ' if prepend}#{display}")
       if extra_info.to_s != ''
         @speaker.speak_up(separator)
         @speaker.speak_up(extra_info)


### PR DESCRIPTION
## Summary
- handle hash-based inputs in `SimpleArgsDispatch#show_available`
- prevent `NoMethodError` when displaying usage for unknown commands

## Testing
- bundle exec ruby -Itest test/librarian_cli_test.rb

------
https://chatgpt.com/codex/tasks/task_e_68fa335b717883278364a21139c2df18