### PR TITLE
Ensure daemon exits after stopping when daemonized

### DIFF
--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -136,6 +136,8 @@ class Daemon
           app.speaker.speak_up('Shutting down')
         end
       end
+
+      exit if daemonized
     end
 
     def stop


### PR DESCRIPTION
## Summary
- ensure the daemonized process terminates after shutdown by exiting once `Daemon.start` finishes when launched in daemon mode

## Testing
- `bundle exec ruby -Itest test/daemon_integration_test.rb` *(fails: Expected 429 but got 503 for queue full scenario)*

------
https://chatgpt.com/codex/tasks/task_e_69024dc40ba48327bc094be8769ee506