### PR TITLE
Fix Torznab link mapping

### DIFF
--- a/lib/torznab_tracker.rb
+++ b/lib/torznab_tracker.rb
@@ -45,8 +45,8 @@ class TorznabTracker
       result << {
           :name => i[:title],
           :size => i[:size],
-          :link => details_url,
-          :torrent_link => download_url,
+          :link => download_url,
+          :torrent_link => details_url,
           :magnet_link => '',
           :seeders => attrs['seeders'],
           :leechers => attrs['leechers'],

--- a/test/services/tracker_query_service_test.rb
+++ b/test/services/tracker_query_service_test.rb
@@ -101,10 +101,10 @@ class TrackerQueryServiceTest < Minitest::Test
       results = tracker.search('movies', 'query')
 
       first, second = results
-      assert_equal 'https://tracker.example/details/1', first[:link]
-      assert_equal 'https://tracker.example/enclosure/1', first[:torrent_link]
-      assert_equal 'https://tracker.example/details/2', second[:link]
-      assert_equal 'https://tracker.example/download/2', second[:torrent_link]
+      assert_equal 'https://tracker.example/enclosure/1', first[:link]
+      assert_equal 'https://tracker.example/details/1', first[:torrent_link]
+      assert_equal 'https://tracker.example/download/2', second[:link]
+      assert_equal 'https://tracker.example/details/2', second[:torrent_link]
       assert_equal '10', first[:seeders]
       assert_equal '2', first[:leechers]
       assert_equal '5', second[:seeders]


### PR DESCRIPTION
## Summary
- ensure torznab tracker responses expose the download URL via the `:link` field and move the detail page into `:torrent_link`
- update tracker query service expectations to reflect the corrected link mapping

## Testing
- bundle exec ruby -Itest test/services/tracker_query_service_test.rb

------
https://chatgpt.com/codex/tasks/task_e_69010c22f3988327ba90a5afe1a08d19