### PR TITLE
Ensure torrent queues store download URLs

### DIFF
--- a/app/media_librarian/services/torrent_queue_service.rb
+++ b/app/media_librarian/services/torrent_queue_service.rb
@@ -26,10 +26,13 @@ module MediaLibrarian
         @client = client
       end
 
+      TORRENT_FILE_RX = %r{(\.torrent(\?.*)?\z|/download\b|download\.php|enclosure|getnzb|getTorrent|action=download)}i
+
       def parse_pending_downloads
         speaker.speak_up('Downloading torrent(s) added during the session (if any)', 0)
         app.db.get_rows('torrents', { status: 2 }).each do |torrent_row|
           torrent = Cache.object_unpack(torrent_row[:tattributes])
+          ensure_download_link!(torrent, torrent_row)
           log_torrent_details(torrent, torrent_row) if Env.debug?
           tdid = (Time.now.to_f * 1000).to_i.to_s
           url = torrent[:link].to_s
@@ -198,6 +201,29 @@ module MediaLibrarian
       private
 
       attr_reader :client
+
+      def ensure_download_link!(torrent, torrent_row)
+        return if torrent_file_link?(torrent[:link])
+
+        download = torrent[:torrent_link]
+        return unless torrent_file_link?(download)
+
+        original_link = torrent[:link]
+        torrent[:details_link] ||= original_link unless original_link.to_s.match?(/\Amagnet:/i)
+        torrent[:link] = download
+        torrent[:torrent_link] = download
+        update_torrent_attributes(torrent_row[:name], torrent)
+      rescue StandardError => e
+        speaker.tell_error(e, Utils.arguments_dump(binding)) if Env.debug?
+      end
+
+      def torrent_file_link?(value)
+        value.to_s.match?(TORRENT_FILE_RX)
+      end
+
+      def update_torrent_attributes(name, torrent)
+        app.db.update_rows('torrents', { tattributes: Cache.object_pack(torrent) }, { name: name })
+      end
 
       def log_torrent_details(torrent, torrent_row)
         speaker.speak_up "#{LINE_SEPARATOR}\nTorrent attributes:"

--- a/lib/torrent_rss.rb
+++ b/lib/torrent_rss.rb
@@ -1,5 +1,7 @@
 class TorrentRss
 
+  TORRENT_FILE_RX = %r{(\.torrent(\?.*)?\z|/download\b|download\.php|enclosure|getnzb|getTorrent|action=download)}i
+
   def self.links(url, limit = NUMBER_OF_LINKS)
     generate_links(url, limit)
   end
@@ -12,13 +14,17 @@ class TorrentRss
     size = raw_size.match(/[\d\.]+/).to_s.to_d
     s_unit = raw_size.match(/\w{2}/).to_s
     size = size_unit_convert(size, s_unit)
-    tlink = detect_link(link.image || link.url)
+    resources = [link.image, link.url, link.entry_id].compact
+    download_url = resources.find { |candidate| torrent_file_link?(candidate) }.to_s
+    magnet_url = resources.find { |candidate| magnet_link?(candidate) }.to_s
+    details_url = (link.entry_id || link.url).to_s
     {
         :name => link.title.to_s.force_encoding('utf-8'),
         :size => size,
-        :link => link.entry_id || link.url,
-        :torrent_link => tlink == 't' ? link.image || link.url : '',
-        :magnet_link => tlink == 'm' ? link.image || link.url : '',
+        :link => download_url,
+        :torrent_link => download_url,
+        :details_link => details_url,
+        :magnet_link => magnet_url,
         :seeders => (desc.match(/Seeders: (\d+)?/)[1] rescue 1),
         :leechers => (desc.match(/Leechers: (\d+)?/)[1] rescue 0),
         :id => link.title,
@@ -27,12 +33,12 @@ class TorrentRss
     }
   end
 
-  def self.detect_link(tlink)
-    if tlink.match(/^magnet\:.*/)
-      "m"
-    else
-      "t"
-    end
+  def self.torrent_file_link?(value)
+    value.to_s.match?(TORRENT_FILE_RX)
+  end
+
+  def self.magnet_link?(value)
+    value.to_s.match?(/\Amagnet:/i)
   end
 
   def self.generate_links(url, limit = NUMBER_OF_LINKS)

--- a/test/services/tracker_query_service_test.rb
+++ b/test/services/tracker_query_service_test.rb
@@ -101,10 +101,12 @@ class TrackerQueryServiceTest < Minitest::Test
       results = tracker.search('movies', 'query')
 
       first, second = results
-      assert_equal 'https://tracker.example/details/1', first[:link]
+      assert_equal 'https://tracker.example/enclosure/1', first[:link]
       assert_equal 'https://tracker.example/enclosure/1', first[:torrent_link]
-      assert_equal 'https://tracker.example/details/2', second[:link]
+      assert_equal 'https://tracker.example/details/1', first[:details_link]
+      assert_equal 'https://tracker.example/download/2', second[:link]
       assert_equal 'https://tracker.example/download/2', second[:torrent_link]
+      assert_equal 'https://tracker.example/details/2', second[:details_link]
       assert_equal '10', first[:seeders]
       assert_equal '2', first[:leechers]
       assert_equal '5', second[:seeders]


### PR DESCRIPTION
## Summary
- enforce torrent queue normalization so stored links point at actual torrent downloads while keeping non-magnet details intact
- update Torznab and RSS producers to emit download URLs only when they resolve to torrent files and capture magnets separately
- refine the torznab link repair script and tests to migrate magnet records and reflect the new layout

## Testing
- bundle exec ruby -Itest test/services/tracker_query_service_test.rb
- bundle exec ruby -Itest test/scripts/fix_torznab_links_script_test.rb

------
https://chatgpt.com/codex/tasks/task_e_6902058bc3788327b9b5f32d8cb56b0b