### PR TITLE
Add stop control to web dashboard

### DIFF
--- a/app/web/app.js
+++ b/app/web/app.js
@@ -556,15 +556,16 @@ async function reloadScheduler() {
   }
 }
 
-async function restartDaemon() {
-  const button = document.getElementById('restart-daemon');
+async function controlDaemon({ path, buttonId, message }) {
+  const button = buttonId ? document.getElementById(buttonId) : null;
   if (button) {
     button.disabled = true;
   }
   try {
-    await fetchJson('/restart', { method: 'POST' });
-    showNotification('Redémarrage du démon en cours…');
-    stopAutoRefresh();
+    await fetchJson(path, { method: 'POST' });
+    if (message) {
+      showNotification(message);
+    }
     setAuthenticated(false);
   } catch (error) {
     showNotification(error.message, 'error');
@@ -573,6 +574,22 @@ async function restartDaemon() {
       button.disabled = false;
     }
   }
+}
+
+async function restartDaemon() {
+  await controlDaemon({
+    path: '/restart',
+    buttonId: 'restart-daemon',
+    message: 'Redémarrage du démon en cours…',
+  });
+}
+
+async function stopDaemon() {
+  await controlDaemon({
+    path: '/stop',
+    buttonId: 'stop-daemon',
+    message: 'Arrêt du démon en cours…',
+  });
 }
 
 const TAB_LOADERS = {
@@ -699,6 +716,7 @@ function setupTabs() {
 function setupEventListeners() {
   setupTabs();
   document.getElementById('refresh-status').addEventListener('click', loadStatus);
+  document.getElementById('stop-daemon').addEventListener('click', stopDaemon);
   document.getElementById('restart-daemon').addEventListener('click', restartDaemon);
   document.getElementById('refresh-logs').addEventListener('click', loadLogs);
   document.getElementById('save-config').addEventListener('click', saveConfig);

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -73,6 +73,7 @@
             <div class="panel-header">
               <h2>Jobs</h2>
               <div class="actions">
+                <button id="stop-daemon" type="button" class="danger">Arrêter</button>
                 <button id="restart-daemon" type="button" class="danger">Redémarrer</button>
                 <button id="refresh-status" type="button">Actualiser</button>
               </div>


### PR DESCRIPTION
## Summary
- add a stop control button to the jobs panel of the web dashboard
- reuse shared logic for restart and stop actions

## Testing
- bundle exec rake test *(fails: Cache is not a class (TypeError))*
- bundle exec rake test TEST=test/daemon_integration_test.rb


------
https://chatgpt.com/codex/tasks/task_e_68fcff098ce083278053506fbc683674