### PR TITLE
Handle missing folders and tracker response edge cases

### DIFF
--- a/app/torrent_search.rb
+++ b/app/torrent_search.rb
@@ -292,11 +292,11 @@ class TorrentSearch
     end
     attributes = {
         :identifier => torrent[:identifier],
-        :identifiers => torrent[:identifiers],
         :tattributes => Cache.object_pack(torrent.select { |k, _| ![:identifier, :identifiers, :name, :download_now].include?(k) }),
         :waiting_until => waiting_until,
         :status => torrent[:download_now]
     }
+    attributes[:identifiers] = torrent[:identifiers] unless torrent[:identifiers].nil?
     selector = {:name => torrent[:name]}
     if torrent[:in_db] || app.db.get_rows('torrents', selector).first
       app.db.update_rows('torrents', attributes, selector)

--- a/app/torrent_search.rb
+++ b/app/torrent_search.rb
@@ -290,17 +290,18 @@ class TorrentSearch
       app.speaker.speak_up("Adding torrent #{torrent[:name]} on #{torrent[:tracker]} to the torrents to download")
       torrent[:download_now] = 2
     end
-    if torrent[:in_db]
-      app.db.update_rows('torrents', {:status => torrent[:download_now], :waiting_until => waiting_until}, {:name => torrent[:name]})
+    attributes = {
+        :identifier => torrent[:identifier],
+        :identifiers => torrent[:identifiers],
+        :tattributes => Cache.object_pack(torrent.select { |k, _| ![:identifier, :identifiers, :name, :download_now].include?(k) }),
+        :waiting_until => waiting_until,
+        :status => torrent[:download_now]
+    }
+    selector = {:name => torrent[:name]}
+    if torrent[:in_db] || app.db.get_rows('torrents', selector).first
+      app.db.update_rows('torrents', attributes, selector)
     else
-      app.db.insert_row('torrents', {
-          :identifier => torrent[:identifier],
-          :identifiers => torrent[:identifiers],
-          :name => torrent[:name],
-          :tattributes => Cache.object_pack(torrent.select { |k, _| ![:identifier, :identifiers, :name, :download_now].include?(k) }),
-          :waiting_until => waiting_until,
-          :status => torrent[:download_now]
-      })
+      app.db.insert_row('torrents', attributes.merge(:name => torrent[:name]))
     end
     if torrent[:download_now] == 2
       remove_others.each do |tname|

--- a/lib/file_utils.rb
+++ b/lib/file_utils.rb
@@ -241,6 +241,7 @@ module FileUtils
     def search_folder(folder, filter_criteria = {})
       MediaLibrarian.app.speaker.speak_up Utils.arguments_dump(binding) if Env.debug?
       filter_criteria = {} if filter_criteria.nil?
+      return [] unless folder && File.directory?(folder)
       search_folder = []
       Find.find(folder).each do |path|
         path = File.absolute_path(path)

--- a/lib/torznab_tracker.rb
+++ b/lib/torznab_tracker.rb
@@ -24,7 +24,9 @@ class TorznabTracker
       cat = @tracker.caps.categories.select { |c| c.name.downcase.include?('tv') }.map { |c| c.id }
     end
     MediaLibrarian.app.speaker.speak_up "Running search on tracker '#{name}' for query '#{query}' for category '#{type}' (#{cat.join(',')})" if Env.debug?
-    Hash.from_xml(@tracker.get({'t' => t, 'cat' => cat.join(','), 'q' => query, 'limit' => limit}))[:rss][:channel][:item].each do |i|
+    response = Hash.from_xml(@tracker.get({'t' => t, 'cat' => cat.join(','), 'q' => query, 'limit' => limit}))
+    items = Array(response.dig(:rss, :channel, :item))
+    items.each do |i|
       enclosure_url = i.dig(:enclosure, :@url) || i.dig(:enclosure, :url)
       guid = if i[:guid].is_a?(Hash)
         guid_hash = i[:guid]


### PR DESCRIPTION
## Summary
- avoid traversing non-existent search folders before invoking Find
- ensure torznab tracker searches can handle feeds without items
- prevent duplicate torrent inserts by updating existing rows when re-queued

## Testing
- bundle exec rake test *(fails: existing suite errors – NoMethodError in LibrarianCliTest and Zeitwerk loader conflicts)*

------
https://chatgpt.com/codex/tasks/task_e_6907466902e08327afbdb9e10ddb0993