### PR TITLE
Expose daemon runtime metrics to control UI

### DIFF
--- a/app/web/app.css
+++ b/app/web/app.css
@@ -155,6 +155,30 @@ main {
   flex-wrap: wrap;
 }
 
+.panel-title {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.jobs-metrics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.jobs-metrics span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+}
+
 .panel-header h2 {
   margin: 0;
 }

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -71,7 +71,10 @@
         >
           <section class="panel" id="jobs-panel">
             <div class="panel-header">
-              <h2>Jobs</h2>
+              <div class="panel-title">
+                <h2>Jobs</h2>
+                <div id="jobs-metrics" class="jobs-metrics" hidden></div>
+              </div>
               <div class="actions">
                 <button id="stop-daemon" type="button" class="danger">Arrêter</button>
                 <button id="restart-daemon" type="button" class="danger">Redémarrer</button>

--- a/test/librarian_cli_test.rb
+++ b/test/librarian_cli_test.rb
@@ -60,7 +60,14 @@ class LibrarianCliTest < Minitest::Test
       'queued' => [],
       'finished' => [{ 'id' => 'job-1' }],
       'queues' => [{ 'queue' => 'priority', 'running' => 0, 'queued' => 0, 'finished' => 1, 'total' => 1 }],
-      'lock_time' => ''
+      'lock_time' => '',
+      'started_at' => Time.now.utc.iso8601,
+      'uptime_seconds' => 12.5,
+      'resources' => {
+        'cpu_time_seconds' => 1.5,
+        'cpu_percent' => 20.0,
+        'rss_mb' => 42.0
+      }
     }
 
     fake_client = Minitest::Mock.new


### PR DESCRIPTION
## Summary
- capture the daemon boot time and expose uptime, CPU, and RSS data through the `/status` endpoint
- surface the new metrics in the web dashboard jobs header and keep CLI status parsing compatible
- extend status snapshot tests to cover metadata propagation for both local and remote snapshots

## Testing
- bundle exec rake test *(fails: 115 runs, 458 assertions, 1 failures, 6 errors – existing suite issues such as tracker login cookie handling and Zeitwerk conflicts)*

------
https://chatgpt.com/codex/tasks/task_e_6909fbf27f408327a454f44b1bc9b660