### PR TITLE
Persist control session cookies across daemon restarts

### DIFF
--- a/app/web/app.js
+++ b/app/web/app.js
@@ -584,8 +584,11 @@ async function logout() {
 
 async function bootstrapSession() {
   try {
-    await fetchJson('/status');
-    setAuthenticated(true, state.username);
+    const session = await fetchJson('/session');
+    if (!session || !session.username) {
+      return;
+    }
+    setAuthenticated(true, session.username);
     await refreshAll();
   } catch (error) {
     // Auth required or other errors already handled.

--- a/test/daemon_integration_test.rb
+++ b/test/daemon_integration_test.rb
@@ -286,12 +286,18 @@ class DaemonIntegrationTest < Minitest::Test
   def test_logout_revokes_session
     boot_daemon_environment
 
+    stale_cookie = @session_cookie
+    refute_nil stale_cookie
+
     logout = control_delete('/session')
     assert_equal 204, logout[:status_code]
     assert_nil @session_cookie
 
+    @session_cookie = stale_cookie
     forbidden = control_get('/status')
     assert_equal 403, forbidden[:status_code]
+  ensure
+    @session_cookie = nil
   end
 
   def test_session_cookie_survives_daemon_restart


### PR DESCRIPTION
## Summary
- sign control-session cookies so they can be validated without in-memory state
- add a session inspection endpoint and use it on the web UI to restore logins after reloads
- cover session persistence across daemon restarts in integration tests

## Testing
- bundle exec rake test

------
https://chatgpt.com/codex/tasks/task_e_68fba22703348327a89cb357222d1a27