### PR TITLE
Fix file editor path handling for load/save actions

### DIFF
--- a/app/web/app.js
+++ b/app/web/app.js
@@ -325,12 +325,19 @@ function registerFileEditor(key, options) {
     const keys = Array.isArray(options.selectionKeys) && options.selectionKeys.length
       ? options.selectionKeys
       : [options.paramName || 'name'];
-    const query = new URLSearchParams();
-    keys.filter(Boolean).forEach((key) => {
-      query.set(key, selection);
-    });
-    const search = query.toString();
-    return search ? `${base}?${search}` : base;
+    if (typeof window !== 'undefined' && typeof window.buildEditorSelectionPath === 'function') {
+      return window.buildEditorSelectionPath(base, selection, action, keys);
+    }
+    if (action === 'reload') {
+      const query = new URLSearchParams();
+      keys.filter(Boolean).forEach((key) => {
+        query.set(key, selection);
+      });
+      const search = query.toString();
+      return search ? `${base}?${search}` : base;
+    }
+    const separator = base.endsWith('/') ? '' : '/';
+    return `${base}${separator}${encodeURIComponent(selection)}`;
   };
 
   editor.buildPayload = ({ includeContent = true, includeSelection = true } = {}) => {

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -196,6 +196,7 @@
 
     <div id="notification" role="status" aria-live="polite"></div>
 
+    <script src="path_utils.js" defer></script>
     <script src="app.js" defer></script>
   </body>
 </html>

--- a/app/web/path_utils.js
+++ b/app/web/path_utils.js
@@ -1,0 +1,30 @@
+;(function attachPathUtilities(global) {
+  function buildEditorSelectionPath(base, selection, action, keys) {
+    const normalizedBase = base || '';
+    if (!normalizedBase || !selection) {
+      return normalizedBase;
+    }
+
+    if (action === 'reload') {
+      const effectiveKeys = Array.isArray(keys) ? keys.filter(Boolean) : [];
+      const queryKeys = effectiveKeys.length ? effectiveKeys : ['name'];
+      const query = new URLSearchParams();
+      queryKeys.forEach((key) => {
+        query.set(key, selection);
+      });
+      const search = query.toString();
+      return search ? `${normalizedBase}?${search}` : normalizedBase;
+    }
+
+    const separator = normalizedBase.endsWith('/') ? '' : '/';
+    return `${normalizedBase}${separator}${encodeURIComponent(selection)}`;
+  }
+
+  if (global && typeof global === 'object') {
+    global.buildEditorSelectionPath = buildEditorSelectionPath;
+  }
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { buildEditorSelectionPath };
+  }
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/test/web/editor_paths.test.js
+++ b/test/web/editor_paths.test.js
@@ -1,0 +1,41 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { buildEditorSelectionPath } = require('../../app/web/path_utils.js');
+
+test('returns base path when no selection is provided', () => {
+  assert.equal(buildEditorSelectionPath('/templates', '', 'load'), '/templates');
+  assert.equal(buildEditorSelectionPath('/templates', null, 'save'), '/templates');
+});
+
+test('appends selection as path segment for load and save actions', () => {
+  assert.equal(
+    buildEditorSelectionPath('/templates', 'alpha.yml', 'load'),
+    '/templates/alpha.yml',
+  );
+  assert.equal(
+    buildEditorSelectionPath('/trackers/', 'main.yml', 'save'),
+    '/trackers/main.yml',
+  );
+});
+
+test('encodes special characters in path segments', () => {
+  assert.equal(
+    buildEditorSelectionPath('/templates', 'français.yaml', 'load'),
+    '/templates/fran%C3%A7ais.yaml',
+  );
+});
+
+test('preserves query strategy for reload actions', () => {
+  assert.equal(
+    buildEditorSelectionPath('/templates', 'alpha.yml', 'reload', ['name']),
+    '/templates?name=alpha.yml',
+  );
+});
+
+test('supports multiple selection keys for reload actions', () => {
+  assert.equal(
+    buildEditorSelectionPath('/trackers', 'main.yml', 'reload', ['name', 'alt']),
+    '/trackers?name=main.yml&alt=main.yml',
+  );
+});


### PR DESCRIPTION
## Summary
- add a shared helper that builds file editor URLs with path segments for load/save and query params for reload
- update the dashboard script to rely on the helper so template and tracker editors hit the correct endpoints
- cover the new URL logic with a lightweight Node test suite

## Testing
- node --test test/web/editor_paths.test.js

------
https://chatgpt.com/codex/tasks/task_e_69066728c3ec8327b08e0f28e906aff1