### PR TITLE
Fix Torznab tracker link mapping

### DIFF
--- a/lib/torznab_tracker.rb
+++ b/lib/torznab_tracker.rb
@@ -23,11 +23,16 @@ class TorznabTracker
     end
     MediaLibrarian.app.speaker.speak_up "Running search on tracker '#{name}' for query '#{query}' for category '#{type}' (#{cat.join(',')})" if Env.debug?
     Hash.from_xml(@tracker.get({'t' => t, 'cat' => cat.join(','), 'q' => query, 'limit' => limit}))[:rss][:channel][:item].each do |i|
+      enclosure_url = i.dig(:enclosure, :@url) || i.dig(:enclosure, :url)
+      guid = i[:guid].is_a?(Hash) ? i[:guid][:__content__] || i[:guid][:content] : i[:guid]
+      download_fallback = guid.to_s.empty? ? i[:link] : guid
+      download_url = enclosure_url.to_s.empty? ? download_fallback : enclosure_url
+      details_url = i[:link].to_s.empty? ? download_fallback : i[:link]
       result << {
           :name => i[:title],
           :size => i[:size],
-          :link => i[:guid],
-          :torrent_link => i[:link],
+          :link => details_url,
+          :torrent_link => download_url,
           :magnet_link => '',
           :seeders => i[:attr].select{|t| t[:name] == 'seeders'}.first[:value],
           :leechers => i[:attr].select{|t| t[:name] == 'seeders'}.first[:seeders],

--- a/lib/torznab_tracker.rb
+++ b/lib/torznab_tracker.rb
@@ -24,7 +24,15 @@ class TorznabTracker
     MediaLibrarian.app.speaker.speak_up "Running search on tracker '#{name}' for query '#{query}' for category '#{type}' (#{cat.join(',')})" if Env.debug?
     Hash.from_xml(@tracker.get({'t' => t, 'cat' => cat.join(','), 'q' => query, 'limit' => limit}))[:rss][:channel][:item].each do |i|
       enclosure_url = i.dig(:enclosure, :@url) || i.dig(:enclosure, :url)
-      guid = i[:guid].is_a?(Hash) ? i[:guid][:__content__] || i[:guid][:content] : i[:guid]
+      guid = if i[:guid].is_a?(Hash)
+        guid_hash = i[:guid]
+        [:__content__, :content, :text, '__content__', 'content', 'text']
+          .lazy
+          .map { |key| guid_hash[key] }
+          .find { |value| !value.to_s.empty? }
+      else
+        i[:guid]
+      end
       download_fallback = guid.to_s.empty? ? i[:link] : guid
       download_url = enclosure_url.to_s.empty? ? download_fallback : enclosure_url
       details_url = i[:link].to_s.empty? ? download_fallback : i[:link]

--- a/test/services/tracker_query_service_test.rb
+++ b/test/services/tracker_query_service_test.rb
@@ -1,9 +1,14 @@
 # frozen_string_literal: true
 
+require 'ostruct'
+
 require_relative 'service_test_helper'
 require_relative '../../app/media_librarian/services'
 require_relative '../../app/media_librarian/services/base_service'
 require_relative '../../app/media_librarian/services/tracker_query_service'
+require_relative '../../lib/media_librarian/application'
+require_relative '../../lib/hash'
+require_relative '../../lib/torznab_tracker'
 
 class TrackerQueryServiceTest < Minitest::Test
   class FakeApp
@@ -44,5 +49,69 @@ class TrackerQueryServiceTest < Minitest::Test
     result = @service.get_trackers(nil)
 
     assert_equal ['alpha'], result
+  end
+
+  def test_torznab_tracker_uses_details_and_download_links
+    caps = OpenStruct.new(
+      search_modes: OpenStruct.new(
+        search: OpenStruct.new(available: true),
+        movie_search: OpenStruct.new(available: true),
+        tv_search: OpenStruct.new(available: true)
+      ),
+      categories: [OpenStruct.new(name: 'Movies', id: '100')]
+    )
+
+    xml = <<~XML
+      <rss>
+        <channel>
+          <item>
+            <title>Example One</title>
+            <size>123</size>
+            <link>https://tracker.example/details/1</link>
+            <guid>https://tracker.example/download/1</guid>
+            <enclosure url="https://tracker.example/enclosure/1" />
+            <attr name="seeders" value="10" />
+            <attr name="leechers" value="2" />
+          </item>
+          <item>
+            <title>Example Two</title>
+            <size>456</size>
+            <link>https://tracker.example/details/2</link>
+            <guid>https://tracker.example/download/2</guid>
+            <attr name="seeders" value="5" />
+            <attr name="leechers" value="1" />
+          </item>
+        </channel>
+      </rss>
+    XML
+
+    fake_client = Struct.new(:caps, :xml) do
+      def get(_params)
+        xml
+      end
+    end.new(caps, xml)
+
+    environment = build_service_environment
+    app_defined = MediaLibrarian.instance_variable_defined?(:@application)
+    old_application = MediaLibrarian.instance_variable_get(:@application) if app_defined
+    MediaLibrarian.application = environment.application
+
+    Torznab::Client.stub(:new, ->(*) { fake_client }) do
+      tracker = TorznabTracker.new({ 'api_url' => 'api', 'api_key' => 'key' }, 'test')
+      results = tracker.search('movies', 'query')
+
+      first, second = results
+      assert_equal 'https://tracker.example/details/1', first[:link]
+      assert_equal 'https://tracker.example/enclosure/1', first[:torrent_link]
+      assert_equal 'https://tracker.example/details/2', second[:link]
+      assert_equal 'https://tracker.example/download/2', second[:torrent_link]
+    end
+  ensure
+    if app_defined
+      MediaLibrarian.application = old_application
+    elsif MediaLibrarian.instance_variable_defined?(:@application)
+      MediaLibrarian.remove_instance_variable(:@application)
+    end
+    environment&.cleanup
   end
 end


### PR DESCRIPTION
## Summary
- update the Torznab tracker to expose details URLs via `:link` and download URLs via `:torrent_link`
- add a service test that stubs a Torznab client response and asserts the link mappings

## Testing
- bundle exec rake test

------
https://chatgpt.com/codex/tasks/task_e_68fdff952d4c83278861931a5f851906