### PR TITLE
Fully revert PR 197 changes

### DIFF
--- a/app/report.rb
+++ b/app/report.rb
@@ -35,15 +35,12 @@ class Report
   end
 
   def self.sent_out(email_subject, t = Thread.current, content = '')
-    thread_context = t || Thread.current
-    email_content = content.to_s.empty? ? thread_context[:email_msg].to_s : content.to_s
-    send_email_flag = content.to_s.empty? ? thread_context[:send_email].to_i : 1
-
-    return if app.email.nil? || email_content.empty? || send_email_flag <= 0
-
-    Librarian.route_cmd(['Report', 'push_email', email_subject, email_content], 1, 'email', 1, 'priority')
-    Librarian.reset_notifications(t) if t
-    Thread.current[:parent] = nil
+    email_content = content.to_s.empty? ? (t || Thread.current)[:email_msg].to_s : content.to_s
+    if app.email && !email_content.empty? && (t.nil? || t[:send_email].to_i > 0)
+      Librarian.route_cmd(['Report', 'push_email', email_subject, email_content], 1, 'email', 1, 'priority')
+      Librarian.reset_notifications(t) if t
+      Thread.current[:parent] = nil
+    end
   end
 
   private

--- a/test/app/report_test.rb
+++ b/test/app/report_test.rb
@@ -47,36 +47,6 @@ class ReportTest < Minitest::Test
     end
   end
 
-  def test_sent_out_delivers_when_send_flag_is_enabled
-    thread = Thread.current
-    thread[:email_msg] = "Scheduled results"
-    thread[:send_email] = 1
-
-    Librarian.new(container: @environment.container, args: [])
-
-    assert_sends_email(subject: 'Scheduled task', body: thread[:email_msg]) do
-      Report.sent_out('Scheduled task', thread)
-    end
-  ensure
-    thread[:email_msg] = nil
-    thread[:send_email] = nil
-  end
-
-  def test_sent_out_skips_when_send_flag_is_disabled
-    thread = Thread.current
-    thread[:email_msg] = "Healthy torrent check"
-    thread[:send_email] = 0
-
-    Librarian.new(container: @environment.container, args: [])
-
-    assert_no_email_delivered do
-      Report.sent_out('Scheduled task', thread)
-    end
-  ensure
-    thread[:email_msg] = nil
-    thread[:send_email] = nil
-  end
-
   private
 
   def assert_sends_email(subject:, body:)
@@ -89,12 +59,5 @@ class ReportTest < Minitest::Test
     expected_subject = Report.formatted_subject(subject)
     assert_equal expected_subject, mail.subject
     assert_includes mail.text_part.body.decoded, body
-  end
-
-  def assert_no_email_delivered
-    yield
-
-    deliveries = Mail::TestMailer.deliveries
-    assert_equal 0, deliveries.size, 'Expected no email to be delivered'
   end
 end


### PR DESCRIPTION
## Summary
- remove the additional Report.sent_out regression tests added in PR 197 to restore the previous baseline

## Testing
- bundle exec ruby -Itest test/app/report_test.rb

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b3f356bbc8327a43cd5aa0151c94b)