### PR TITLE
Fix fix_torznab_links active torrent detection

### DIFF
--- a/lib/torznab_tracker.rb
+++ b/lib/torznab_tracker.rb
@@ -36,14 +36,20 @@ class TorznabTracker
       download_fallback = guid.to_s.empty? ? i[:link] : guid
       download_url = enclosure_url.to_s.empty? ? download_fallback : enclosure_url
       details_url = i[:link].to_s.empty? ? download_fallback : i[:link]
+      attrs = Array(i[:attr]).each_with_object({}) do |attr, memo|
+        next unless attr.respond_to?(:[])
+        name = attr[:name] || attr['name']
+        next unless name
+        memo[name.to_s] = attr[:value] || attr['value']
+      end
       result << {
           :name => i[:title],
           :size => i[:size],
           :link => details_url,
           :torrent_link => download_url,
           :magnet_link => '',
-          :seeders => i[:attr].select{|t| t[:name] == 'seeders'}.first[:value],
-          :leechers => i[:attr].select{|t| t[:name] == 'seeders'}.first[:seeders],
+          :seeders => attrs['seeders'],
+          :leechers => attrs['leechers'],
           :id => (Time.now.to_f * 1000).to_i.to_s,
           :added => i[:pubDate],
           :tracker => name

--- a/scripts/fix_torznab_links.rb
+++ b/scripts/fix_torznab_links.rb
@@ -5,40 +5,46 @@ require 'bundler/setup'
 require_relative '../lib/media_librarian/application'
 require_relative '../lib/cache'
 
-app = MediaLibrarian.application
-db = app.db
-
 DOWNLOAD_RX = %r{(magnet:|\.torrent(\?.*)?\z|/download\b|download\.php|enclosure|getnzb|getTorrent|action=download)}i
 DETAIL_RX = /(details|view|info|torrent)/i
 
-fixed = 0
+def fix_torznab_links(db, out: $stdout)
+  fixed = 0
 
-db.get_rows('torrents', {}, { 'status >' => 0 }).each do |row|
-  attrs = begin
-    Cache.object_unpack(row[:tattributes])
-  rescue StandardError
-    nil
+  db.get_rows('torrents').each do |row|
+    next unless row[:status].to_i.positive?
+    attrs = begin
+      Cache.object_unpack(row[:tattributes])
+    rescue StandardError
+      nil
+    end
+    next unless attrs.is_a?(Hash)
+
+    attrs = attrs.each_with_object({}) { |(k, v), memo| memo[k.respond_to?(:to_sym) ? k.to_sym : k] = v }
+    before_link = attrs[:link].to_s.strip
+    before_torrent = attrs[:torrent_link].to_s.strip
+    next if before_link.empty? || before_torrent.empty?
+    next unless before_link.match?(DOWNLOAD_RX) && (!before_torrent.match?(DOWNLOAD_RX) || before_torrent.match?(DETAIL_RX))
+
+    out.puts '---'
+    out.puts "Fixing '#{row[:name]}' (status=#{row[:status]})"
+    out.puts "  record: #{row.inspect}"
+    out.puts "  before: link=#{before_link.inspect}"
+    out.puts "          torrent_link=#{before_torrent.inspect}"
+
+    attrs[:link], attrs[:torrent_link] = before_torrent, before_link
+    db.update_rows('torrents', { tattributes: Cache.object_pack(attrs) }, { name: row[:name] })
+
+    out.puts "  after:  link=#{attrs[:link].inspect}"
+    out.puts "          torrent_link=#{attrs[:torrent_link].inspect}"
+    fixed += 1
   end
-  next unless attrs.is_a?(Hash)
 
-  attrs = attrs.each_with_object({}) { |(k, v), memo| memo[k.respond_to?(:to_sym) ? k.to_sym : k] = v }
-  before_link = attrs[:link].to_s.strip
-  before_torrent = attrs[:torrent_link].to_s.strip
-  next if before_link.empty? || before_torrent.empty?
-  next unless before_link.match?(DOWNLOAD_RX) && (!before_torrent.match?(DOWNLOAD_RX) || before_torrent.match?(DETAIL_RX))
-
-  puts '---'
-  puts "Fixing '#{row[:name]}' (status=#{row[:status]})"
-  puts "  record: #{row.inspect}"
-  puts "  before: link=#{before_link.inspect}"
-  puts "          torrent_link=#{before_torrent.inspect}"
-
-  attrs[:link], attrs[:torrent_link] = before_torrent, before_link
-  db.update_rows('torrents', { tattributes: Cache.object_pack(attrs) }, { name: row[:name] })
-
-  puts "  after:  link=#{attrs[:link].inspect}"
-  puts "          torrent_link=#{attrs[:torrent_link].inspect}"
-  fixed += 1
+  out.puts "Fixed #{fixed} torrent#{'s' unless fixed == 1}."
+  fixed
 end
 
-puts "Fixed #{fixed} torrent#{'s' unless fixed == 1}."
+if $PROGRAM_NAME == __FILE__
+  app = MediaLibrarian.application
+  fix_torznab_links(app.db)
+end

--- a/test/lib/storage_db_test.rb
+++ b/test/lib/storage_db_test.rb
@@ -61,6 +61,19 @@ class StorageDbTest < Minitest::Test
     end
   end
 
+  def test_get_rows_supports_greater_than_filters
+    with_stubbed_app do
+      db = Storage::Db.new(@db_path)
+      db.insert_row('torrents', { name: 'keep-me', status: 1 })
+      db.insert_row('torrents', { name: 'skip-me', status: 0 })
+
+      results = db.get_rows('torrents', {}, { 'status >' => 0 })
+
+      assert_equal ['keep-me'], results.map { |row| row[:name] }
+      db.database.disconnect
+    end
+  end
+
   def test_touch_rows_updates_timestamp
     with_stubbed_app do
       db = Storage::Db.new(@db_path)

--- a/test/scripts/fix_torznab_links_script_test.rb
+++ b/test/scripts/fix_torznab_links_script_test.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'tmpdir'
+require 'ostruct'
+require 'stringio'
+require 'fileutils'
+
+require_relative '../test_helper'
+require_relative '../../lib/storage/db'
+
+class FixTorznabLinksScriptTest < Minitest::Test
+  def setup
+    reset_librarian_state!
+    @cache_stub = Cache if Object.const_defined?(:Cache)
+    Object.send(:remove_const, :Cache) if Object.const_defined?(:Cache)
+    load File.expand_path('../../lib/cache.rb', __dir__)
+    load File.expand_path('../../scripts/fix_torznab_links.rb', __dir__)
+    @tmp_dir = Dir.mktmpdir('fix-torznab-links-test')
+    @db_path = File.join(@tmp_dir, 'test.db')
+    @speaker = TestSupport::Fakes::Speaker.new
+    @app = OpenStruct.new(
+      db: Storage::Db.new(@db_path),
+      speaker: @speaker,
+      env_flags: {}
+    )
+    MediaLibrarian.application = @app
+  end
+
+  def teardown
+    Object.send(:remove_const, :Cache) if Object.const_defined?(:Cache)
+    Object.const_set(:Cache, @cache_stub) if @cache_stub
+    MediaLibrarian.application = nil
+    @app&.db&.database&.disconnect
+    FileUtils.remove_entry(@tmp_dir) if @tmp_dir && Dir.exist?(@tmp_dir)
+  end
+
+  def test_swaps_links_for_active_torrents
+    attrs = {
+      link: 'https://example.com/download/1',
+      torrent_link: 'https://example.com/details/1'
+    }
+
+    packed = Cache.object_pack(attrs)
+    @app.db.insert_row('torrents', { name: 'fix-me', status: 2, tattributes: packed })
+    @app.db.insert_row('torrents', { name: 'skip-me', status: 0, tattributes: packed })
+
+    output = StringIO.new
+    fixed = fix_torznab_links(@app.db, out: output)
+
+    assert_equal 1, fixed
+
+    updated = @app.db.get_rows('torrents', { name: 'fix-me' }).first
+    unpacked = Cache.object_unpack(updated[:tattributes])
+    assert_equal 'https://example.com/details/1', unpacked[:link]
+    assert_equal 'https://example.com/download/1', unpacked[:torrent_link]
+
+    untouched = @app.db.get_rows('torrents', { name: 'skip-me' }).first
+    assert_equal attrs[:link], Cache.object_unpack(untouched[:tattributes])[:link]
+
+    assert_includes output.string, 'Fixed 1 torrent'
+  end
+end

--- a/test/services/tracker_query_service_test.rb
+++ b/test/services/tracker_query_service_test.rb
@@ -105,6 +105,10 @@ class TrackerQueryServiceTest < Minitest::Test
       assert_equal 'https://tracker.example/enclosure/1', first[:torrent_link]
       assert_equal 'https://tracker.example/details/2', second[:link]
       assert_equal 'https://tracker.example/download/2', second[:torrent_link]
+      assert_equal '10', first[:seeders]
+      assert_equal '2', first[:leechers]
+      assert_equal '5', second[:seeders]
+      assert_equal '1', second[:leechers]
     end
   ensure
     if app_defined


### PR DESCRIPTION
## Summary
- refactor the fix_torznab_links script into a reusable helper that filters active torrents in Ruby
- add regression coverage for Storage::Db greater-than filters and the torznab link swapping script

## Testing
- bundle exec rake test test/lib/storage_db_test.rb
- bundle exec rake test test/scripts/fix_torznab_links_script_test.rb

------
https://chatgpt.com/codex/tasks/task_e_68fe4f4b9218832791d074b74dc291c4