### PR TITLE
Fix email subject encoding and add mailer test

### DIFF
--- a/app/report.rb
+++ b/app/report.rb
@@ -73,6 +73,7 @@ class Report
   def self.formatted_subject(subject)
     hostname = Socket.gethostname.to_s
     timestamp = Time.now.strftime("%a %d %b %Y")
-    "[#{hostname}]#{subject} - #{timestamp}"
+    sanitized_subject = StringUtils.fix_encoding(subject.to_s)
+    "[#{hostname}]#{sanitized_subject} - #{timestamp}"
   end
 end

--- a/test/app/report_test.rb
+++ b/test/app/report_test.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'hanami/mailer'
+require_relative '../../app/report'
+require_relative '../../lib/string_utils'
+
+class ReportTest < Minitest::Test
+  NEW_LINE_VALUE = "\n".freeze
+
+  def setup
+    @environment = build_stubbed_environment
+    MediaLibrarian.application = @environment.application
+    @environment.application.email_templates = File.expand_path('../../app/mailer_templates', __dir__)
+    @environment.application.email = {
+      'notification_from' => 'from@example.com',
+      'notification_to' => 'to@example.com'
+    }
+
+    Object.const_set(:NEW_LINE, NEW_LINE_VALUE) unless Object.const_defined?(:NEW_LINE)
+
+    Mail::TestMailer.deliveries.clear if defined?(Mail::TestMailer)
+    Hanami::Mailer.configuration = Hanami::Mailer::Configuration.new
+    Hanami::Mailer.configuration.add_mailer(Report)
+    Report.configuration = Hanami::Mailer.configuration.duplicate
+    Hanami::Mailer.configuration.copy!(Report)
+    email_templates = @environment.application.email_templates
+    Hanami::Mailer.configure do
+      root email_templates
+      delivery_method :test
+    end.load!
+  end
+
+  def teardown
+    Mail::TestMailer.deliveries.clear if defined?(Mail::TestMailer)
+    Hanami::Mailer.configuration = Hanami::Mailer::Configuration.new
+    MediaLibrarian.application = nil
+    @environment.cleanup if @environment
+  end
+
+  def test_push_email_sanitizes_invalid_subjects_before_delivery
+    invalid_subject = "Report".dup.force_encoding('ASCII-8BIT') << "\xC3"
+    body = "Job finished with résumé entries"
+
+    assert_sends_email(subject: StringUtils.fix_encoding(invalid_subject), body: body) do
+      Report.push_email(invalid_subject, body)
+    end
+  end
+
+  private
+
+  def assert_sends_email(subject:, body:)
+    yield
+
+    deliveries = Mail::TestMailer.deliveries
+    assert_equal 1, deliveries.size, 'Expected an email to be delivered'
+
+    mail = deliveries.first
+    expected_subject = Report.formatted_subject(subject)
+    assert_equal expected_subject, mail.subject
+    assert_includes mail.text_part.body.decoded, body
+  end
+end

--- a/test/support/container_helpers.rb
+++ b/test/support/container_helpers.rb
@@ -31,7 +31,8 @@ module TestSupport
 
     class StubApplication
       attr_accessor :librarian, :speaker, :args_dispatch,
-                    :workers_pool_size, :queue_slots, :container
+                    :workers_pool_size, :queue_slots, :container,
+                    :email, :email_templates
       attr_reader :root, :loader, :template_dir, :pidfile,
                   :env_flags, :config_dir, :config_file, :config_example,
                   :tracker_dir, :api_config_file
@@ -166,7 +167,7 @@ module TestSupport
         @messages << message
       end
 
-      def tell_error(error, context = nil)
+      def tell_error(error, context = nil, *_args)
         @messages << [:error, error, context]
       end
     end


### PR DESCRIPTION
## Summary
- sanitize formatted email subjects to remove invalid encoding before delivery
- extend test stubs to support email configuration and tolerant error logging
- add a Report mailer test that exercises delivery with invalid subject bytes

## Testing
- bundle exec ruby -Itest test/app/report_test.rb
- bundle exec ruby -Itest test/app/movie_test.rb

------
https://chatgpt.com/codex/tasks/task_e_68fa7a1123548327a21f0d591a5336c2