### PR TITLE
Add Torznab torrent link repair script

### DIFF
--- a/scripts/fix_torznab_links.rb
+++ b/scripts/fix_torznab_links.rb
@@ -1,0 +1,42 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'bundler/setup'
+require_relative '../lib/media_librarian/application'
+require_relative '../lib/cache'
+
+app = MediaLibrarian.application
+db = app.db
+
+def download_url?(url)
+  url = url.to_s.strip
+  return false if url.empty?
+
+  return true if url.start_with?('magnet:')
+  return true if url.match?(/\.(torrent|nzb)(?:\?.*)?\z/i)
+
+  url.match?(/(\/download\b|download\.php|enclosure|getnzb|getTorrent|action=download)/i)
+end
+
+fixed = 0
+
+db.get_rows('torrents').each do |row|
+  attrs = begin
+    Cache.object_unpack(row[:tattributes])
+  rescue StandardError
+    nil
+  end
+  next unless attrs.is_a?(Hash)
+
+  attrs = attrs.transform_keys { |key| key.respond_to?(:to_sym) ? key.to_sym : key }
+  link = attrs[:link].to_s
+  torrent_link = attrs[:torrent_link].to_s
+  next if link.empty? || torrent_link.empty?
+  next unless download_url?(link) && !download_url?(torrent_link)
+
+  attrs[:link], attrs[:torrent_link] = torrent_link, link
+  db.update_rows('torrents', { tattributes: Cache.object_pack(attrs) }, { name: row[:name] })
+  fixed += 1
+end
+
+puts "Fixed #{fixed} torrent#{'s' unless fixed == 1}."


### PR DESCRIPTION
## Summary
- add a fix-up script that iterates stored torrents through the application container
- swap any rows where the download URL is still stored under `link` and persist via the database wrapper

## Testing
- bundle exec rake test

------
https://chatgpt.com/codex/tasks/task_e_68fdfdfdffc483279a468e010fc9c348