### PR TITLE
Add timeouts to movie metadata lookups

### DIFF
--- a/app/movie.rb
+++ b/app/movie.rb
@@ -1,4 +1,5 @@
 require 'timeout'
+require 'socket'
 
 class Movie
   include MediaLibrarian::AppContainerSupport

--- a/app/movie.rb
+++ b/app/movie.rb
@@ -1,3 +1,5 @@
+require 'timeout'
+
 class Movie
   include MediaLibrarian::AppContainerSupport
 
@@ -145,6 +147,11 @@ class Movie
             .compact
   end
 
+  NETWORK_TIMEOUT_ERRORS = [Timeout::Error, SocketError].tap do |errors|
+    errors << Net::OpenTimeout if defined?(Net::OpenTimeout)
+    errors << Net::ReadTimeout if defined?(Net::ReadTimeout)
+  end.freeze
+
   def self.movie_get(ids, type = 'movie_get', movie = nil, app: self.app)
     cache_name = ids.map { |k, v| v.to_s.empty? ? nil : "#{k}#{v}" }.compact.join
     return '', nil if cache_name.empty?
@@ -157,14 +164,20 @@ class Movie
     case type
     when 'movie_get'
       if movie.nil? && (ids['tmdb'].to_s != '' || ids['imdb'].to_s != '')
-        tmdb_movie = Tmdb::Movie.detail(ids['tmdb'] || ids['imdb']) rescue nil
-        movie = Cache.object_pack(tmdb_movie, 1)
-        src = 'tmdb'
+        tmdb_movie = lookup_with_timeout(app, 'tmdb') { Tmdb::Movie.detail(ids['tmdb'] || ids['imdb']) }
+        if tmdb_movie
+          movie = Cache.object_pack(tmdb_movie, 1)
+          src = 'tmdb'
+        end
       end
       if (movie.nil? || movie['title'].nil?) && (ids['trakt'].to_s != '' || ids['imdb'].to_s != '' || ids['slug'].to_s != '')
-        trakt_movie = TraktAgent.movie__summary(ids['trakt'] || ids['imdb'] || ids['slug'], "?extended=full") rescue nil
-        movie = Cache.object_pack(trakt_movie, 1)
-        src = 'trakt'
+        trakt_movie = lookup_with_timeout(app, 'trakt') do
+          TraktAgent.movie__summary(ids['trakt'] || ids['imdb'] || ids['slug'], "?extended=full")
+        end
+        if trakt_movie
+          movie = Cache.object_pack(trakt_movie, 1)
+          src = 'trakt'
+        end
       end
       movie = Movie.new(movie.merge('data_source' => src), app: app) if movie
       full_save = movie
@@ -189,6 +202,18 @@ class Movie
     app.speaker.tell_error(e, Utils.arguments_dump(binding))
     Cache.cache_add(type, cache_name, ['', nil], nil)
     return '', nil
+  end
+
+  def self.lookup_with_timeout(app, source, &block)
+    return unless block
+
+    Timeout.timeout(15) { block.call }
+  rescue *NETWORK_TIMEOUT_ERRORS => e
+    app.speaker.tell_error(e, "Movie.movie_get #{source} lookup timed out")
+    nil
+  rescue StandardError => e
+    app.speaker.tell_error(e, "Movie.movie_get #{source} lookup failed")
+    nil
   end
 
   def self.movie_search(title, no_prompt = 0, original_filename = '', ids = {}, app: self.app)

--- a/test/app/movie_test.rb
+++ b/test/app/movie_test.rb
@@ -2,6 +2,7 @@
 
 require 'test_helper'
 require 'time'
+require 'timeout'
 require_relative '../../app/movie'
 require_relative '../../app/languages'
 require_relative '../../lib/metadata'
@@ -26,6 +27,25 @@ class MovieTest < Minitest::Test
     @environment.cleanup if @environment
   end
 
+  def with_short_timeout(limit = 0.1)
+    original_timeout = Timeout.method(:timeout)
+    Timeout.stub(:timeout, ->(seconds, klass = nil, &block) { original_timeout.call([seconds, limit].min, klass, &block) }) do
+      yield
+    end
+  end
+
+  def without_cache
+    singleton = Cache.singleton_class
+    singleton.define_method(:cache_get) { |_type = nil, _keyword = nil, *_rest| nil } unless Cache.respond_to?(:cache_get)
+    singleton.define_method(:cache_add) { |_type = nil, _keyword = nil, _result = nil, *_rest| nil } unless Cache.respond_to?(:cache_add)
+
+    Cache.stub(:cache_get, nil) do
+      Cache.stub(:cache_add, nil) do
+        yield
+      end
+    end
+  end
+
   def test_year_uses_release_date_without_trakt_lookup
     TraktAgent.define_singleton_method(:movie__releases) do |*_args|
       flunk 'TraktAgent.movie__releases should not be called when a release date is available'
@@ -45,5 +65,77 @@ class MovieTest < Minitest::Test
     if defined?(TraktAgent) && TraktAgent.singleton_class.method_defined?(:movie__releases)
       TraktAgent.singleton_class.send(:remove_method, :movie__releases)
     end
+  end
+
+  def test_movie_get_returns_promptly_when_tmdb_lookup_times_out
+    ensure_tmdb_stubs
+
+    result = nil
+    elapsed = measure_elapsed do
+      with_short_timeout do
+        without_cache do
+          Tmdb::Movie.stub(:detail, ->(*) { sleep 1 }) do
+            result = Movie.movie_get({ 'tmdb' => '1' }, app: @environment.application)
+          end
+        end
+      end
+    end
+
+    assert_operator elapsed, :<, 0.5, "Tmdb lookup took too long (#{elapsed}s)"
+    assert_equal ['', nil], result
+    assert_includes error_contexts, 'Movie.movie_get tmdb lookup timed out'
+  end
+
+  def test_movie_get_returns_promptly_when_trakt_lookup_times_out
+    ensure_tmdb_stubs
+
+    result = nil
+    elapsed = measure_elapsed do
+      with_short_timeout do
+        without_cache do
+          Tmdb::Movie.stub(:detail, ->(*) { nil }) do
+            TraktAgent.stub(:movie__summary, ->(*) { sleep 1 }) do
+              result = Movie.movie_get({ 'trakt' => '1' }, app: @environment.application)
+            end
+          end
+        end
+      end
+    end
+
+    assert_operator elapsed, :<, 0.5, "Trakt lookup took too long (#{elapsed}s)"
+    assert_equal ['', nil], result
+    assert_includes error_contexts, 'Movie.movie_get trakt lookup timed out'
+  end
+
+  private
+
+  def ensure_tmdb_stubs
+    unless defined?(Tmdb)
+      Object.const_set(:Tmdb, Module.new)
+    end
+    unless defined?(Tmdb::Movie)
+      Tmdb.const_set(:Movie, Class.new)
+    end
+    unless Tmdb::Movie.respond_to?(:detail)
+      Tmdb::Movie.define_singleton_method(:detail) { nil }
+    end
+
+    unless defined?(TraktAgent)
+      Object.const_set(:TraktAgent, Class.new)
+    end
+    unless TraktAgent.respond_to?(:movie__summary)
+      TraktAgent.define_singleton_method(:movie__summary) { nil }
+    end
+  end
+
+  def error_contexts
+    @environment.application.speaker.messages.select { |msg| msg.is_a?(Array) && msg.first == :error }
+                 .map { |(_, _, context)| context }
+  end
+
+  def measure_elapsed
+    start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    yield
+    Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
   end
 end


### PR DESCRIPTION
## Summary
- wrap the TMDB and Trakt lookups in `Movie.movie_get` with a bounded timeout and network error logging
- reuse the same pattern to guard against nil results before packing movie data
- add tests that stub the remote clients to sleep and assert the lookup returns quickly on timeout

## Testing
- bundle exec ruby -Itest test/app/movie_test.rb

------
https://chatgpt.com/codex/tasks/task_e_68fbbb8adf308327a13baad41ccbe255