### PR TITLE
Expand torznab download detection

### DIFF
--- a/scripts/fix_torznab_links.rb
+++ b/scripts/fix_torznab_links.rb
@@ -9,7 +9,7 @@ unless defined?(SPACE_SUBSTITUTE) && defined?(VALID_VIDEO_EXT) && defined?(BASIC
   require_relative '../init/global'
 end
 
-DOWNLOAD_RX = %r{(magnet:|\.torrent(\?.*)?\z|/download\b|download\.php|download_torrent|enclosure|getnzb|getTorrent|action=download)}i
+DOWNLOAD_RX = %r{(magnet:|\.torrent(\?.*)?\z|/download\b|download\.php|download_torrent|enclosure|getnzb|getTorrent|action=download|://[^\s]+/dl/)}i
 DETAIL_RX = /(details|view|info|torrent)/i
 TORZNAB_HINT_RX = /(jackett|torznab|apikey=)/i
 


### PR DESCRIPTION
## Summary
- broaden the download URL detection regex to treat Jackett /dl/ endpoints as downloads

## Testing
- bundle exec ruby -Itest test/scripts/fix_torznab_links_script_test.rb

------
https://chatgpt.com/codex/tasks/task_e_6903bd2bccdc8327bda358ce2b935c19