### PR TITLE
Pin logger gem to default Ruby version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ ruby '3.2.3'
 
 gem 'archive-zip', :git => 'https://github.com/raphyduck/archive-zip.git', :require => false
 gem 'activesupport', :require => false
+gem 'logger', '< 1.6', :require => false
 gem 'rake', :require => false
 gem 'bencode', :require => false
 gem 'deluge-rpc', :git => 'https://github.com/raphyduck/deluge-rpc.git', :require => false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,7 +141,7 @@ GEM
       concurrent-ruby (~> 1.0)
     io-like (0.3.1)
     json (2.13.2)
-    logger (1.7.0)
+    logger (1.5.3)
     loofah (2.24.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -256,6 +256,7 @@ DEPENDENCIES
   get_process_mem
   hanami-mailer
   imdb_party!
+  logger (< 1.6)
   mechanize
   mediainfo!
   net-ssh


### PR DESCRIPTION
## Summary
- constrain the logger gem to Ruby's bundled version to avoid duplicate constant warnings from the newer release
- update the lockfile to reflect the pinned logger dependency

## Testing
- bundle exec ruby librarian.rb daemon status *(interactive prompt interrupted after confirming absence of logger warnings)*


------
https://chatgpt.com/codex/tasks/task_e_68fb84f952688327ab13d36678d579c8