### PR TITLE
Prefer primary torrent link when downloading

### DIFF
--- a/app/media_librarian/services/torrent_queue_service.rb
+++ b/app/media_librarian/services/torrent_queue_service.rb
@@ -32,7 +32,8 @@ module MediaLibrarian
           torrent = Cache.object_unpack(torrent_row[:tattributes])
           log_torrent_details(torrent, torrent_row) if Env.debug?
           tdid = (Time.now.to_f * 1000).to_i.to_s
-          url = torrent[:torrent_link] ? torrent[:torrent_link] : ''
+          url = torrent[:link].to_s
+          url = torrent[:torrent_link].to_s if url.empty?
           magnet = torrent[:magnet_link]
           options = build_download_options(torrent_row, torrent, tdid)
           Cache.queue_state_add_or_update('deluge_options', options)

--- a/test/services/torrent_queue_service_test.rb
+++ b/test/services/torrent_queue_service_test.rb
@@ -1,9 +1,25 @@
 # frozen_string_literal: true
 
+require 'tmpdir'
+
 require_relative 'service_test_helper'
 require_relative '../../app/media_librarian/services'
 require_relative '../../app/media_librarian/services/base_service'
 require_relative '../../app/media_librarian/services/torrent_queue_service'
+
+unless defined?(TorrentSearch)
+  class TorrentSearch
+    class << self
+      def get_tracker_config(*)
+        {}
+      end
+
+      def get_torrent_file(*)
+        ''
+      end
+    end
+  end
+end
 
 class TorrentQueueServiceTest < Minitest::Test
   class FakeDB
@@ -28,10 +44,11 @@ class TorrentQueueServiceTest < Minitest::Test
   end
 
   class FakeApp
-    attr_accessor :db
+    attr_accessor :db, :temp_dir
 
-    def initialize(db:)
+    def initialize(db:, temp_dir: Dir.tmpdir)
       @db = db
+      @temp_dir = temp_dir
     end
   end
 
@@ -69,5 +86,64 @@ class TorrentQueueServiceTest < Minitest::Test
     assert_equal({ name: 'test' }, conditions)
     assert_equal 3, values[:status]
     refute_nil values[:torrent_id]
+  end
+
+  def test_parse_pending_downloads_prefers_link_over_torrent_link
+    torrent_attributes = {
+      link: 'https://primary.example/download',
+      torrent_link: 'https://fallback.example/download',
+      tracker: 'tracker',
+      magnet_link: '',
+      files: [],
+      move_completed: '',
+      rename_main: '',
+      queue: '',
+      assume_quality: nil,
+      category: nil
+    }
+    torrent_row = {
+      name: 'Test Torrent',
+      status: 2,
+      tattributes: 'packed',
+      identifiers: ['id'],
+      identifier: 'legacy-id'
+    }
+
+    db = FakeDB.new
+    def db.get_rows(table, conditions = nil)
+      if table == 'torrents' && conditions == { status: 2 }
+        [@row]
+      else
+        []
+      end
+    end
+    db.instance_variable_set(:@row, torrent_row)
+
+    Dir.mktmpdir do |tmp_dir|
+      app = FakeApp.new(db: db, temp_dir: tmp_dir)
+      service = MediaLibrarian::Services::TorrentQueueService.new(
+        app: app,
+        speaker: @speaker,
+        client: FakeClient.new
+      )
+
+      captured_urls = []
+      processed_paths = []
+
+      Cache.stub(:object_unpack, ->(_value) { torrent_attributes }) do
+        Cache.stub(:queue_state_add_or_update, nil) do
+          TorrentSearch.stub(:get_tracker_config, ->(*_) { { 'no_download' => '0' } }) do
+            TorrentSearch.stub(:get_torrent_file, ->(_tdid, url) { captured_urls << url; 'downloaded.torrent' }) do
+              service.stub(:process_download_request, ->(request) { processed_paths << request.path; true }) do
+                service.parse_pending_downloads
+              end
+            end
+          end
+        end
+      end
+
+      assert_equal ['https://primary.example/download'], captured_urls
+      assert_equal ['downloaded.torrent'], processed_paths
+    end
   end
 end

--- a/test/support/dependency_stubs.rb
+++ b/test/support/dependency_stubs.rb
@@ -107,6 +107,10 @@ if defined?(Utils)
         value
       end
 
+      def parse_filename_template(template, _metadata)
+        template
+      end
+
       def check_if_active(*)
         true
       end
@@ -137,6 +141,10 @@ else
 
       def recursive_typify_keys(value)
         value
+      end
+
+      def parse_filename_template(template, _metadata)
+        template
       end
 
       def check_if_active(*)
@@ -275,6 +283,10 @@ module Cache
     end
 
     def object_pack(value, *_args)
+      value
+    end
+
+    def object_unpack(value, *_args)
       value
     end
   end


### PR DESCRIPTION
## Summary
- read the torrent download URL from `torrent[:link]` and fall back to `:torrent_link`
- cover the new behaviour in `TorrentQueueService` specs with additional stubs
- extend shared dependency stubs with helpers used by the updated tests

## Testing
- bundle exec rake test TEST=test/services/torrent_queue_service_test.rb

------
https://chatgpt.com/codex/tasks/task_e_69010c2993f08327b3d0f9f2da090211