### PR TITLE
Handle methods in cache serializer

### DIFF
--- a/test/lib/cache_object_pack_test.rb
+++ b/test/lib/cache_object_pack_test.rb
@@ -5,7 +5,14 @@ $LOAD_PATH.unshift(File.expand_path('../support/stubs', __dir__))
 require 'bigdecimal'
 require 'date'
 require 'minitest/autorun'
-require_relative '../../lib/cache'
+
+cache_stub = Object.const_get(:Cache) if Object.const_defined?(:Cache)
+Object.send(:remove_const, :Cache) if Object.const_defined?(:Cache)
+load File.expand_path('../../lib/cache.rb', __dir__)
+RealCache = Cache
+Object.send(:remove_const, :Cache)
+Object.const_set(:Cache, cache_stub) if cache_stub
+
 
 class CacheObjectPackTest < Minitest::Test
   class WithoutDup
@@ -17,13 +24,18 @@ class CacheObjectPackTest < Minitest::Test
   end
 
   def test_pack_object_without_dup
-    result = Cache.object_pack(WithoutDup.new('value'))
+    result = RealCache.object_pack(WithoutDup.new('value'))
     assert_equal('CacheObjectPackTest::WithoutDup', result.first)
     assert_equal(['String', 'value'], result.last['value'])
   end
 
   def test_pack_frozen_object_without_dup
-    result = Cache.object_pack(WithoutDup.new('value').freeze)
+    result = RealCache.object_pack(WithoutDup.new('value').freeze)
     assert_equal('CacheObjectPackTest::WithoutDup', result.first)
+  end
+
+  def test_pack_method_objects
+    result = RealCache.object_pack(method(:test_pack_method_objects))
+    assert_equal(['String', 'Illegal object type'], result)
   end
 end


### PR DESCRIPTION
## Summary
- guard Cache.object_pack against Method/UnboundMethod instances before duplicating
- adjust cache object pack tests to load the real class alongside existing stubs and cover method objects

## Testing
- bundle exec rake test

------
https://chatgpt.com/codex/tasks/task_e_68fcf8b92bbc8327adadd27e146f689b