### PR TITLE
Add deep duplication support for Hash and Array

### DIFF
--- a/lib/array.rb
+++ b/lib/array.rb
@@ -1,0 +1,15 @@
+class Array
+  def deep_dup
+    map do |value|
+      begin
+        if value.respond_to?(:deep_dup)
+          value.deep_dup
+        else
+          value.dup
+        end
+      rescue StandardError
+        value
+      end
+    end
+  end
+end

--- a/lib/hash.rb
+++ b/lib/hash.rb
@@ -1,5 +1,19 @@
 class Hash
 
+  def deep_dup
+    each_with_object({}) do |(key, value), memo|
+      memo[key] = begin
+        if value.respond_to?(:deep_dup)
+          value.deep_dup
+        else
+          value.dup
+        end
+      rescue StandardError
+        value
+      end
+    end
+  end
+
   def +(h)
     h.keys.each do |k|
       if key?(k) && [Array, Hash, Vash].include?(h[k].class) && [Array, Hash, Vash].include?(values_at(k).first.class)

--- a/lib/media_librarian/application.rb
+++ b/lib/media_librarian/application.rb
@@ -126,6 +126,8 @@ module MediaLibrarian
       require 'mechanize' unless defined?(Mechanize)
       require 'deluge/rpc' unless defined?(Deluge::Rpc::Client)
       require 'mediainfo' unless defined?(MediaInfo)
+      require_relative '../hash'
+      require_relative '../array'
       require_relative '../file_utils'
       load File.expand_path('../simple_speaker.rb', __dir__)
     end

--- a/test/lib/metadata_test.rb
+++ b/test/lib/metadata_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+require_relative '../../lib/metadata'
+
+class MetadataTest < Minitest::Test
+  def test_media_add_deep_duplicates_nested_attributes
+    attrs = {
+      metadata: {
+        tags: ['action', { rating: 5 }]
+      }
+    }
+    file_attrs = {}
+    file = { name: 'file.mkv' }
+    data = {}
+
+    result = Metadata.media_add('Example', 'movies', 'Example Movie', ['id-1'], attrs, file_attrs, file, data)
+
+    stored = result['id-1']
+    refute_nil stored
+    assert_equal ['action', { rating: 5 }], stored[:metadata][:tags]
+    refute_same attrs[:metadata][:tags], stored[:metadata][:tags]
+    refute_same attrs[:metadata][:tags].last, stored[:metadata][:tags].last
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,6 +2,8 @@
 
 require 'minitest/autorun'
 
+require_relative '../lib/hash'
+require_relative '../lib/array'
 require_relative 'support/dependency_stubs'
 require_relative '../librarian'
 require_relative 'support/container_helpers'


### PR DESCRIPTION
## Summary
- add Hash#deep_dup and Array#deep_dup implementations to the runtime
- load the extensions during application setup and in tests
- add a regression test covering Metadata.media_add with nested attributes

## Testing
- bundle exec rake test

------
https://chatgpt.com/codex/tasks/task_e_68fd180b124083279977440dc39ce6cd