### PR TITLE
Adjust session cookie security based on TLS usage

### DIFF
--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -656,7 +656,9 @@ class Daemon
         AccessLog: []
       }
 
-      if ssl_enabled?(opts)
+      @session_cookie_secure = ssl_enabled?(opts)
+
+      if @session_cookie_secure
         begin
           server_options.merge!(build_ssl_server_options(opts, address))
         rescue StandardError => e
@@ -1079,7 +1081,7 @@ class Daemon
     def build_session_cookie(value)
       cookie = WEBrick::Cookie.new(SESSION_COOKIE_NAME, value.to_s)
       cookie.path = '/'
-      cookie.secure = true
+      cookie.secure = !!@session_cookie_secure
       cookie.instance_variable_set(:@httponly, true)
       cookie
     end
@@ -1442,6 +1444,7 @@ class Daemon
       @stop_event = nil
       @is_daemon = false
       @scheduler_name = nil
+      @session_cookie_secure = nil
     end
 
     def job_registry

--- a/test/daemon_integration_test.rb
+++ b/test/daemon_integration_test.rb
@@ -212,6 +212,10 @@ class DaemonIntegrationTest < Minitest::Test
     assert_equal 201, login[:status_code]
     refute_nil @session_cookie
 
+    cookie_header = Array(login[:headers]['set-cookie']).first.to_s
+    attributes = cookie_header.split(';').map { |entry| entry.strip.downcase }
+    refute_includes attributes, 'secure'
+
     status = control_get('/status')
     assert_equal 200, status[:status_code]
   end
@@ -285,6 +289,11 @@ class DaemonIntegrationTest < Minitest::Test
 
   def test_https_control_server_serves_requests
     boot_daemon_environment(api_overrides: { 'ssl_enabled' => true, 'ssl_verify_mode' => 'none' })
+
+    login = authenticate_session
+    cookie_header = Array(login[:headers]['set-cookie']).first.to_s
+    attributes = cookie_header.split(';').map { |entry| entry.strip.downcase }
+    assert_includes attributes, 'secure'
 
     response = control_get('/status')
     assert_equal 200, response[:status_code]


### PR DESCRIPTION
## Summary
- remember whether the control server is running with TLS so session cookies match the transport security
- clear the saved TLS flag during daemon cleanup
- extend the daemon integration tests to cover HTTP and HTTPS session cookies and status access

## Testing
- bundle exec rake test

------
https://chatgpt.com/codex/tasks/task_e_68fb9e499abc8327a07d57106e107546