### PR TITLE
Improve torznab repair heuristics

### DIFF
--- a/scripts/fix_torznab_links.rb
+++ b/scripts/fix_torznab_links.rb
@@ -1,0 +1,44 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'bundler/setup'
+require_relative '../lib/media_librarian/application'
+require_relative '../lib/cache'
+
+app = MediaLibrarian.application
+db = app.db
+
+DOWNLOAD_RX = %r{(magnet:|\.torrent(\?.*)?\z|/download\b|download\.php|enclosure|getnzb|getTorrent|action=download)}i
+DETAIL_RX = /(details|view|info|torrent)/i
+
+fixed = 0
+
+db.get_rows('torrents', {}, { 'status >' => 0 }).each do |row|
+  attrs = begin
+    Cache.object_unpack(row[:tattributes])
+  rescue StandardError
+    nil
+  end
+  next unless attrs.is_a?(Hash)
+
+  attrs = attrs.each_with_object({}) { |(k, v), memo| memo[k.respond_to?(:to_sym) ? k.to_sym : k] = v }
+  before_link = attrs[:link].to_s.strip
+  before_torrent = attrs[:torrent_link].to_s.strip
+  next if before_link.empty? || before_torrent.empty?
+  next unless before_link.match?(DOWNLOAD_RX) && (!before_torrent.match?(DOWNLOAD_RX) || before_torrent.match?(DETAIL_RX))
+
+  puts '---'
+  puts "Fixing '#{row[:name]}' (status=#{row[:status]})"
+  puts "  record: #{row.inspect}"
+  puts "  before: link=#{before_link.inspect}"
+  puts "          torrent_link=#{before_torrent.inspect}"
+
+  attrs[:link], attrs[:torrent_link] = before_torrent, before_link
+  db.update_rows('torrents', { tattributes: Cache.object_pack(attrs) }, { name: row[:name] })
+
+  puts "  after:  link=#{attrs[:link].inspect}"
+  puts "          torrent_link=#{attrs[:torrent_link].inspect}"
+  fixed += 1
+end
+
+puts "Fixed #{fixed} torrent#{'s' unless fixed == 1}."


### PR DESCRIPTION
## Summary
- keep the torznab repair script focused on active torrents while swapping only link pairs that match the old download/detail signature
- log each swap with the before/after values for easier auditing

## Testing
- bundle exec rake test

------
https://chatgpt.com/codex/tasks/task_e_68fdfdfdffc483279a468e010fc9c348