### PR TITLE
Add calendar feed service for upcoming releases

### DIFF
--- a/app/calendar_feed.rb
+++ b/app/calendar_feed.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'date'
+
+class CalendarFeed
+  include MediaLibrarian::AppContainerSupport
+
+  def self.refresh_feed(days: MediaLibrarian::Services::CalendarFeedService::DEFAULT_WINDOW_DAYS, limit: 100, sources: nil)
+    window = days.to_i
+    date_range = Date.today..(Date.today + window)
+    calendar_service.refresh(date_range: date_range, limit: limit.to_i, sources: normalize_sources(sources))
+  end
+
+  def self.calendar_service
+    @calendar_service ||= MediaLibrarian::Services::CalendarFeedService.new(app: app)
+  end
+
+  def self.normalize_sources(value)
+    return nil if value.nil?
+
+    Array(value).flat_map { |src| src.to_s.split(',') }
+                .map { |src| src.strip.downcase }
+                .reject(&:empty?)
+  end
+end

--- a/app/media_librarian/services/calendar_feed_service.rb
+++ b/app/media_librarian/services/calendar_feed_service.rb
@@ -1,0 +1,253 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'net/http'
+require 'uri'
+require 'date'
+
+module MediaLibrarian
+  module Services
+    class CalendarFeedService < BaseService
+      DEFAULT_WINDOW_DAYS = 30
+
+      def initialize(app: self.class.app, speaker: nil, file_system: nil, db: nil, providers: nil)
+        super(app: app, speaker: speaker, file_system: file_system)
+        @db = db || app&.db
+        @providers = providers || default_providers
+      end
+
+      def refresh(date_range: default_date_range, limit: 100, sources: nil)
+        return [] unless calendar_table_available?
+
+        normalized = collect_entries(date_range, limit, normalize_sources(sources))
+        persist_entries(normalized)
+        normalized
+      end
+
+      private
+
+      attr_reader :db, :providers
+
+      def calendar_table_available?
+        db && db.table_exists?(:calendar_entries)
+      end
+
+      def collect_entries(date_range, limit, sources)
+        active_providers = select_providers(sources)
+        return [] if active_providers.empty?
+
+        active_providers.flat_map { |provider| safe_fetch(provider, date_range, limit) }
+                        .map { |entry| normalize_entry(entry, date_range) }
+                        .compact
+                        .uniq { |entry| [entry[:source], entry[:external_id]] }
+                        .first(limit)
+      end
+
+      def default_date_range
+        today = Date.today
+        today..(today + DEFAULT_WINDOW_DAYS)
+      end
+
+      def normalize_entry(entry, date_range)
+        return unless entry.is_a?(Hash)
+
+        release_date = parse_date(entry[:release_date])
+        return unless release_date && date_range.cover?(release_date)
+
+        source = entry[:source].to_s.strip
+        external_id = entry[:external_id].to_s.strip
+        title = entry[:title].to_s.strip
+        media_type = entry[:media_type].to_s.strip
+        return if source.empty? || external_id.empty? || title.empty? || media_type.empty?
+
+        {
+          source: source,
+          external_id: external_id,
+          title: title,
+          media_type: media_type,
+          genres: Array(entry[:genres]).compact.map(&:to_s),
+          languages: Array(entry[:languages]).compact.map(&:to_s),
+          countries: Array(entry[:countries]).compact.map(&:to_s),
+          rating: entry[:rating] ? entry[:rating].to_f : nil,
+          release_date: release_date
+        }
+      end
+
+      def normalize_sources(value)
+        return nil if value.nil?
+
+        Array(value).flat_map { |src| src.to_s.split(',') }
+                    .map { |src| src.strip.downcase }
+                    .reject(&:empty?)
+      end
+
+      def parse_date(value)
+        case value
+        when Date
+          value
+        when Time, DateTime
+          value.to_date
+        else
+          Date.parse(value.to_s)
+        end
+      rescue ArgumentError
+        nil
+      end
+
+      def persist_entries(entries)
+        return [] if entries.empty?
+
+        db.insert_rows(:calendar_entries, entries, true)
+        entries
+      end
+
+      def safe_fetch(provider, date_range, limit)
+        provider.upcoming(date_range: date_range, limit: limit)
+      rescue StandardError => e
+        speaker.tell_error(e, "Calendar provider failure: #{provider.class.name}") if speaker
+        []
+      end
+
+      def select_providers(sources)
+        return providers if sources.nil? || sources.empty?
+
+        providers.select do |provider|
+          sources.include?(provider.source)
+        end
+      end
+
+      def default_providers
+        return [] unless app&.config
+
+        providers = []
+        tmdb_config = app.config['tmdb']
+        if tmdb_config.is_a?(Hash)
+          providers << TmdbCalendarProvider.new(
+            api_key: tmdb_config['api_key'],
+            language: tmdb_config['language'] || tmdb_config['languages'],
+            region: tmdb_config['region'],
+            speaker: speaker
+          )
+        end
+        providers.compact.select(&:available?)
+      end
+
+      class TmdbCalendarProvider
+        API_HOST = 'api.themoviedb.org'
+
+        attr_reader :source
+
+        def initialize(api_key:, language: 'en', region: 'US', speaker: nil)
+          @api_key = api_key.to_s
+          @language = language.to_s.empty? ? 'en' : language.to_s
+          @region = region.to_s.empty? ? 'US' : region.to_s
+          @speaker = speaker
+          @source = 'tmdb'
+        end
+
+        def available?
+          !@api_key.empty? && @api_key != 'api_key'
+        end
+
+        def upcoming(date_range:, limit: 100)
+          return [] unless available?
+
+          movies = fetch_collection('/3/movie/upcoming', date_range, limit, :movie)
+          shows = fetch_collection('/3/tv/on_the_air', date_range, limit, :tv)
+          (movies + shows).first(limit)
+        end
+
+        private
+
+        attr_reader :language, :region
+
+        def fetch_collection(path, date_range, limit, kind)
+          page = 1
+          results = []
+          loop do
+            payload = get_json(path, page: page)
+            break unless payload.is_a?(Hash) && payload['results'].is_a?(Array)
+
+            payload['results'].each do |item|
+              release_date = release_from(item, kind)
+              next unless release_date && date_range.cover?(release_date)
+
+              details = fetch_details(kind, item['id'])
+              next unless details
+
+              results << build_entry(details, kind, release_date)
+              return results if results.length >= limit
+            end
+
+            page += 1
+            break if page > payload.fetch('total_pages', 1).to_i
+          end
+          results
+        end
+
+        def release_from(item, kind)
+          parse_date(kind == :movie ? item['release_date'] : item['first_air_date'])
+        end
+
+        def fetch_details(kind, id)
+          path = kind == :movie ? "/3/movie/#{id}" : "/3/tv/#{id}"
+          get_json(path)
+        end
+
+        def build_entry(details, kind, release_date)
+          {
+            source: source,
+            external_id: "#{kind}-#{details['id']}",
+            title: (kind == :movie ? details['title'] : details['name']) ||
+                   details['original_title'] || details['original_name'] || '',
+            media_type: kind == :movie ? 'movie' : 'show',
+            genres: Array(details['genres']).filter_map { |genre| genre['name'] },
+            languages: extract_languages(details),
+            countries: extract_countries(details),
+            rating: details['vote_average'],
+            release_date: release_date
+          }
+        end
+
+        def extract_languages(details)
+          spoken = Array(details['spoken_languages']).filter_map { |lang| lang['english_name'] || lang['name'] }
+          codes = Array(details['languages']).map(&:to_s)
+          languages = spoken.empty? ? codes : spoken
+          languages.empty? && details['original_language'] ? [details['original_language']] : languages
+        end
+
+        def extract_countries(details)
+          prod = Array(details['production_countries']).filter_map { |country| country['name'] || country['iso_3166_1'] }
+          origins = Array(details['origin_country']).map(&:to_s)
+          prod.empty? ? origins : prod
+        end
+
+        def get_json(path, **query)
+          uri = URI::HTTPS.build(host: API_HOST, path: path, query: build_query(query))
+          response = Net::HTTP.get_response(uri)
+          return unless response.is_a?(Net::HTTPSuccess)
+
+          JSON.parse(response.body)
+        rescue StandardError => e
+          @speaker&.tell_error(e, "Calendar TMDB fetch failed for #{uri}") if defined?(uri)
+          nil
+        end
+
+        def build_query(query)
+          params = { api_key: @api_key, language: language }
+          params[:region] = region unless region.to_s.empty?
+          params.merge!(query.compact)
+          URI.encode_www_form(params)
+        end
+
+        def parse_date(value)
+          return nil if value.to_s.strip.empty?
+
+          Date.parse(value.to_s)
+        rescue ArgumentError
+          nil
+        end
+      end
+    end
+  end
+end

--- a/config/templates/scheduler.yml.example
+++ b/config/templates/scheduler.yml.example
@@ -4,6 +4,12 @@ periodic:
     execution: 3600
     every: 1 minutes
     args:
+  calendar_feed_refresh:
+    command: calendar.refresh_feed
+    every: 12 hours
+    args:
+      days: 45
+      limit: 200
 continuous:
   task1:
     command: library.fetch_media_box

--- a/lib/db/migrations/002_add_calendar_entries.rb
+++ b/lib/db/migrations/002_add_calendar_entries.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    create_table?(:calendar_entries) do
+      primary_key :id
+      String :source, size: 50, null: false
+      String :external_id, size: 200, null: false
+      String :title, size: 500, null: false
+      String :media_type, size: 50, null: false
+      Text :genres
+      Text :languages
+      Text :countries
+      Float :rating
+      Date :release_date
+      DateTime :created_at
+      DateTime :updated_at
+
+      index %i[source external_id], unique: true, name: :idx_calendar_entries_unique
+      index :release_date, name: :idx_calendar_entries_release_date
+    end
+  end
+end

--- a/lib/media_librarian/command_registry.rb
+++ b/lib/media_librarian/command_registry.rb
@@ -43,6 +43,9 @@ module MediaLibrarian
         tracker: {
           login: ['TrackerTools', 'login']
         },
+        calendar: {
+          refresh_feed: ['CalendarFeed', 'refresh_feed']
+        },
         usage: ['Librarian', 'help'],
         list_db: ['Utils', 'list_db'],
         flush_queues: ['TorrentClient', 'flush_queues', 1, 'torrenting'],

--- a/test/services/calendar_feed_service_test.rb
+++ b/test/services/calendar_feed_service_test.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'tmpdir'
+require 'date'
+
+require_relative 'service_test_helper'
+require_relative '../../app/media_librarian/services/base_service'
+require_relative '../../app/media_librarian/services/calendar_feed_service'
+require_relative '../../lib/storage/db'
+
+class CalendarFeedServiceTest < Minitest::Test
+  class FakeProvider
+    attr_reader :calls
+
+    def initialize(entries)
+      @entries = entries
+      @calls = []
+    end
+
+    def upcoming(date_range:, limit:)
+      @calls << { range: date_range, limit: limit }
+      @entries
+    end
+
+    def source
+      'fake'
+    end
+  end
+
+  def setup
+    @tmp_dir = Dir.mktmpdir('calendar-feed')
+    @db_path = File.join(@tmp_dir, 'librarian.db')
+    @db = Storage::Db.new(@db_path)
+    @speaker = TestSupport::Fakes::Speaker.new
+  end
+
+  def teardown
+    FileUtils.remove_entry(@tmp_dir) if @tmp_dir && Dir.exist?(@tmp_dir)
+  end
+
+  def test_refresh_persists_entries
+    provider = FakeProvider.new([
+      base_entry.merge(external_id: 'movie-1', title: 'Test Movie', genres: ['Drama']),
+      base_entry.merge(
+        external_id: 'show-2',
+        title: 'Test Show',
+        media_type: 'show',
+        genres: ['Sci-Fi'],
+        languages: ['en', 'fr'],
+        release_date: Date.today + 2
+      )
+    ])
+
+    service = MediaLibrarian::Services::CalendarFeedService.new(app: nil, speaker: @speaker, db: @db, providers: [provider])
+
+    service.refresh(date_range: Date.today..(Date.today + 5), limit: 10)
+
+    rows = @db.get_rows(:calendar_entries).sort_by { |row| row[:external_id] }
+    assert_equal 2, rows.count
+    assert_equal ['Drama'], rows.first[:genres]
+    assert_equal 'movie', rows.first[:media_type]
+    assert_equal 'Test Show', rows.last[:title]
+    assert_equal %w[en fr], rows.last[:languages]
+  end
+
+  def test_refresh_replaces_duplicates
+    initial_provider = FakeProvider.new([
+      base_entry.merge(external_id: 'movie-1', title: 'First Title', rating: 6.4)
+    ])
+    service = MediaLibrarian::Services::CalendarFeedService.new(app: nil, speaker: @speaker, db: @db, providers: [initial_provider])
+    service.refresh(date_range: Date.today..(Date.today + 3), limit: 5)
+
+    updated_provider = FakeProvider.new([
+      base_entry.merge(external_id: 'movie-1', title: 'First Title', rating: 8.2, languages: ['fr'])
+    ])
+    service = MediaLibrarian::Services::CalendarFeedService.new(app: nil, speaker: @speaker, db: @db, providers: [updated_provider])
+    service.refresh(date_range: Date.today..(Date.today + 3), limit: 5)
+
+    rows = @db.get_rows(:calendar_entries, { source: 'fake', external_id: 'movie-1' })
+    assert_equal 1, rows.count
+    assert_in_delta 8.2, rows.first[:rating]
+    assert_equal ['fr'], rows.first[:languages]
+  end
+
+  private
+
+  def base_entry
+    {
+      source: 'fake',
+      external_id: 'base-id',
+      title: 'Base',
+      media_type: 'movie',
+      genres: [],
+      languages: ['en'],
+      countries: ['US'],
+      rating: 7.1,
+      release_date: Date.today + 1
+    }
+  end
+end


### PR DESCRIPTION
## Summary
- add a calendar feed service that normalizes upcoming release metadata and stores it in the new calendar_entries table
- expose a calendar.refresh_feed command with a scheduler template example for periodic refreshes
- cover the new calendar pipeline with service-level tests and database migration

## Testing
- bundle exec ruby -Itest test/services/calendar_feed_service_test.rb

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c3bd52cc88327a7e567a56505c14d)