### PR TITLE
Load mediainfo gem during dependency setup

### DIFF
--- a/lib/media_librarian/application.rb
+++ b/lib/media_librarian/application.rb
@@ -125,6 +125,7 @@ module MediaLibrarian
       require 'fuzzystringmatch' unless defined?(FuzzyStringMatch)
       require 'mechanize' unless defined?(Mechanize)
       require 'deluge/rpc' unless defined?(Deluge::Rpc::Client)
+      require 'mediainfo' unless defined?(MediaInfo)
       require_relative '../file_utils'
       load File.expand_path('../simple_speaker.rb', __dir__)
     end


### PR DESCRIPTION
## Summary
- require the mediainfo gem during application dependency setup so MediaInfo is defined when file info is loaded

## Testing
- bundle exec ruby -Itest test/librarian_cli_test.rb

------
https://chatgpt.com/codex/tasks/task_e_68fa6bc1c46c832789327edb30e3a02c