### PR TITLE
Ensure Env autoloads when requiring librarian

### DIFF
--- a/librarian.rb
+++ b/librarian.rb
@@ -4,6 +4,8 @@ require_relative 'boot/librarian'
 require_relative 'lib/media_librarian/command_registry'
 require_relative 'lib/media_librarian/app_container_support'
 
+autoload :Env, File.expand_path('lib/env.rb', __dir__) unless defined?(Env)
+
 class Librarian
   include MediaLibrarian::AppContainerSupport
 

--- a/test/lib/env_test.rb
+++ b/test/lib/env_test.rb
@@ -39,6 +39,18 @@ class EnvTest < Minitest::Test
     Thread.current[:no_email_notif] = nil
   end
 
+  def test_env_constant_available_after_requiring_librarian
+    result = nil
+
+    Bundler.with_unbundled_env do
+      Dir.chdir(File.expand_path('../..', __dir__)) do
+        result = system('bundle', 'exec', 'ruby', '-r./librarian', '-e', 'Env')
+      end
+    end
+
+    assert result, 'Env constant should load when requiring librarian'
+  end
+
   private
 
   def env_class


### PR DESCRIPTION
## Summary
- autoload the `Env` constant from the CLI entrypoint so it is available for console debugging without additional requires
- add a regression test that shells out to ensure `Env` loads after requiring `librarian`

## Testing
- bundle exec rake test

------
https://chatgpt.com/codex/tasks/task_e_68fa88bf7d3c8327822a304cf46f68da