### PR TITLE
Ensure SMTP SSL context respects custom parameters

### DIFF
--- a/init/email.rb
+++ b/init/email.rb
@@ -1,4 +1,5 @@
 # Configure email alerts
+require 'mail'
 require 'openssl'
 require_relative '../boot/librarian'
 
@@ -6,6 +7,25 @@ app = MediaLibrarian::Boot.application
 app.email_templates = File.expand_path('../app/mailer_templates', __dir__)
 FileUtils.mkdir_p(app.email_templates) unless File.exist?(app.email_templates)
 app.email = app.config['email']
+
+module Mail
+  module SMTPSSLContextPatch
+    private
+
+    def ssl_context
+      super.tap do |context|
+        if (params = settings[:ssl_context_params] || settings['ssl_context_params'])
+          params.each do |key, value|
+            setter = :"#{key}="
+            context.__send__(setter, value) if context.respond_to?(setter)
+          end
+        end
+      end
+    end
+  end
+
+  SMTP.prepend(SMTPSSLContextPatch)
+end
 
 if app.email
   Hanami::Mailer.configure do

--- a/test/init/email_test.rb
+++ b/test/init/email_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'mail'
+require 'openssl'
+require_relative '../../init/email'
+
+class EmailInitTest < Minitest::Test
+  def test_ssl_context_applies_custom_params
+    verify_callback = ->(ok, store) { ok && store }
+
+    smtp = Mail::SMTP.new(
+      address: 'localhost',
+      port: 25,
+      ssl_context_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE, verify_callback: verify_callback }
+    )
+
+    context = smtp.send(:ssl_context)
+
+    assert_equal verify_callback, context.verify_callback
+    assert_equal OpenSSL::SSL::VERIFY_NONE, context.verify_mode
+  end
+end


### PR DESCRIPTION
## Summary
- patch `Mail::SMTP#ssl_context` in the email initializer to apply `ssl_context_params` after the default setup
- add a focused test covering the patched behavior by asserting the custom verify callback is present on the SSL context

## Testing
- bundle exec rake test
- bundle exec ruby <<'RUBY'
require 'thread'
require 'socket'
require 'mail'
require 'openssl'
require 'tmpdir'
require 'fileutils'

tmp_home = Dir.mktmpdir('ml-email-test')
ENV['HOME'] = tmp_home
config_dir = File.join(tmp_home, '.medialibrarian')
FileUtils.mkdir_p(config_dir)
File.write(File.join(config_dir, 'conf.yml'), "--- { email: {} }\n")
File.write(File.join(config_dir, 'api.yml'), "--- {}\n")

module Hanami
  class Mailer
    class Config
      def root(*)
        self
      end

      def delivery_method(*)
        self
      end

      def load!
        self
      end
    end

    def self.configure(&block)
      config = Config.new
      config.instance_eval(&block) if block
      config
    end
  end
end

require_relative 'init/email'

key = OpenSSL::PKey::RSA.new(2048)
name = OpenSSL::X509::Name.parse('/CN=localhost')
cert = OpenSSL::X509::Certificate.new
cert.subject = cert.issuer = name
cert.public_key = key.public_key
cert.not_before = Time.now
cert.not_after = Time.now + 3600
cert.serial = 1
cert.version = 2
factory = OpenSSL::X509::ExtensionFactory.new
factory.subject_certificate = cert
factory.issuer_certificate = cert
cert.add_extension(factory.create_extension('basicConstraints', 'CA:FALSE', true))
cert.add_extension(factory.create_extension('subjectKeyIdentifier', 'hash'))
cert.add_extension(factory.create_extension('authorityKeyIdentifier', 'keyid:always,issuer:always'))
cert.add_extension(factory.create_extension('subjectAltName', 'DNS:localhost'))
cert.sign(key, OpenSSL::Digest::SHA256.new)

server = TCPServer.new('127.0.0.1', 0)
port = server.addr[1]
ctx = OpenSSL::SSL::SSLContext.new
ctx.cert = cert
ctx.key = key
ctx.verify_mode = OpenSSL::SSL::VERIFY_NONE
ssl_server = OpenSSL::SSL::SSLServer.new(server, ctx)
received = Queue.new
Thread.report_on_exception = false
server_thread = Thread.new do
  ssl = ssl_server.accept
  ssl.sync = true
  ssl.puts "220 localhost ESMTP"
  loop do
    line = ssl.gets or break
    case line
    when /\AEHLO/
      ssl.puts "250-localhost"
      ssl.puts "250 OK"
    when /\AMAIL FROM/
      ssl.puts "250 OK"
    when /\ARCPT TO/
      ssl.puts "250 OK"
    when /\ADATA/
      ssl.puts "354 End data with <CR><LF>.<CR><LF>"
      data = []
      while (l = ssl.gets)
        break if l == ".\r\n"
        data << l
      end
      received << data.join
      ssl.puts "250 queued"
    when /\AQUIT/
      ssl.puts "221 Bye"
      break
    else
      ssl.puts "250 OK"
    end
  end
  ssl.close
end

callback_called = false
Mail.defaults do
  delivery_method :smtp,
                  address: '127.0.0.1',
                  port: port,
                  tls: true,
                  ssl: true,
                  enable_starttls_auto: false,
                  openssl_verify_mode: OpenSSL::SSL::VERIFY_PEER,
                  ssl_context_params: {
                    verify_mode: OpenSSL::SSL::VERIFY_PEER,
                    verify_callback: lambda do |preverify_ok, store_ctx|
                      callback_called = true
                      true
                    end
                  }
end

Mail.deliver do
  to 'test@example.com'
  from 'me@example.com'
  subject 'Manual Test'
  body 'Hello'
end

Thread.pass until callback_called || !server_thread.alive?
body = received.pop(true)
puts "Delivered body: #{body.inspect}"
puts "Callback called: #{callback_called}"

server_thread.join
FileUtils.remove_entry(tmp_home)
RUBY

------
https://chatgpt.com/codex/tasks/task_e_68fbd315116883279916c0cb497afa8d