### PR TITLE
Allow lowercase direct command constants

### DIFF
--- a/librarian.rb
+++ b/librarian.rb
@@ -253,7 +253,7 @@ class Librarian
         if direct.to_i > 0
           m = cmd.shift
           a = cmd.shift
-          p = Object.const_get(m).method(a.to_sym)
+          p = resolve_constant(m).method(a.to_sym)
           cmd.nil? ? p.call : p.call(*cmd)
         else
           app.speaker.speak_up(String.new('Running command: '), 0)
@@ -288,6 +288,20 @@ class Librarian
       end
 
       sanitized
+    end
+
+    def resolve_constant(name)
+      Object.const_get(name)
+    rescue NameError => original_error
+      normalized = name.to_s.split('::').map do |part|
+        part.split('_').map { |segment| segment.capitalize }.join
+      end.join('::')
+      begin
+        return Object.const_get(normalized) if normalized != name
+      rescue NameError
+        nil
+      end
+      raise original_error
     end
 
     def notify_missing_command(original_cmd)


### PR DESCRIPTION
## Summary
- normalize direct command constant lookup so lowercase names resolve to their camel-cased classes

## Testing
- bundle exec rake test *(fails: existing suite has 1 failure, 4 errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_690783b641088327a69ef324dad2dd93