### PR TITLE
Fix symbol handling when matching file identifiers

### DIFF
--- a/app/library.rb
+++ b/app/library.rb
@@ -370,7 +370,7 @@ class Library
     app.speaker.speak_up("Adding #{file[:type]} '#{full_name}' (filename '#{File.basename(file[:name])}', ids '#{identifiers}') to list", 0) if Env.debug?
     if file[:type].to_s == 'file'
       Cache.queue_state_get('file_handling').each do |i, fs|
-        if i.to_s != '' && identifiers.join.include?(i) && !fs.empty? && !fs.map { |obj| obj[:name] if obj[:type] == 'file' }.compact.include?(file[:name])
+        if i.to_s != '' && identifiers.join.include?(i.to_s) && !fs.empty? && !fs.map { |obj| obj[:name] if obj[:type] == 'file' }.compact.include?(file[:name])
           Utils.lock_block("file_handling_found_#{i}") do
             ok = false
             fs.uniq.each do |f|


### PR DESCRIPTION
## Summary
- ensure Library.parse_media compares identifier keys as strings when checking pending file handlers

## Testing
- bundle exec rake test *(fails: DaemonQueueConcurrencyTest#test_enqueue_retries_until_executor_accepts_job assertion and Zeitwerk loader conflict in TrackerQueryServiceTest plus other pre-existing errors)*

------
https://chatgpt.com/codex/tasks/task_e_6907a85e9744832793692059ced8dd03