### PR TITLE
Fix torznab link fixer to handle detail-first records

### DIFF
--- a/scripts/fix_torznab_links.rb
+++ b/scripts/fix_torznab_links.rb
@@ -28,7 +28,8 @@ def fix_torznab_links(db, out: $stdout)
     before_link = attrs[:link].to_s.strip
     before_torrent = attrs[:torrent_link].to_s.strip
     next if before_link.empty? || before_torrent.empty?
-    next unless before_link.match?(DOWNLOAD_RX) && (!before_torrent.match?(DOWNLOAD_RX) || before_torrent.match?(DETAIL_RX))
+    next if before_link.match?(DOWNLOAD_RX)
+    next unless before_link.match?(DETAIL_RX) && before_torrent.match?(DOWNLOAD_RX)
 
     out.puts '---'
     out.puts "Fixing '#{row[:name]}' (status=#{row[:status]})"

--- a/test/scripts/fix_torznab_links_script_test.rb
+++ b/test/scripts/fix_torznab_links_script_test.rb
@@ -73,10 +73,10 @@ class FixTorznabLinksScriptTest < Minitest::Test
     Object.send(:remove_const, :SPACE_SUBSTITUTE) if defined?(@defined_space_substitute) && Object.const_defined?(:SPACE_SUBSTITUTE)
   end
 
-  def test_swaps_links_for_active_torrents
+  def test_swaps_detail_links_into_torrent_link
     attrs = {
-      link: 'https://example.com/download/1',
-      torrent_link: 'https://example.com/details/1'
+      link: 'https://example.com/details/1',
+      torrent_link: 'https://example.com/download/1'
     }
 
     packed = Cache.object_pack(attrs)
@@ -90,12 +90,34 @@ class FixTorznabLinksScriptTest < Minitest::Test
 
     updated = @app.db.get_rows('torrents', { name: 'fix-me' }).first
     unpacked = Cache.object_unpack(updated[:tattributes])
-    assert_equal 'https://example.com/details/1', unpacked[:link]
-    assert_equal 'https://example.com/download/1', unpacked[:torrent_link]
+    assert_equal 'https://example.com/download/1', unpacked[:link]
+    assert_equal 'https://example.com/details/1', unpacked[:torrent_link]
 
     untouched = @app.db.get_rows('torrents', { name: 'skip-me' }).first
     assert_equal attrs[:link], Cache.object_unpack(untouched[:tattributes])[:link]
 
     assert_includes output.string, 'Fixed 1 torrent'
+  end
+
+  def test_leaves_existing_download_links_alone
+    attrs = {
+      link: 'https://example.com/download/2',
+      torrent_link: 'https://example.com/details/2'
+    }
+
+    packed = Cache.object_pack(attrs)
+    @app.db.insert_row('torrents', { name: 'correct', status: 2, tattributes: packed })
+
+    output = StringIO.new
+    fixed = fix_torznab_links(@app.db, out: output)
+
+    assert_equal 0, fixed
+
+    updated = @app.db.get_rows('torrents', { name: 'correct' }).first
+    unpacked = Cache.object_unpack(updated[:tattributes])
+    assert_equal attrs[:link], unpacked[:link]
+    assert_equal attrs[:torrent_link], unpacked[:torrent_link]
+
+    assert_includes output.string, 'Fixed 0 torrents'
   end
 end


### PR DESCRIPTION
## Summary
- update the torznab link fixer to flip detail-style links into the torrent slot while leaving download links untouched
- expand the script test coverage to include the new swap rule and the skip case for already-correct downloads

## Testing
- bundle exec ruby -Itest test/scripts/fix_torznab_links_script_test.rb

------
https://chatgpt.com/codex/tasks/task_e_69010c31b734832787d2ce81f4ead1d0