### PR TITLE
Fix parent thread restoration on inline jobs

### DIFF
--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -642,7 +642,8 @@ class Daemon
       job.output = captured_output.dup if captured_output
       thread[:captured_output] = nil if captured_output
       thread[:current_daemon] = saved_thread_locals[:current_daemon]
-      thread[:parent] = saved_thread_locals[:parent]
+      saved_parent = saved_thread_locals[:parent]
+      thread[:parent] = saved_parent.equal?(thread) ? nil : saved_parent
       thread[:jid] = saved_thread_locals[:jid]
       thread[:queue_name] = saved_thread_locals[:queue_name]
       unless child_log_buffer && saved_thread_locals[:log_msg].nil?


### PR DESCRIPTION
## Summary
- clear self-referential parent thread locals when jobs finish
- add regression test covering inline child execution when worker is pre-seeded with a self parent

## Testing
- bundle exec ruby -Itest test/daemon_job_control_test.rb

------
https://chatgpt.com/codex/tasks/task_e_68fc98be89d083278e0f2a0c729abadb