### PR TITLE
Fix completed torrent lookup when removing completed torrents

### DIFF
--- a/app/media_librarian/services/torrent_queue_service.rb
+++ b/app/media_librarian/services/torrent_queue_service.rb
@@ -117,7 +117,10 @@ module MediaLibrarian
       def process_completed_torrents
         speaker.speak_up('Will process completed torrents', 0) if Env.debug?
         Cache.queue_state_get('deluge_torrents_completed').each do |tid, data|
-          torrent_record = app.db.get_rows('torrents', {}, { 'torrent_id like ' => tid }).first
+          tid = tid.to_s
+          next if tid.empty?
+
+          torrent_record = app.db.get_rows('torrents', { torrent_id: tid }).first
           remove_it = 0
           begin
             if torrent_record.nil?


### PR DESCRIPTION
## Summary
- normalize queued torrent identifiers before querying the database
- use an exact match when loading completed torrents to avoid malformed LIKE clauses

## Testing
- bundle exec ruby -Itest test/services/torrent_queue_service_test.rb

------
https://chatgpt.com/codex/tasks/task_e_68fa4a535d2083279d0bf55587d252ce