### PR TITLE
Add watchlist storage and download list support

### DIFF
--- a/app/library.rb
+++ b/app/library.rb
@@ -421,7 +421,7 @@ class Library
             :move_completed => (destination[category] || File.dirname(DEFAULT_MEDIA_DESTINATION[category])) }
         )
       end
-    when 'filesystem', 'trakt', 'lists'
+    when 'filesystem', 'trakt', 'lists', 'download_list'
       existing_files, search_list = get_search_list(source_type, category, source, no_prompt)
       search_list.keys.each do |id|
         app.speaker.speak_up(id) #REMOVEME

--- a/config/templates/search_from_torrents.yml.example
+++ b/config/templates/search_from_torrents.yml.example
@@ -42,6 +42,10 @@ filter_sources:
     existing_folder:
       movies: '/folder/of/movies'
       shows: '/folder/of/tvseries'
+  download_list:
+    existing_folder:
+      movies: '/folder/of/movies'
+      shows: '/folder/of/tvseries'
 category: shows
 search_category: optional_can_be_one_of_movies_shows
 no_prompt: 0

--- a/lib/db/migrations/002_create_watchlist.rb
+++ b/lib/db/migrations/002_create_watchlist.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    create_table?(:watchlist) do
+      Text :external_id, null: false
+      Text :type, null: false
+      Text :title, null: false
+      Text :metadata
+      DateTime :created_at
+      DateTime :updated_at
+
+      index [:external_id, :type], unique: true, name: :idx_watchlist_external_type
+    end
+  end
+end

--- a/lib/watchlist_store.rb
+++ b/lib/watchlist_store.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module WatchlistStore
+  module_function
+
+  def upsert(entries)
+    rows = normalize_entries(entries)
+    rows.each { |row| MediaLibrarian.app.db.insert_row('watchlist', row, 1) }
+    rows.length
+  rescue StandardError => e
+    MediaLibrarian.app.speaker.tell_error(e, 'WatchlistStore.upsert') rescue nil
+    0
+  end
+
+  def fetch(type: nil)
+    conditions = {}
+    conditions[:type] = type if type && !type.to_s.empty?
+    MediaLibrarian.app.db.get_rows('watchlist', conditions)
+  rescue StandardError => e
+    MediaLibrarian.app.speaker.tell_error(e, 'WatchlistStore.fetch') rescue nil
+    []
+  end
+
+  def normalize_entries(entries)
+    Array(entries).filter_map do |entry|
+      next unless entry
+
+      external_id = entry[:external_id] || entry['external_id']
+      title = entry[:title] || entry['title']
+      type = entry[:type] || entry['type'] || 'movies'
+      next if external_id.to_s.empty? || title.to_s.empty?
+
+      metadata = entry[:metadata] || entry['metadata'] || {}
+      metadata = {} unless metadata.is_a?(Hash)
+
+      {
+        external_id: external_id.to_s,
+        type: type.to_s,
+        title: title.to_s,
+        metadata: metadata,
+        updated_at: Time.now.utc
+      }
+    end
+  end
+  private_class_method :normalize_entries
+end

--- a/test/services/list_management_service_test.rb
+++ b/test/services/list_management_service_test.rb
@@ -1,9 +1,17 @@
 # frozen_string_literal: true
 
+require 'ostruct'
+require 'tmpdir'
+
 require_relative 'service_test_helper'
 require_relative '../../app/media_librarian/services'
 require_relative '../../app/media_librarian/services/base_service'
 require_relative '../../app/media_librarian/services/list_management_service'
+require_relative '../../lib/media_librarian/application'
+require_relative '../../app/library'
+require_relative '../../lib/metadata'
+require_relative '../../lib/watchlist_store'
+require_relative '../../lib/storage/db'
 
 class ListManagementServiceTest < Minitest::Test
   def setup
@@ -48,6 +56,46 @@ class ListManagementServiceTest < Minitest::Test
 
       assert_equal(['/media/movies/file.mkv'], files[cache_name])
       assert_equal({ 'file.mkv' => { size: 123 } }, list)
+    end
+  end
+
+  def test_download_list_source_reads_watchlist_store_and_flags_calendar
+    Dir.mktmpdir('watchlist-test') do |dir|
+      db_path = File.join(dir, 'librarian.db')
+      db = Storage::Db.new(db_path)
+      app = OpenStruct.new(db: db, speaker: @speaker)
+      previous_app = MediaLibrarian.instance_variable_get(:@application)
+      MediaLibrarian.instance_variable_set(:@application, app)
+
+      WatchlistStore.upsert([
+        {
+          external_id: 'tmdb-42',
+          type: 'movies',
+          title: 'Sample',
+          metadata: { year: 2024, ids: { 'tmdb' => '42' }, calendar_entries: [{ external_id: 'tmdb-42' }] }
+        }
+      ])
+
+      request = MediaLibrarian::Services::SearchListRequest.new(
+        source_type: 'download_list',
+        category: 'movies',
+        source: { 'existing_folder' => { 'movies' => '/media/movies' } }
+      )
+
+      parsed_media = { 'tmdb-42' => { already_followed: 1 } }
+      Library.stub(:parse_media, parsed_media) do
+        existing = { 'tmdb-42' => { identifier: 'tmdb-42' } }
+        Library.stub(:process_folder, existing) do
+          files, search_list = @service.get_search_list(request)
+
+          assert_equal existing, files['movies']
+          assert_equal parsed_media['tmdb-42'], search_list['tmdb-42']
+          assert_equal true, search_list[:calendar_entries].first[:downloaded]
+          assert_equal 'tmdb-42', search_list[:calendar_entries].first[:external_id]
+        end
+      end
+    ensure
+      MediaLibrarian.instance_variable_set(:@application, previous_app)
     end
   end
 end


### PR DESCRIPTION
## Summary
- add a persistent watchlist table and helper for storing interest list entries
- hook the new download_list filter source to the watchlist data and flag tracked/downloaded calendar entries
- document the source in the torrent search template and cover it with a service test

## Testing
- bundle exec ruby -Itest test/services/list_management_service_test.rb

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c3bda775c8327a50f08c9b9270ea2)