### PR TITLE
Handle daemon stop inline

### DIFF
--- a/librarian.rb
+++ b/librarian.rb
@@ -176,10 +176,14 @@ class Librarian
         end
 
         if proxy_internal.to_i.zero? && args.first.to_s.casecmp('daemon').zero?
-          # `daemon status` needs to execute in-process so it can call `Client.status`
-          # and stream the daemon snapshot output directly to the CLI. Other daemon
-          # subcommands should continue to be routed through the running daemon.
-          proxy_internal = 1 if args[1].to_s.casecmp('status').zero?
+          # `daemon status` and `daemon stop` need to execute in-process so they can
+          # call the appropriate `Client` methods directly and stream output to the CLI.
+          # Other daemon subcommands should continue to be routed through the daemon.
+          subcommand = args[1].to_s
+          if %w[status stop].any? { |cmd| subcommand.casecmp(cmd).zero? }
+            proxy_internal = 1
+            direct_flag = 1
+          end
         end
       end
 

--- a/test/support/container_helpers.rb
+++ b/test/support/container_helpers.rb
@@ -198,6 +198,16 @@ module TestSupport
         :dispatched
       end
 
+      def launch(app_name, action, args, *_rest)
+        @dispatched_commands << { app: app_name, command: args.dup, actions: action }
+        constant_name, method_name = action
+
+        return :launched unless constant_name == 'Daemon'
+
+        constant = Object.const_get(constant_name)
+        constant.public_send(method_name, *args)
+      end
+
       def show_available(app_name, actions)
         @shown_actions << { app: app_name, actions: actions }
         :shown


### PR DESCRIPTION
## Summary
- ensure the CLI routes `daemon stop` in-process alongside `daemon status`
- cover the stop command with a test that verifies the client call without enqueueing when the pidfile is present
- teach the args dispatch test stub to launch daemon actions while recording invocations

## Testing
- bundle exec ruby -Itest test/daemon_cli_stop_test.rb
- bundle exec ruby -Itest test/librarian_cli_test.rb

------
https://chatgpt.com/codex/tasks/task_e_690a0855cf2483278f99794adb40410a