### PR TITLE
Preserve outer job captured output when nested jobs run inline

### DIFF
--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -645,7 +645,8 @@ class Daemon
         thread[:captured_output] = saved_thread_locals[:captured_output]
       end
       thread[:current_daemon] = saved_thread_locals[:current_daemon]
-      thread[:parent] = saved_thread_locals[:parent]
+      saved_parent = saved_thread_locals[:parent]
+      thread[:parent] = saved_parent.equal?(thread) ? nil : saved_parent
       thread[:jid] = saved_thread_locals[:jid]
       thread[:queue_name] = saved_thread_locals[:queue_name]
       unless child_log_buffer && saved_thread_locals[:log_msg].nil?

--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -620,9 +620,9 @@ class Daemon
         parent: thread[:parent],
         jid: thread[:jid],
         queue_name: thread[:queue_name],
-        log_msg: thread[:log_msg],
-        captured_output: thread[:captured_output]
+        log_msg: thread[:log_msg]
       }
+      original_captured_output = thread[:captured_output]
       thread[:current_daemon] = job.client || saved_thread_locals[:current_daemon]
       thread[:parent] = job.parent_thread unless job.parent_thread.equal?(thread)
       thread[:jid] = job.id
@@ -640,10 +640,8 @@ class Daemon
       job.started_at = Time.now
       Librarian.run_command(job.args.dup, job.internal, job.task, &job.block)
     ensure
-      if captured_output
-        job.output = captured_output.dup
-        thread[:captured_output] = saved_thread_locals[:captured_output]
-      end
+      job.output = captured_output.dup if captured_output
+      thread[:captured_output] = original_captured_output if captured_output
       thread[:current_daemon] = saved_thread_locals[:current_daemon]
       saved_parent = saved_thread_locals[:parent]
       thread[:parent] = saved_parent.equal?(thread) ? nil : saved_parent

--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -620,7 +620,8 @@ class Daemon
         parent: thread[:parent],
         jid: thread[:jid],
         queue_name: thread[:queue_name],
-        log_msg: thread[:log_msg]
+        log_msg: thread[:log_msg],
+        captured_output: thread[:captured_output]
       }
       thread[:current_daemon] = job.client || saved_thread_locals[:current_daemon]
       thread[:parent] = job.parent_thread unless job.parent_thread.equal?(thread)
@@ -639,8 +640,10 @@ class Daemon
       job.started_at = Time.now
       Librarian.run_command(job.args.dup, job.internal, job.task, &job.block)
     ensure
-      job.output = captured_output.dup if captured_output
-      thread[:captured_output] = nil if captured_output
+      if captured_output
+        job.output = captured_output.dup
+        thread[:captured_output] = saved_thread_locals[:captured_output]
+      end
       thread[:current_daemon] = saved_thread_locals[:current_daemon]
       thread[:parent] = saved_thread_locals[:parent]
       thread[:jid] = saved_thread_locals[:jid]


### PR DESCRIPTION
## Summary
- restore the original `:captured_output` thread local after running a job that captures output
- add a regression test covering nested caller-runs jobs with output capture and share the worker-pool setup helper

## Testing
- bundle exec ruby -Itest test/daemon_job_control_test.rb

------
https://chatgpt.com/codex/tasks/task_e_68fc98c55d9c83278dbfd9111bfb0b3a