### PR TITLE
Preserve parent captured output buffer for nested jobs

### DIFF
--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -620,7 +620,8 @@ class Daemon
         parent: thread[:parent],
         jid: thread[:jid],
         queue_name: thread[:queue_name],
-        log_msg: thread[:log_msg]
+        log_msg: thread[:log_msg],
+        captured_output: thread[:captured_output]
       }
       thread[:current_daemon] = job.client || saved_thread_locals[:current_daemon]
       thread[:parent] = job.parent_thread unless job.parent_thread.equal?(thread)
@@ -640,7 +641,7 @@ class Daemon
       Librarian.run_command(job.args.dup, job.internal, job.task, &job.block)
     ensure
       job.output = captured_output.dup if captured_output
-      thread[:captured_output] = nil if captured_output
+      thread[:captured_output] = saved_thread_locals[:captured_output] if captured_output
       thread[:current_daemon] = saved_thread_locals[:current_daemon]
       saved_parent = saved_thread_locals[:parent]
       thread[:parent] = saved_parent.equal?(thread) ? nil : saved_parent


### PR DESCRIPTION
## Summary
- preserve the original `thread[:captured_output]` while running a job with output capture
- ensure nested caller-runs jobs restore the parent buffer with a new regression test

## Testing
- bundle exec ruby -Itest test/daemon_job_control_test.rb

------
https://chatgpt.com/codex/tasks/task_e_68fcc75a31d08327bdb71de931e16a54