### PR TITLE
Support tracker-authenticated torrent downloads

### DIFF
--- a/app/media_librarian/services/torrent_queue_service.rb
+++ b/app/media_librarian/services/torrent_queue_service.rb
@@ -49,7 +49,7 @@ module MediaLibrarian
               path = url
               torrent_type = 2
             elsif url.to_s != ''
-              path = TorrentSearch.get_torrent_file(tdid, url)
+              path = TorrentSearch.get_torrent_file(tdid, url, tracker: torrent[:tracker])
             else
               speaker.speak_up 'no_download setting is activated for this tracker, please download manually.'
               path = 'nodl'

--- a/app/media_librarian/services/tracker_query_service.rb
+++ b/app/media_librarian/services/tracker_query_service.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+require 'yaml'
+
+require_relative 'tracker_login_service'
+
 module MediaLibrarian
   module Services
     class TrackerSearchRequest
@@ -29,6 +33,8 @@ module MediaLibrarian
     end
 
     class TrackerQueryService < BaseService
+      LoginRequiredError = Class.new(StandardError)
+
       def get_results(request)
         tries ||= 3
         results = []
@@ -98,17 +104,26 @@ module MediaLibrarian
         category && category != '' && app.config[type] && app.config[type]['site_specific_kw'] && app.config[type]['site_specific_kw'][category] ? " #{app.config[type]['site_specific_kw'][category]}" : ''
       end
 
-      def get_torrent_file(did, url, destination_folder = app.temp_dir)
+      def get_torrent_file(did, url, destination_folder = app.temp_dir, tracker: nil)
         return did if Env.pretend?
         path = "#{destination_folder}/#{did}.torrent"
         FileUtils.rm(path) if File.exist?(path)
         url = @base_url + '/' + url if url.start_with?('/')
+        metadata = tracker_login_metadata(tracker)
+        agent = metadata ? tracker_login_service.ensure_session(tracker) : app.mechanizer
+        retried_login = false
         begin
           tries ||= 3
-          app.mechanizer.get(url).save(path)
+          page = agent.get(url)
+          raise LoginRequiredError if metadata && login_redirect?(page, metadata)
+          page.save(path)
         rescue StandardError => e
-          if (tries -= 1) >= 0
-            sleep 1
+          if metadata && !retried_login && login_retryable?(e)
+            agent = tracker_login_service.login(tracker)
+            retried_login = true
+            retry
+          elsif (tries -= 1) >= 0
+            sleep 1 unless metadata && login_retryable?(e)
             retry
           else
             raise e
@@ -188,6 +203,34 @@ module MediaLibrarian
         end
         download_criteria[:whitelisted_extensions] = FileUtils.get_valid_extensions(category) unless download_criteria[:whitelisted_extensions].is_a?(Array)
         download_criteria.merge(post_actions)
+      end
+
+      def tracker_login_metadata(tracker)
+        return if tracker.to_s.strip.empty?
+
+        path = File.join(app.tracker_dir, "#{tracker}.login.yml")
+        return unless File.exist?(path)
+
+        YAML.safe_load(File.read(path), aliases: true) || {}
+      end
+
+      def tracker_login_service
+        @tracker_login_service ||= TrackerLoginService.new(app: app, speaker: speaker)
+      end
+
+      def login_redirect?(page, metadata)
+        login_url = metadata['login_url'].to_s
+        return false if login_url.empty?
+
+        page_uri = page.respond_to?(:uri) ? page.uri : nil
+        page_uri && page_uri.to_s.start_with?(login_url)
+      end
+
+      def login_retryable?(error)
+        return true if error.is_a?(LoginRequiredError)
+        return error.response_code.to_s == '401' if defined?(Mechanize::ResponseCodeError) && error.is_a?(Mechanize::ResponseCodeError)
+
+        false
       end
     end
   end

--- a/app/torrent_search.rb
+++ b/app/torrent_search.rb
@@ -75,8 +75,8 @@ class TorrentSearch
     tracker_query_service.get_site_keywords(type, category)
   end
 
-  def self.get_torrent_file(did, url, destination_folder = app.temp_dir)
-    tracker_query_service.get_torrent_file(did, url, destination_folder)
+  def self.get_torrent_file(did, url, destination_folder = app.temp_dir, tracker: nil)
+    tracker_query_service.get_torrent_file(did, url, destination_folder, tracker: tracker)
   end
 
   def self.get_trackers(sources)

--- a/lib/torznab_tracker.rb
+++ b/lib/torznab_tracker.rb
@@ -39,6 +39,10 @@ class TorznabTracker
       download_fallback = guid.to_s.empty? ? link : guid
       download_url = enclosure_url.to_s.empty? ? download_fallback : enclosure_url
       details_url = link.to_s.empty? ? guid : link
+      comments_url = i[:comments]
+      if comments_url && !comments_url.to_s.empty? && details_url.to_s.match?(DOWNLOAD_URL_PATTERN)
+        details_url = comments_url
+      end
       attrs = Array(i[:attr]).each_with_object({}) do |attr, memo|
         next unless attr.respond_to?(:[])
         name = attr[:name] || attr['name']

--- a/test/lib/torrent_rss_test.rb
+++ b/test/lib/torrent_rss_test.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require 'yaml'
+require 'ostruct'
+require 'bigdecimal/util'
+
+require_relative '../services/service_test_helper'
+require_relative '../../lib/media_librarian/application'
+require_relative '../../init/global'
+require_relative '../../lib/torrent_rss'
+
+module Feedjira
+  class << self
+    attr_accessor :parsed_bodies
+  end
+  def self.parse(*)
+    raise 'stub'
+  end
+end unless defined?(Feedjira)
+
+class TorrentRssTest < Minitest::Test
+  FEED_URL = 'https://feed.example/rss'
+
+  def setup
+    @speaker = TestSupport::Fakes::Speaker.new
+  end
+
+  def test_links_uses_tracker_session_when_metadata_exists
+    environment, app, tracker, old_application, app_defined = prepare_application
+    metadata_path = File.join(app.tracker_dir, "#{tracker}.login.yml")
+    File.write(metadata_path, { 'login_url' => 'https://tracker.example/login' }.to_yaml)
+
+    response = Struct.new(:body).new('<rss></rss>')
+    agent = Minitest::Mock.new
+    agent.expect(:get, response, [FEED_URL])
+    login_service = Minitest::Mock.new
+    login_service.expect(:ensure_session, agent, [tracker])
+
+    entries = [build_entry]
+    results = verify_links(entries) do
+      TorrentRss.stub(:tracker_login_service, login_service) do
+        TorrentRss.links(FEED_URL, tracker: tracker)
+      end
+    end
+    login_service.verify
+    agent.verify
+    assert_equal 1, results.size
+  ensure
+    cleanup_application(environment, old_application, app_defined)
+  end
+
+  def test_links_use_global_agent_without_metadata
+    environment, app, tracker, old_application, app_defined = prepare_application
+    response = Struct.new(:body).new('<rss></rss>')
+    global_agent = Minitest::Mock.new
+    global_agent.expect(:get, response, [FEED_URL])
+    app.mechanizer = global_agent
+
+    entries = [build_entry]
+    results = verify_links(entries) do
+      TorrentRss.links(FEED_URL, tracker: tracker)
+    end
+    global_agent.verify
+    assert_equal 1, results.size
+  ensure
+    cleanup_application(environment, old_application, app_defined)
+  end
+
+  private
+
+  def prepare_application
+    environment = build_service_environment
+    app = environment.application
+    ensure_mechanizer_accessor(app)
+    app_defined = MediaLibrarian.instance_variable_defined?(:@application)
+    old_application = MediaLibrarian.application if app_defined
+    MediaLibrarian.application = app
+    tracker = 'secure'
+    [environment, app, tracker, old_application, app_defined]
+  end
+
+  def ensure_mechanizer_accessor(app)
+    return if app.respond_to?(:mechanizer)
+
+    app.singleton_class.attr_accessor :mechanizer
+  end
+
+  def verify_links(entries)
+    Feedjira.stub(:parse, ->(_body) { Struct.new(:entries).new(entries) }) do
+      yield
+    end
+  end
+
+  def build_entry
+    OpenStruct.new(
+      summary: String.new('Size: 1 MB Seeders: 5 Leechers: 0'),
+      title: String.new('Example Torrent'),
+      image: String.new('magnet:?xt=urn:btih:ABC'),
+      entry_id: String.new('magnet:?xt=urn:btih:ABC'),
+      url: String.new('magnet:?xt=urn:btih:ABC'),
+      published: Time.now
+    )
+  end
+
+  def cleanup_application(environment, old_application, app_defined)
+    if app_defined
+      MediaLibrarian.application = old_application
+    elsif MediaLibrarian.instance_variable_defined?(:@application)
+      MediaLibrarian.remove_instance_variable(:@application)
+    end
+    environment&.cleanup
+  end
+end

--- a/test/services/torrent_queue_service_test.rb
+++ b/test/services/torrent_queue_service_test.rb
@@ -14,7 +14,7 @@ unless defined?(TorrentSearch)
         {}
       end
 
-      def get_torrent_file(*)
+      def get_torrent_file(*, **)
         ''
       end
     end
@@ -132,7 +132,7 @@ class TorrentQueueServiceTest < Minitest::Test
       Cache.stub(:object_unpack, ->(_value) { torrent_attributes }) do
         Cache.stub(:queue_state_add_or_update, nil) do
           TorrentSearch.stub(:get_tracker_config, ->(*_) { { 'no_download' => '0' } }) do
-            TorrentSearch.stub(:get_torrent_file, ->(_tdid, url) { captured_urls << url; 'downloaded.torrent' }) do
+            TorrentSearch.stub(:get_torrent_file, ->(_tdid, url, *_rest, **) { captured_urls << url; 'downloaded.torrent' }) do
               service.stub(:process_download_request, ->(request) { processed_paths << request.path; true }) do
                 service.parse_pending_downloads
               end


### PR DESCRIPTION
## Summary
- allow the queue service to pass tracker identifiers to the query service so authenticated download sessions can be reused
- ensure the torrent query service and RSS fetcher initialize tracker-specific agents when login metadata is present and retry after reauthentication if needed
- extend torznab handling and add focused tests covering authenticated torrent downloads and RSS feed access

## Testing
- bundle exec rake test TEST=test/services/tracker_query_service_test.rb
- bundle exec rake test TEST=test/services/torrent_queue_service_test.rb
- bundle exec rake test TEST=test/lib/torrent_rss_test.rb

------
https://chatgpt.com/codex/tasks/task_e_69036b15e8fc8327a23bfed84632cf84