### PR TITLE
Make daemon worker queue unbounded

### DIFF
--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -691,12 +691,10 @@ class Daemon
       @queue_limits = Concurrent::Hash.new
       @jobs = Concurrent::Hash.new
       @job_children = Concurrent::Hash.new { |h, k| h[k] = Concurrent::Array.new }
-      queue_slots = app.queue_slots.to_i
-      queue_capacity = queue_slots.positive? ? queue_slots : nil
+      # Retain queue_slots for configuration compatibility; the queue is now unbounded.
       @executor = Concurrent::ThreadPoolExecutor.new(
         min_threads: 1,
         max_threads: [app.workers_pool_size.to_i, 1].max,
-        max_queue: queue_capacity,
         fallback_policy: :abort
       )
     end

--- a/config/conf.yml.example
+++ b/config/conf.yml.example
@@ -2,7 +2,7 @@
 preferred_languages: fr en
 daemon:
   workers_pool_size: 4
-  queue_slots: 4
+  queue_slots: 4 # Deprecated; the worker queue is unbounded.
 deluge:
   host: host
   username: username

--- a/lib/media_librarian/container.rb
+++ b/lib/media_librarian/container.rb
@@ -109,7 +109,7 @@ module MediaLibrarian
 
       daemon_config = config.fetch('daemon', {}) || {}
       store(:workers_pool_size, daemon_config['workers_pool_size'] || 4, freeze: true)
-      store(:queue_slots, daemon_config['queue_slots'] || 4, freeze: true)
+      store(:queue_slots, daemon_config['queue_slots'] || 4, freeze: true) # retained for backwards compatibility
 
       store(:trackers, build_trackers)
 
@@ -140,7 +140,7 @@ module MediaLibrarian
 
       daemon_config = config.fetch('daemon', {}) || {}
       store(:workers_pool_size, daemon_config['workers_pool_size'] || 4, freeze: true)
-      store(:queue_slots, daemon_config['queue_slots'] || 4, freeze: true)
+      store(:queue_slots, daemon_config['queue_slots'] || 4, freeze: true) # retained for backwards compatibility
     end
 
     def build_trackers


### PR DESCRIPTION
## Summary
- create the daemon thread pool without a bounded queue while retaining queue_slots for compatibility
- document the deprecation of queue_slots in configuration helpers
- update integration coverage to expect successful enqueues and prove the queue remains unbounded

## Testing
- bundle exec ruby -Itest test/daemon_integration_test.rb

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691196bf6b748327bd5f3eac7ec4efd9)