### PR TITLE
Add Hash#deep_merge fallback

### DIFF
--- a/lib/hash.rb
+++ b/lib/hash.rb
@@ -26,6 +26,27 @@ class Hash
     merge(h)
   end
 
+  unless method_defined?(:deep_merge)
+    def deep_merge(other_hash, &block)
+      dup.deep_merge!(other_hash, &block)
+    end
+
+    def deep_merge!(other_hash, &block)
+      return self unless other_hash.is_a?(Hash)
+
+      other_hash.each_pair do |key, value|
+        if key?(key) && self[key].is_a?(Hash) && value.is_a?(Hash)
+          self[key] = self[key].deep_merge(value, &block)
+        elsif key?(key) && block
+          self[key] = block.call(key, self[key], value)
+        else
+          self[key] = value
+        end
+      end
+      self
+    end
+  end
+
   # USAGE: Hash.from_xml(YOUR_XML_STRING)
   # modified from http://stackoverflow.com/questions/1230741/convert-a-nokogiri-document-to-a-ruby-hash/1231297#123129
 


### PR DESCRIPTION
## Summary
- add a Hash#deep_merge / Hash#deep_merge! implementation that respects optional blocks
- ensure Library.process_folder can merge default filters without ActiveSupport

## Testing
- bundle exec rake test

------
https://chatgpt.com/codex/tasks/task_e_68fde13e11b08327a9e392d45574b617