### PR TITLE
Handle SMTP CRL verification via ssl_context override

### DIFF
--- a/init/email.rb
+++ b/init/email.rb
@@ -1,6 +1,7 @@
 # Configure email alerts
 require 'openssl'
 require_relative '../boot/librarian'
+require 'mail/network/delivery_methods/smtp'
 
 app = MediaLibrarian::Boot.application
 app.email_templates = File.expand_path('../app/mailer_templates', __dir__)
@@ -8,9 +9,25 @@ FileUtils.mkdir_p(app.email_templates) unless File.exist?(app.email_templates)
 app.email = app.config['email']
 
 if app.email
+  module Mail
+    class SMTP
+      module VerifyCallback
+        def ssl_context(*)
+          super.tap do |context|
+            skip_crl_error = OpenSSL::X509::V_ERR_UNABLE_TO_GET_CRL
+            context.verify_callback = lambda do |preverify_ok, store|
+              preverify_ok || store&.error == skip_crl_error
+            end
+          end
+        end
+      end
+
+      prepend VerifyCallback
+    end
+  end
+
   Hanami::Mailer.configure do
     root app.email_templates
-    skip_crl_error = OpenSSL::X509::V_ERR_UNABLE_TO_GET_CRL
     delivery_method :smtp,
                     address:              app.email['host'],
                     port:                 app.email['port'],
@@ -19,9 +36,6 @@ if app.email
                     password:             app.email['password'],
                     authentication:       app.email['auth_type'],
                     enable_starttls_auto: true,
-                    ssl_context_params:   {
-                      verify_mode:    OpenSSL::SSL::VERIFY_PEER,
-                      verify_callback: ->(ok, store) { ok || store&.error == skip_crl_error }
-                    }
+                    openssl_verify_mode:  OpenSSL::SSL::VERIFY_PEER
   end.load!
 end


### PR DESCRIPTION
## Summary
- ensure Mail::SMTP uses a CRL-aware verify_callback by prepending a wrapper around `ssl_context`
- require the SMTP delivery implementation and rely on `openssl_verify_mode` instead of unused `ssl_context_params`

## Testing
- bundle exec rake test

------
https://chatgpt.com/codex/tasks/task_e_68fbb15b56988327bd1256e27f2f71bc