### PR TITLE
Require bencode in torrent queue service

### DIFF
--- a/app/media_librarian/services/torrent_queue_service.rb
+++ b/app/media_librarian/services/torrent_queue_service.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'bencode'
+
 module MediaLibrarian
   module Services
     class TorrentDownloadRequest


### PR DESCRIPTION
## Summary
- ensure the torrent queue service loads the bencode gem before using its constants

## Testing
- `bundle exec rake test`


------
https://chatgpt.com/codex/tasks/task_e_68fe273a482083278461bef688ec53cf