### PR TITLE
Expand job queue chip descriptions

### DIFF
--- a/app/web/app.js
+++ b/app/web/app.js
@@ -366,7 +366,9 @@ function renderJobs(data = {}) {
         const runningCount = entry.running ?? 0;
         const queuedCount = entry.queued ?? 0;
         const finishedCount = entry.finished ?? 0;
-        span.textContent = `${label}: r${runningCount} q${queuedCount} f${finishedCount}`;
+        const description = `${label}: ${runningCount} en cours · ${queuedCount} en attente · ${finishedCount} terminés`;
+        span.textContent = description;
+        span.title = description;
         return span;
       });
       queueContainer.replaceChildren(...chips);


### PR DESCRIPTION
## Summary
- expand the queue chips to show descriptive text for running, queued, and finished counts
- mirror the same descriptive text in the chip tooltip to clarify the metrics

## Testing
- bundle exec rake test

------
https://chatgpt.com/codex/tasks/task_e_68fcfaa342d08327a7b6e85c93142d6c