### PR TITLE
Defer child notification emails to parent threads

### DIFF
--- a/librarian.rb
+++ b/librarian.rb
@@ -374,9 +374,10 @@ class Librarian
       if thread[:block].is_a?(Array) && !thread[:block].empty?
         thread[:block].reverse_each { |b| b.call rescue nil }
       end
-      Report.sent_out("#{'[DEBUG]' if Env.debug?(thread)}#{object || thread[:object]}", thread) if Env.email_notif?
       if thread[:parent]
         Utils.lock_block("merge_child_thread_#{thread[:object]}") { Daemon.merge_notifications(thread, thread[:parent]) }
+      elsif Env.email_notif?
+        Report.sent_out("#{'[DEBUG]' if Env.debug?(thread)}#{object || thread[:object]}", thread)
       end
       Daemon.clear_waiting_worker(thread, thread_value, object, 1)
     end

--- a/test/librarian_terminate_command_test.rb
+++ b/test/librarian_terminate_command_test.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class LibrarianTerminateCommandTest < Minitest::Test
+  class FakeThread
+    def initialize(data = {})
+      @data = data.transform_keys(&:to_sym)
+    end
+
+    def [](key)
+      @data[key.to_sym]
+    end
+
+    def []=(key, value)
+      @data[key.to_sym] = value
+    end
+  end
+
+  def test_child_threads_defer_email_delivery_to_parent
+    parent = build_thread(object: 'parent job', jid: 'parent-jid')
+    child_one = build_thread(object: 'child-one', parent: parent, jid: 'child-jid-1')
+    child_two = build_thread(object: 'child-two', parent: parent, jid: 'child-jid-2')
+
+    sent_out_calls = []
+    merged_children = []
+
+    Env.stub(:email_notif?, ->(*) { true }) do
+      Daemon.stub(:merge_notifications, ->(child, parent_thread) { merged_children << [child, parent_thread] }) do
+        Report.stub(:sent_out, ->(subject, thread) { sent_out_calls << [subject, thread] }) do
+          Librarian.terminate_command(child_one, 'child-value-1', child_one[:object])
+          Librarian.terminate_command(child_two, 'child-value-2', child_two[:object])
+          Librarian.terminate_command(parent, 'parent-value', parent[:object])
+        end
+      end
+    end
+
+    assert_equal [[child_one, parent], [child_two, parent]], merged_children
+    assert_equal 1, sent_out_calls.size
+    assert_equal parent, sent_out_calls.first.last
+  end
+
+  private
+
+  def build_thread(**attrs)
+    defaults = {
+      base_thread: nil,
+      is_active: 0,
+      direct: 1,
+      block: [],
+      start_time: Time.now,
+      object: 'job',
+      jid: 'jid'
+    }
+
+    FakeThread.new(defaults.merge(attrs))
+  end
+end


### PR DESCRIPTION
## Summary
- guard `Librarian.terminate_command` so only parent threads trigger `Report.sent_out`
- keep child notifications merged into their parent thread before final delivery
- cover the aggregation flow with a test that ensures only one email is sent for a parent with multiple children

## Testing
- bundle exec ruby -Itest test/librarian_terminate_command_test.rb

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69105c39f9e88327a6c26c9b0fc41d27)