### PR TITLE
Normalize torrent download links

### DIFF
--- a/lib/torrent_rss.rb
+++ b/lib/torrent_rss.rb
@@ -12,13 +12,20 @@ class TorrentRss
     size = raw_size.match(/[\d\.]+/).to_s.to_d
     s_unit = raw_size.match(/\w{2}/).to_s
     size = size_unit_convert(size, s_unit)
-    tlink = detect_link(link.image || link.url)
+    resource = link.image || link.url
+    tlink = detect_link(resource)
+    download_url = tlink == 't' ? resource : ''
+    magnet_url = tlink == 'm' ? resource : ''
+    primary_link = download_url.to_s.empty? ? magnet_url : download_url
+    details_url = link.entry_id || link.url
+    primary_link = details_url if primary_link.to_s.empty?
     {
         :name => link.title.to_s.force_encoding('utf-8'),
         :size => size,
-        :link => link.entry_id || link.url,
-        :torrent_link => tlink == 't' ? link.image || link.url : '',
-        :magnet_link => tlink == 'm' ? link.image || link.url : '',
+        :link => primary_link,
+        :torrent_link => download_url,
+        :details_link => details_url,
+        :magnet_link => magnet_url,
         :seeders => (desc.match(/Seeders: (\d+)?/)[1] rescue 1),
         :leechers => (desc.match(/Leechers: (\d+)?/)[1] rescue 0),
         :id => link.title,

--- a/lib/torznab_tracker.rb
+++ b/lib/torznab_tracker.rb
@@ -45,8 +45,9 @@ class TorznabTracker
       result << {
           :name => i[:title],
           :size => i[:size],
-          :link => details_url,
+          :link => download_url,
           :torrent_link => download_url,
+          :details_link => details_url,
           :magnet_link => '',
           :seeders => attrs['seeders'],
           :leechers => attrs['leechers'],

--- a/scripts/fix_torznab_links.rb
+++ b/scripts/fix_torznab_links.rb
@@ -10,8 +10,6 @@ unless defined?(SPACE_SUBSTITUTE) && defined?(VALID_VIDEO_EXT) && defined?(BASIC
 end
 
 DOWNLOAD_RX = %r{(magnet:|\.torrent(\?.*)?\z|/download\b|download\.php|enclosure|getnzb|getTorrent|action=download)}i
-DETAIL_RX = /(details|view|info|torrent)/i
-
 def fix_torznab_links(db, out: $stdout)
   fixed = 0
 
@@ -27,8 +25,9 @@ def fix_torznab_links(db, out: $stdout)
     attrs = attrs.each_with_object({}) { |(k, v), memo| memo[k.respond_to?(:to_sym) ? k.to_sym : k] = v }
     before_link = attrs[:link].to_s.strip
     before_torrent = attrs[:torrent_link].to_s.strip
-    next if before_link.empty? || before_torrent.empty?
-    next unless before_link.match?(DOWNLOAD_RX) && (!before_torrent.match?(DOWNLOAD_RX) || before_torrent.match?(DETAIL_RX))
+    next if before_link.empty? && before_torrent.empty?
+    next unless before_torrent.match?(DOWNLOAD_RX)
+    next if before_link.match?(DOWNLOAD_RX)
 
     out.puts '---'
     out.puts "Fixing '#{row[:name]}' (status=#{row[:status]})"
@@ -36,11 +35,14 @@ def fix_torznab_links(db, out: $stdout)
     out.puts "  before: link=#{before_link.inspect}"
     out.puts "          torrent_link=#{before_torrent.inspect}"
 
-    attrs[:link], attrs[:torrent_link] = before_torrent, before_link
+    attrs[:details_link] ||= before_link unless before_link.empty?
+    attrs[:link] = before_torrent
+    attrs[:torrent_link] = before_torrent
     db.update_rows('torrents', { tattributes: Cache.object_pack(attrs) }, { name: row[:name] })
 
     out.puts "  after:  link=#{attrs[:link].inspect}"
     out.puts "          torrent_link=#{attrs[:torrent_link].inspect}"
+    out.puts "          details_link=#{attrs[:details_link].inspect}"
     fixed += 1
   end
 

--- a/test/scripts/fix_torznab_links_script_test.rb
+++ b/test/scripts/fix_torznab_links_script_test.rb
@@ -75,8 +75,8 @@ class FixTorznabLinksScriptTest < Minitest::Test
 
   def test_swaps_links_for_active_torrents
     attrs = {
-      link: 'https://example.com/download/1',
-      torrent_link: 'https://example.com/details/1'
+      link: 'https://example.com/details/1',
+      torrent_link: 'https://example.com/download/1'
     }
 
     packed = Cache.object_pack(attrs)
@@ -90,8 +90,9 @@ class FixTorznabLinksScriptTest < Minitest::Test
 
     updated = @app.db.get_rows('torrents', { name: 'fix-me' }).first
     unpacked = Cache.object_unpack(updated[:tattributes])
-    assert_equal 'https://example.com/details/1', unpacked[:link]
+    assert_equal 'https://example.com/download/1', unpacked[:link]
     assert_equal 'https://example.com/download/1', unpacked[:torrent_link]
+    assert_equal 'https://example.com/details/1', unpacked[:details_link]
 
     untouched = @app.db.get_rows('torrents', { name: 'skip-me' }).first
     assert_equal attrs[:link], Cache.object_unpack(untouched[:tattributes])[:link]

--- a/test/services/tracker_query_service_test.rb
+++ b/test/services/tracker_query_service_test.rb
@@ -101,10 +101,12 @@ class TrackerQueryServiceTest < Minitest::Test
       results = tracker.search('movies', 'query')
 
       first, second = results
-      assert_equal 'https://tracker.example/details/1', first[:link]
+      assert_equal 'https://tracker.example/enclosure/1', first[:link]
       assert_equal 'https://tracker.example/enclosure/1', first[:torrent_link]
-      assert_equal 'https://tracker.example/details/2', second[:link]
+      assert_equal 'https://tracker.example/details/1', first[:details_link]
+      assert_equal 'https://tracker.example/download/2', second[:link]
       assert_equal 'https://tracker.example/download/2', second[:torrent_link]
+      assert_equal 'https://tracker.example/details/2', second[:details_link]
       assert_equal '10', first[:seeders]
       assert_equal '2', first[:leechers]
       assert_equal '5', second[:seeders]


### PR DESCRIPTION
## Summary
- ensure queued torrents persist the download URL in `:link`
- update tracker and RSS producers to expose torrent file URLs while preserving details
- refresh the torznab fix script and tests for the new layout

## Testing
- bundle exec ruby -Itest test/services/tracker_query_service_test.rb
- bundle exec ruby -Itest test/scripts/fix_torznab_links_script_test.rb

------
https://chatgpt.com/codex/tasks/task_e_6902058bc3788327b9b5f32d8cb56b0b