### PR TITLE
Ignore container ivars when packing cache objects

### DIFF
--- a/test/lib/cache_object_pack_test.rb
+++ b/test/lib/cache_object_pack_test.rb
@@ -38,4 +38,20 @@ class CacheObjectPackTest < Minitest::Test
     result = RealCache.object_pack(method(:test_pack_method_objects))
     assert_equal(['String', 'Illegal object type'], result)
   end
+
+  def test_pack_object_ignores_app_reference
+    application = Struct.new(:container).new
+    container = Struct.new(:application).new(application)
+    application.container = container
+
+    sample = Object.new
+    sample.instance_variable_set(:@app, container)
+    sample.instance_variable_set(:@value, 'payload')
+
+    result = RealCache.object_pack(sample)
+
+    assert_equal('Object', result.first)
+    assert_equal(['String', 'payload'], result.last['value'])
+    refute_includes(result.last.keys, 'app')
+  end
 end


### PR DESCRIPTION
## Summary
- filter out known application container instance variables in `Cache.object_pack`
- use the duplicated object when traversing instance variables to avoid mutating the original
- cover the regression with a test that packs an object carrying an `@app` reference

## Testing
- bundle exec ruby -Itest test/lib/cache_object_pack_test.rb

------
https://chatgpt.com/codex/tasks/task_e_68fd0ffeae3483278c423a563e93556d