### PR TITLE
Use Torznab item link directly

### DIFF
--- a/lib/torznab_tracker.rb
+++ b/lib/torznab_tracker.rb
@@ -34,6 +34,8 @@ class TorznabTracker
         i[:guid]
       end
       link = i[:link]
+      download_fallback = guid.to_s.empty? ? link : guid
+      download_url = enclosure_url.to_s.empty? ? download_fallback : enclosure_url
       details_url = link.to_s.empty? ? guid : link
       attrs = Array(i[:attr]).each_with_object({}) do |attr, memo|
         next unless attr.respond_to?(:[])
@@ -44,7 +46,7 @@ class TorznabTracker
       result << {
           :name => i[:title],
           :size => i[:size],
-          :link => link,
+          :link => download_url,
           :torrent_link => details_url,
           :magnet_link => '',
           :seeders => attrs['seeders'],

--- a/lib/torznab_tracker.rb
+++ b/lib/torznab_tracker.rb
@@ -33,9 +33,8 @@ class TorznabTracker
       else
         i[:guid]
       end
-      download_fallback = guid.to_s.empty? ? i[:link] : guid
-      download_url = enclosure_url.to_s.empty? ? download_fallback : enclosure_url
-      details_url = i[:link].to_s.empty? ? download_fallback : i[:link]
+      link = i[:link]
+      details_url = link.to_s.empty? ? guid : link
       attrs = Array(i[:attr]).each_with_object({}) do |attr, memo|
         next unless attr.respond_to?(:[])
         name = attr[:name] || attr['name']
@@ -45,7 +44,7 @@ class TorznabTracker
       result << {
           :name => i[:title],
           :size => i[:size],
-          :link => download_url,
+          :link => link,
           :torrent_link => details_url,
           :magnet_link => '',
           :seeders => attrs['seeders'],

--- a/test/services/tracker_query_service_test.rb
+++ b/test/services/tracker_query_service_test.rb
@@ -101,14 +101,73 @@ class TrackerQueryServiceTest < Minitest::Test
       results = tracker.search('movies', 'query')
 
       first, second = results
-      assert_equal 'https://tracker.example/enclosure/1', first[:link]
+      assert_equal 'https://tracker.example/details/1', first[:link]
       assert_equal 'https://tracker.example/details/1', first[:torrent_link]
-      assert_equal 'https://tracker.example/download/2', second[:link]
+      assert_equal 'https://tracker.example/details/2', second[:link]
       assert_equal 'https://tracker.example/details/2', second[:torrent_link]
       assert_equal '10', first[:seeders]
       assert_equal '2', first[:leechers]
       assert_equal '5', second[:seeders]
       assert_equal '1', second[:leechers]
+    end
+  ensure
+    if app_defined
+      MediaLibrarian.application = old_application
+    elsif MediaLibrarian.instance_variable_defined?(:@application)
+      MediaLibrarian.remove_instance_variable(:@application)
+    end
+    environment&.cleanup
+  end
+
+  def test_torznab_tracker_prefers_comments_for_details_links
+    caps = OpenStruct.new(
+      search_modes: OpenStruct.new(
+        search: OpenStruct.new(available: true),
+        movie_search: OpenStruct.new(available: true),
+        tv_search: OpenStruct.new(available: true)
+      ),
+      categories: [OpenStruct.new(name: 'Movies', id: '100')]
+    )
+
+    xml = <<~XML
+      <rss>
+        <channel>
+          <item>
+            <title>Example</title>
+            <size>123</size>
+            <link>https://jackett.example/dl/1</link>
+            <guid>https://tracker.example/download/1</guid>
+            <attr name="seeders" value="10" />
+            <attr name="leechers" value="2" />
+          </item>
+          <item>
+            <title>Placeholder</title>
+            <size>456</size>
+            <link>https://tracker.example/details/2</link>
+            <guid>https://tracker.example/download/2</guid>
+            <attr name="seeders" value="5" />
+            <attr name="leechers" value="1" />
+          </item>
+        </channel>
+      </rss>
+    XML
+
+    fake_client = Struct.new(:caps, :xml) do
+      def get(_params)
+        xml
+      end
+    end.new(caps, xml)
+
+    environment = build_service_environment
+    app_defined = MediaLibrarian.instance_variable_defined?(:@application)
+    old_application = MediaLibrarian.instance_variable_get(:@application) if app_defined
+    MediaLibrarian.application = environment.application
+
+    Torznab::Client.stub(:new, ->(*) { fake_client }) do
+      tracker = TorznabTracker.new({ 'api_url' => 'api', 'api_key' => 'key' }, 'test')
+      results = tracker.search('movies', 'query')
+
+      assert_equal 'https://jackett.example/dl/1', results.first[:link]
     end
   ensure
     if app_defined

--- a/test/services/tracker_query_service_test.rb
+++ b/test/services/tracker_query_service_test.rb
@@ -101,9 +101,9 @@ class TrackerQueryServiceTest < Minitest::Test
       results = tracker.search('movies', 'query')
 
       first, second = results
-      assert_equal 'https://tracker.example/details/1', first[:link]
+      assert_equal 'https://tracker.example/enclosure/1', first[:link]
       assert_equal 'https://tracker.example/details/1', first[:torrent_link]
-      assert_equal 'https://tracker.example/details/2', second[:link]
+      assert_equal 'https://tracker.example/download/2', second[:link]
       assert_equal 'https://tracker.example/details/2', second[:torrent_link]
       assert_equal '10', first[:seeders]
       assert_equal '2', first[:leechers]
@@ -167,7 +167,7 @@ class TrackerQueryServiceTest < Minitest::Test
       tracker = TorznabTracker.new({ 'api_url' => 'api', 'api_key' => 'key' }, 'test')
       results = tracker.search('movies', 'query')
 
-      assert_equal 'https://jackett.example/dl/1', results.first[:link]
+      assert_equal 'https://tracker.example/download/1', results.first[:link]
     end
   ensure
     if app_defined


### PR DESCRIPTION
## Summary
- set Torznab results to use the feed <link> element directly as the download link
- simplify detail URL fallback to only consider the feed link or guid
- update tracker query service tests to reflect the simplified link behavior

## Testing
- bundle exec ruby -Itest test/services/tracker_query_service_test.rb

------
https://chatgpt.com/codex/tasks/task_e_69025fc5cd5483279b6dc98be426d011