### PR TITLE
Handle duplicate torrent inserts

### DIFF
--- a/app/torrent_search.rb
+++ b/app/torrent_search.rb
@@ -300,7 +300,7 @@ class TorrentSearch
           :tattributes => Cache.object_pack(torrent.select { |k, _| ![:identifier, :identifiers, :name, :download_now].include?(k) }),
           :waiting_until => waiting_until,
           :status => torrent[:download_now]
-      })
+      }, 1)
     end
     if torrent[:download_now] == 2
       remove_others.each do |tname|

--- a/lib/storage/db.rb
+++ b/lib/storage/db.rb
@@ -67,7 +67,14 @@ module Storage
 
     def insert_row(table, values, or_replace = 0)
       dataset = dataset_for(table)
-      dataset = dataset.insert_conflict(:replace) if or_replace.to_i.positive?
+      dataset =
+        if or_replace.is_a?(Hash)
+          dataset.insert_conflict(or_replace)
+        elsif or_replace.to_i.positive?
+          dataset.insert_conflict(:replace)
+        else
+          dataset
+        end
       prepared = prepare_values(table, values)
       sql = dataset.insert_sql(prepared)
       run_write(table, sql) { dataset.insert(prepared) }


### PR DESCRIPTION
## Summary
- ensure torrent inserts use a replace-on-conflict strategy so duplicate names update existing rows

## Testing
- bundle exec rake test *(fails: existing test failures — Zeitwerk loader conflicts and other unrelated issues)*

------
https://chatgpt.com/codex/tasks/task_e_6907582c8c908327b6ea819375422005