### PR TITLE
Improve status job hierarchy display

### DIFF
--- a/app/web/app.css
+++ b/app/web/app.css
@@ -224,6 +224,15 @@ button.danger:hover {
   background: rgba(15, 23, 42, 0.6);
 }
 
+.job-children {
+  list-style: none;
+  margin: 0.75rem 0 0;
+  padding: 0 0 0 1.5rem;
+  display: grid;
+  gap: 0.75rem;
+  border-left: 1px solid rgba(255, 255, 255, 0.12);
+}
+
 .job-item header {
   display: flex;
   justify-content: space-between;

--- a/test/daemon_status_snapshot_test.rb
+++ b/test/daemon_status_snapshot_test.rb
@@ -43,6 +43,7 @@ class DaemonStatusSnapshotTest < Minitest::Test
     parent_payload = Daemon.send(:serialize_job, parent_job)
     assert_equal 'alpha', parent_payload['queue']
     assert_equal 1, parent_payload['children']
+    assert_equal ['child'], parent_payload['children_ids']
 
     child_payload = Daemon.send(:serialize_job, child_job)
     assert_equal 'parent', child_payload['parent_id']


### PR DESCRIPTION
## Summary
- sort daemon status snapshot data by queue and include child identifiers in serialized jobs
- render the status tab with hierarchical running jobs and parent/child metadata while sorting by queue
- add nested job list styling and extend the daemon status snapshot test for child identifiers

## Testing
- bundle exec ruby -Itest test/daemon_status_snapshot_test.rb

------
https://chatgpt.com/codex/tasks/task_e_68fa75e45bc48327b15f3c689535f033