### PR TITLE
Handle missing Torznab items in search results

### DIFF
--- a/lib/torznab_tracker.rb
+++ b/lib/torznab_tracker.rb
@@ -24,7 +24,8 @@ class TorznabTracker
       cat = @tracker.caps.categories.select { |c| c.name.downcase.include?('tv') }.map { |c| c.id }
     end
     MediaLibrarian.app.speaker.speak_up "Running search on tracker '#{name}' for query '#{query}' for category '#{type}' (#{cat.join(',')})" if Env.debug?
-    Hash.from_xml(@tracker.get({'t' => t, 'cat' => cat.join(','), 'q' => query, 'limit' => limit}))[:rss][:channel][:item].each do |i|
+    response = Hash.from_xml(@tracker.get({'t' => t, 'cat' => cat.join(','), 'q' => query, 'limit' => limit})) || {}
+    Array(response.dig(:rss, :channel, :item)).each do |i|
       enclosure_url = i.dig(:enclosure, :@url) || i.dig(:enclosure, :url)
       guid = if i[:guid].is_a?(Hash)
         guid_hash = i[:guid]


### PR DESCRIPTION
## Summary
- avoid calling `each` on a nil Torznab search result
- default to an empty array when the response is missing items

## Testing
- bundle exec rake test *(fails: existing suite errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_69075a93e5d8832799c9d92007d1daad