### PR TITLE
Normalize SMTP configuration for mailer

### DIFF
--- a/app/report.rb
+++ b/app/report.rb
@@ -73,6 +73,7 @@ class Report
   def self.formatted_subject(subject)
     hostname = Socket.gethostname.to_s
     timestamp = Time.now.strftime("%a %d %b %Y")
-    "[#{hostname}]#{subject} - #{timestamp}"
+    sanitized_subject = StringUtils.fix_encoding(subject.to_s)
+    StringUtils.fix_encoding("[#{hostname}]#{sanitized_subject} - #{timestamp}")
   end
 end

--- a/init/email.rb
+++ b/init/email.rb
@@ -7,15 +7,21 @@ FileUtils.mkdir_p(app.email_templates) unless File.exist?(app.email_templates)
 app.email = app.config['email']
 
 if app.email
+  smtp_settings = {
+    address: app.email['host'],
+    port: app.email['port'],
+    domain: app.email['domain'],
+    user_name: app.email['username'],
+    password: app.email['password'],
+    enable_starttls_auto: true
+  }
+
+  auth_type = app.email['auth_type'].to_s.strip
+  smtp_settings[:authentication] = auth_type.to_sym unless auth_type.empty?
+  smtp_settings.delete_if { |_, value| value.nil? || (value.respond_to?(:empty?) && value.empty?) }
+
   Hanami::Mailer.configure do
     root app.email_templates
-    delivery_method :smtp,
-                    address:              app.email['host'],
-                    port:                 app.email['port'],
-                    domain:               app.email['domain'],
-                    user_name:            app.email['username'],
-                    password:             app.email['password'],
-                    authentication:       app.email['auth_type'],
-                    enable_starttls_auto: true
+    delivery_method :smtp, smtp_settings
   end.load!
 end

--- a/test/app/report_test.rb
+++ b/test/app/report_test.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'hanami/mailer'
+require_relative '../../app/report'
+require_relative '../../lib/string_utils'
+
+class ReportTest < Minitest::Test
+  NEW_LINE_VALUE = "\n".freeze
+
+  def setup
+    @environment = build_stubbed_environment
+    MediaLibrarian.application = @environment.application
+    @environment.application.email_templates = File.expand_path('../../app/mailer_templates', __dir__)
+    @environment.application.email = {
+      'notification_from' => 'from@example.com',
+      'notification_to' => 'to@example.com'
+    }
+
+    Object.const_set(:NEW_LINE, NEW_LINE_VALUE) unless Object.const_defined?(:NEW_LINE)
+
+    Mail::TestMailer.deliveries.clear if defined?(Mail::TestMailer)
+    Hanami::Mailer.configuration = Hanami::Mailer::Configuration.new
+    Hanami::Mailer.configuration.add_mailer(Report)
+    Report.configuration = Hanami::Mailer.configuration.duplicate
+    Hanami::Mailer.configuration.copy!(Report)
+    email_templates = @environment.application.email_templates
+    Hanami::Mailer.configure do
+      root email_templates
+      delivery_method :test
+    end.load!
+  end
+
+  def teardown
+    Mail::TestMailer.deliveries.clear if defined?(Mail::TestMailer)
+    Hanami::Mailer.configuration = Hanami::Mailer::Configuration.new
+    MediaLibrarian.application = nil
+    @environment.cleanup if @environment
+  end
+
+  def test_push_email_sanitizes_invalid_subjects_before_delivery
+    invalid_subject = "Report".dup.force_encoding('ASCII-8BIT') << "\xC3"
+    body = "Job finished with résumé entries"
+
+    assert_sends_email(subject: StringUtils.fix_encoding(invalid_subject), body: body) do
+      Report.push_email(invalid_subject, body)
+    end
+  end
+
+  private
+
+  def assert_sends_email(subject:, body:)
+    yield
+
+    deliveries = Mail::TestMailer.deliveries
+    assert_equal 1, deliveries.size, 'Expected an email to be delivered'
+
+    mail = deliveries.first
+    expected_subject = Report.formatted_subject(subject)
+    assert_equal expected_subject, mail.subject
+    assert_includes mail.text_part.body.decoded, body
+  end
+end

--- a/test/init/email_configuration_test.rb
+++ b/test/init/email_configuration_test.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'hanami/mailer'
+
+class EmailConfigurationTest < Minitest::Test
+  def setup
+    @environment = build_stubbed_environment
+    MediaLibrarian.application = @environment.application
+    env = @environment
+    @environment.application.define_singleton_method(:config) { env.container.config }
+
+    email_settings = SimpleConfigMan::DEFAULT_SETTINGS.merge(
+      'email' => {
+        'host' => 'smtp.gmail.com',
+        'port' => 587,
+        'domain' => '',
+        'username' => 'user@example.com',
+        'password' => 'secret',
+        'auth_type' => ' plain '
+      }
+    )
+
+    @environment.container.config = email_settings
+    reset_librarian_state!
+  end
+
+  def teardown
+    MediaLibrarian.application = nil
+    @environment.cleanup if @environment
+  end
+
+  def test_configures_smtp_delivery_with_symbol_authentication
+    captured = {}
+
+    Hanami::Mailer.stub(:configure, lambda do |&block|
+      fake_config = Object.new
+      fake_config.define_singleton_method(:root) { |value| captured[:root] = value }
+      fake_config.define_singleton_method(:delivery_method) do |method, settings = {}|
+        captured[:delivery_method] = method
+        captured[:settings] = settings
+      end
+      fake_config.define_singleton_method(:load!) { captured[:loaded] = true }
+      fake_config.instance_eval(&block)
+      fake_config
+    end) do
+      load File.expand_path('../../init/email.rb', __dir__)
+    end
+
+    expected_root = File.expand_path('../../app/mailer_templates', __dir__)
+    assert_equal expected_root, captured[:root]
+    assert_equal :smtp, captured[:delivery_method]
+
+    expected_settings = {
+      address: 'smtp.gmail.com',
+      port: 587,
+      user_name: 'user@example.com',
+      password: 'secret',
+      enable_starttls_auto: true,
+      authentication: :plain
+    }
+
+    assert_equal expected_settings, captured[:settings]
+    assert_equal true, captured[:loaded]
+  end
+end

--- a/test/support/container_helpers.rb
+++ b/test/support/container_helpers.rb
@@ -31,7 +31,8 @@ module TestSupport
 
     class StubApplication
       attr_accessor :librarian, :speaker, :args_dispatch,
-                    :workers_pool_size, :queue_slots, :container
+                    :workers_pool_size, :queue_slots, :container,
+                    :email, :email_templates
       attr_reader :root, :loader, :template_dir, :pidfile,
                   :env_flags, :config_dir, :config_file, :config_example,
                   :tracker_dir, :api_config_file
@@ -166,7 +167,7 @@ module TestSupport
         @messages << message
       end
 
-      def tell_error(error, context = nil)
+      def tell_error(error, context = nil, *_args)
         @messages << [:error, error, context]
       end
     end


### PR DESCRIPTION
## Summary
- sanitize formatted report subjects and normalize their encoding
- strip blank SMTP options and symbolize authentication before configuring Hanami mailer
- cover the SMTP configuration bootstrap with a dedicated test

## Testing
- bundle exec ruby -Itest test/init/email_configuration_test.rb
- bundle exec ruby -Itest test/app/report_test.rb
- bundle exec ruby -Itest test/app/movie_test.rb

------
https://chatgpt.com/codex/tasks/task_e_68fa7a1123548327a21f0d591a5336c2