### PR TITLE
Add calendar dashboard tab with filters and watchlist action

### DIFF
--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -1006,6 +1006,12 @@ class Daemon
         )
       end
 
+      @control_server.mount_proc('/calendar') do |req, res|
+        next unless require_authorization(req, res)
+
+        handle_calendar_request(req, res)
+      end
+
       @control_server.mount_proc('/stop') do |req, res|
         next unless require_authorization(req, res)
 
@@ -1144,6 +1150,12 @@ class Daemon
       end
 
       json_response(res, body: { 'logs' => logs })
+    end
+
+    def handle_calendar_request(req, res)
+      return method_not_allowed(res, 'GET') unless req.request_method == 'GET'
+
+      json_response(res, body: { 'calendar' => [] })
     end
 
     def handle_config_request(req, res)

--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -1006,12 +1006,6 @@ class Daemon
         )
       end
 
-      @control_server.mount_proc('/calendar') do |req, res|
-        next unless require_authorization(req, res)
-
-        handle_calendar_request(req, res)
-      end
-
       @control_server.mount_proc('/stop') do |req, res|
         next unless require_authorization(req, res)
 
@@ -1150,12 +1144,6 @@ class Daemon
       end
 
       json_response(res, body: { 'logs' => logs })
-    end
-
-    def handle_calendar_request(req, res)
-      return method_not_allowed(res, 'GET') unless req.request_method == 'GET'
-
-      json_response(res, body: { 'calendar' => [] })
     end
 
     def handle_config_request(req, res)

--- a/app/web/app.css
+++ b/app/web/app.css
@@ -414,3 +414,132 @@ button:disabled {
   opacity: 0.6;
   cursor: not-allowed;
 }
+
+.calendar-actions {
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.calendar-actions select {
+  padding: 0.4rem 0.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(15, 23, 42, 0.65);
+  color: inherit;
+}
+
+.calendar-filters {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.75rem;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.calendar-filters label {
+  font-weight: 600;
+}
+
+.calendar-filters select,
+.calendar-filters input {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(15, 23, 42, 0.6);
+  color: inherit;
+}
+
+.calendar-filters select[multiple] {
+  min-height: 4.5rem;
+}
+
+.calendar-range {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.calendar-content {
+  display: grid;
+  gap: 1rem;
+}
+
+.calendar-group {
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 1rem;
+  padding: 1rem;
+  background: rgba(15, 23, 42, 0.6);
+}
+
+.calendar-group h3 {
+  margin: 0 0 0.5rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: #e5e7eb;
+}
+
+.calendar-items {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 0.75rem;
+}
+
+.calendar-item {
+  padding: 0.75rem 1rem;
+  border-radius: 0.85rem;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  display: grid;
+  gap: 0.35rem;
+}
+
+.calendar-item header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.calendar-item h4 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.calendar-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.calendar-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.25rem 0.55rem;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.2);
+  border: 1px solid rgba(37, 99, 235, 0.35);
+  color: #e0ecff;
+  font-size: 0.85rem;
+}
+
+.calendar-meta {
+  color: var(--muted);
+  font-size: 0.9rem;
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.calendar-actions-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.calendar-actions-row button {
+  margin-left: auto;
+}

--- a/app/web/app.js
+++ b/app/web/app.js
@@ -1038,8 +1038,10 @@ function readCalendarFilters() {
         .filter(Boolean)
     : [];
 
-  const ratingMin = Number(document.getElementById('calendar-rating-min')?.value);
-  const ratingMax = Number(document.getElementById('calendar-rating-max')?.value);
+  const ratingMinRaw = document.getElementById('calendar-rating-min')?.value || '';
+  const ratingMaxRaw = document.getElementById('calendar-rating-max')?.value || '';
+  const ratingMin = ratingMinRaw === '' ? '' : Number(ratingMinRaw);
+  const ratingMax = ratingMaxRaw === '' ? '' : Number(ratingMaxRaw);
   filters.ratingMin = Number.isFinite(ratingMin) ? ratingMin : '';
   filters.ratingMax = Number.isFinite(ratingMax) ? ratingMax : '';
 

--- a/app/web/app.js
+++ b/app/web/app.js
@@ -10,6 +10,17 @@ const state = {
     trackers: false,
   },
   isRefreshing: false,
+  calendar: {
+    view: 'week',
+    filters: {
+      type: '',
+      genres: [],
+      ratingMin: '',
+      ratingMax: '',
+      language: '',
+      country: '',
+    },
+  },
 };
 
 const fileEditors = new Map();
@@ -937,6 +948,377 @@ function renderLogs(logs = {}) {
   });
 }
 
+function pickEntryValue(entry, keys) {
+  if (!entry || typeof entry !== 'object') {
+    return null;
+  }
+  return keys.map((key) => entry[key]).find((value) => value !== undefined && value !== null) ?? null;
+}
+
+function normalizeCalendarEntries(data = {}) {
+  if (Array.isArray(data)) {
+    return data;
+  }
+  const candidates = [data.entries, data.items, data.results, data.calendar];
+  const entries = candidates.find(Array.isArray);
+  return Array.isArray(entries) ? entries : [];
+}
+
+function extractGenres(entry) {
+  const raw = pickEntryValue(entry, ['genres', 'genre', 'tags', 'categories']);
+  if (!raw) {
+    return [];
+  }
+  const normalized = Array.isArray(raw) ? raw : String(raw).split(/[,;]/);
+  return normalized
+    .map((value) => String(value || '').trim())
+    .filter(Boolean)
+    .map((value) => value.toLowerCase())
+    .filter(Boolean);
+}
+
+function resolveCalendarDate(entry) {
+  const raw = pickEntryValue(entry, [
+    'date',
+    'release_date',
+    'air_date',
+    'airing_at',
+    'first_aired',
+    'on',
+  ]);
+  if (!raw) {
+    return null;
+  }
+  const date = new Date(raw);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function updateCalendarGenres(entries) {
+  const select = document.getElementById('calendar-genres');
+  if (!select) {
+    return;
+  }
+  const previous = new Set(state.calendar.filters.genres);
+  const available = new Set();
+  entries.forEach((entry) => {
+    extractGenres(entry).forEach((genre) => available.add(genre));
+  });
+  if (!available.size) {
+    if (!select.options.length) {
+      const option = document.createElement('option');
+      option.disabled = true;
+      option.value = '';
+      option.textContent = 'Aucun genre détecté';
+      select.appendChild(option);
+    }
+    return;
+  }
+  select.innerHTML = '';
+  Array.from(available)
+    .sort((a, b) => a.localeCompare(b))
+    .forEach((genre) => {
+      const option = document.createElement('option');
+      option.value = genre;
+      option.textContent = genre;
+      option.selected = previous.has(genre);
+      select.appendChild(option);
+    });
+}
+
+function readCalendarFilters() {
+  const filters = state.calendar.filters;
+  const viewSelect = document.getElementById('calendar-view');
+  state.calendar.view = viewSelect?.value || 'week';
+
+  filters.type = (document.getElementById('calendar-type')?.value || '').toLowerCase();
+  const genreSelect = document.getElementById('calendar-genres');
+  filters.genres = genreSelect
+    ? Array.from(genreSelect.selectedOptions)
+        .map((option) => option.value)
+        .filter(Boolean)
+    : [];
+
+  const ratingMin = Number(document.getElementById('calendar-rating-min')?.value);
+  const ratingMax = Number(document.getElementById('calendar-rating-max')?.value);
+  filters.ratingMin = Number.isFinite(ratingMin) ? ratingMin : '';
+  filters.ratingMax = Number.isFinite(ratingMax) ? ratingMax : '';
+
+  filters.language = (document.getElementById('calendar-language')?.value || '').trim();
+  filters.country = (document.getElementById('calendar-country')?.value || '').trim();
+  return filters;
+}
+
+function entryMatchesFilters(entry, filters) {
+  const type = (pickEntryValue(entry, ['type', 'kind', 'category']) || '').toString().toLowerCase();
+  if (filters.type && filters.type !== type) {
+    return false;
+  }
+
+  if (filters.genres.length) {
+    const genres = extractGenres(entry);
+    const matches = filters.genres.some((genre) => genres.includes(genre));
+    if (!matches) {
+      return false;
+    }
+  }
+
+  const rating = Number(pickEntryValue(entry, ['imdb_rating', 'rating', 'score']));
+  if (filters.ratingMin !== '' && !Number.isFinite(rating)) {
+    return false;
+  }
+  if (filters.ratingMin !== '' && rating < filters.ratingMin) {
+    return false;
+  }
+  if (filters.ratingMax !== '' && !Number.isFinite(rating)) {
+    return false;
+  }
+  if (filters.ratingMax !== '' && rating > filters.ratingMax) {
+    return false;
+  }
+
+  const language = (pickEntryValue(entry, ['language', 'lang', 'original_language']) || '').toString().toLowerCase();
+  if (filters.language && !language.includes(filters.language.toLowerCase())) {
+    return false;
+  }
+
+  const countryRaw = pickEntryValue(entry, ['country', 'origin_country', 'production_country']);
+  const countries = Array.isArray(countryRaw)
+    ? countryRaw.map((value) => String(value || '').toLowerCase())
+    : String(countryRaw || '').toLowerCase();
+  if (filters.country && !countries.toString().includes(filters.country.toLowerCase())) {
+    return false;
+  }
+
+  return true;
+}
+
+function buildCalendarGroups(entries, view) {
+  const groups = new Map();
+  const startOfWeek = (date) => {
+    const copy = new Date(date);
+    const weekday = (copy.getDay() + 6) % 7;
+    copy.setHours(0, 0, 0, 0);
+    copy.setDate(copy.getDate() - weekday);
+    return copy;
+  };
+
+  entries.forEach((entry) => {
+    const date = resolveCalendarDate(entry);
+    const key = date
+      ? view === 'month'
+        ? `${date.getFullYear()}-${date.getMonth()}`
+        : startOfWeek(date).toISOString()
+      : 'no-date';
+    if (!groups.has(key)) {
+      const label = (() => {
+        if (!date) return 'Sans date';
+        if (view === 'month') {
+          return new Intl.DateTimeFormat('fr-FR', { month: 'long', year: 'numeric' }).format(date);
+        }
+        const start = startOfWeek(date);
+        const end = new Date(start);
+        end.setDate(start.getDate() + 6);
+        const format = (value) =>
+          new Intl.DateTimeFormat('fr-FR', { day: 'numeric', month: 'short' }).format(value);
+        return `Semaine du ${format(start)} au ${format(end)}`;
+      })();
+      groups.set(key, { label, sortKey: date ? date.getTime() : Number.POSITIVE_INFINITY, items: [] });
+    }
+    groups.get(key).items.push({ entry, date });
+  });
+
+  return Array.from(groups.values()).sort((a, b) => a.sortKey - b.sortKey);
+}
+
+function makeCalendarBadge(text) {
+  const span = document.createElement('span');
+  span.className = 'calendar-badge';
+  span.textContent = text;
+  return span;
+}
+
+function resolveIdentifier(entry) {
+  return (
+    pickEntryValue(entry, ['id', 'slug', 'imdb_id', 'tmdb_id', 'tvdb_id'])
+      || pickEntryValue(entry, ['title', 'name'])
+  );
+}
+
+function isDownloaded(entry) {
+  const flag = pickEntryValue(entry, ['downloaded', 'is_downloaded', 'download_status', 'status']);
+  if (typeof flag === 'string') {
+    return flag.toLowerCase().includes('download');
+  }
+  return Boolean(flag);
+}
+
+function isInWatchlist(entry) {
+  const flag = pickEntryValue(entry, ['in_watchlist', 'watchlist', 'on_watchlist', 'listed']);
+  if (typeof flag === 'string') {
+    return flag.toLowerCase().includes('watch');
+  }
+  return Boolean(flag);
+}
+
+async function addToWatchlist(entry, button) {
+  const payload = {
+    id: resolveIdentifier(entry),
+    type: pickEntryValue(entry, ['type', 'kind', 'category']) || '',
+    title: pickEntryValue(entry, ['title', 'name']) || '',
+  };
+  if (!payload.id && !payload.title) {
+    showNotification("Impossible d'ajouter cet élément.", 'error');
+    return;
+  }
+  if (button) {
+    button.disabled = true;
+  }
+  try {
+    await fetchJson('/watchlist', {
+      method: 'POST',
+      headers: new Headers({ 'Content-Type': 'application/json' }),
+      body: JSON.stringify(payload),
+    });
+    showNotification('Ajouté à la liste d’intérêt.');
+    await loadCalendar({ preserveFilters: true });
+  } catch (error) {
+    showNotification(error.message, 'error');
+  } finally {
+    if (button) {
+      button.disabled = false;
+    }
+  }
+}
+
+function renderCalendar(data = {}) {
+  const container = document.getElementById('calendar-content');
+  if (!container) {
+    return;
+  }
+  const entries = normalizeCalendarEntries(data);
+  updateCalendarGenres(entries);
+  const filters = readCalendarFilters();
+  const filtered = entries.filter((entry) => entryMatchesFilters(entry, filters));
+  if (!filtered.length) {
+    container.innerHTML = '<p class="hint">Aucune sortie ne correspond aux filtres.</p>';
+    return;
+  }
+
+  const groups = buildCalendarGroups(filtered, state.calendar.view);
+  const fragments = groups.map((group) => {
+    const wrapper = document.createElement('article');
+    wrapper.className = 'calendar-group';
+    const title = document.createElement('h3');
+    title.textContent = group.label;
+    wrapper.appendChild(title);
+
+    const list = document.createElement('div');
+    list.className = 'calendar-items';
+    group.items
+      .sort((a, b) => (a.date?.getTime() || 0) - (b.date?.getTime() || 0))
+      .forEach(({ entry, date }) => {
+        const item = document.createElement('article');
+        item.className = 'calendar-item';
+
+        const header = document.createElement('header');
+        const titleEl = document.createElement('h4');
+        titleEl.textContent = pickEntryValue(entry, ['title', 'name']) || 'Titre inconnu';
+        const dateLabel = document.createElement('span');
+        dateLabel.className = 'calendar-meta';
+        dateLabel.textContent = date
+          ? new Intl.DateTimeFormat('fr-FR', {
+              weekday: 'short',
+              day: 'numeric',
+              month: 'short',
+            }).format(date)
+          : 'Date inconnue';
+        header.append(titleEl, dateLabel);
+        item.appendChild(header);
+
+        const badges = document.createElement('div');
+        badges.className = 'calendar-badges';
+        const type = pickEntryValue(entry, ['type', 'kind', 'category']);
+        if (type) {
+          badges.appendChild(makeCalendarBadge(type));
+        }
+        const rating = pickEntryValue(entry, ['imdb_rating', 'rating', 'score']);
+        if (rating !== undefined && rating !== null && rating !== '') {
+          badges.appendChild(makeCalendarBadge(`IMDb ${rating}`));
+        }
+        const genres = extractGenres(entry);
+        if (genres.length) {
+          badges.appendChild(makeCalendarBadge(genres.slice(0, 3).join(', ')));
+        }
+        if (isDownloaded(entry)) {
+          badges.appendChild(makeCalendarBadge('Téléchargé'));
+        }
+        if (isInWatchlist(entry)) {
+          badges.appendChild(makeCalendarBadge("Dans la liste d’intérêt"));
+        }
+        if (badges.childElementCount) {
+          item.appendChild(badges);
+        }
+
+        const metaSegments = [];
+        const language = pickEntryValue(entry, ['language', 'lang', 'original_language']);
+        const country = pickEntryValue(entry, ['country', 'origin_country', 'production_country']);
+        if (language) {
+          metaSegments.push(`Langue: ${language}`);
+        }
+        if (country) {
+          metaSegments.push(`Pays: ${country}`);
+        }
+        if (metaSegments.length) {
+          const meta = document.createElement('div');
+          meta.className = 'calendar-meta';
+          meta.textContent = metaSegments.join(' · ');
+          item.appendChild(meta);
+        }
+
+        if (!isInWatchlist(entry)) {
+          const actions = document.createElement('div');
+          actions.className = 'calendar-actions-row';
+          const button = document.createElement('button');
+          button.type = 'button';
+          button.textContent = 'Ajouter à la liste d’intérêt';
+          button.addEventListener('click', () => addToWatchlist(entry, button));
+          actions.appendChild(button);
+          item.appendChild(actions);
+        }
+
+        list.appendChild(item);
+      });
+
+    wrapper.appendChild(list);
+    return wrapper;
+  });
+
+  container.replaceChildren(...fragments);
+}
+
+async function loadCalendar(options = {}) {
+  if (!state.authenticated) {
+    return;
+  }
+  const filters = readCalendarFilters();
+  const search = new URLSearchParams();
+  if (filters.type) search.set('type', filters.type);
+  if (filters.genres.length) search.set('genres', filters.genres.join(','));
+  if (filters.ratingMin !== '') search.set('imdb_min', filters.ratingMin);
+  if (filters.ratingMax !== '') search.set('imdb_max', filters.ratingMax);
+  if (filters.language) search.set('language', filters.language);
+  if (filters.country) search.set('country', filters.country);
+  const path = `/calendar${search.toString() ? `?${search.toString()}` : ''}`;
+  try {
+    const data = await fetchJson(path);
+    renderCalendar(data || {});
+  } catch (error) {
+    if (state.authenticated) {
+      showNotification(error.message, 'error');
+    }
+  }
+}
+
 async function loadStatus() {
   try {
     const data = await fetchJson('/status');
@@ -1016,6 +1398,7 @@ const TAB_LOADERS = {
   jobs: () => loadStatus(),
   logs: () => loadLogs(),
   config: (options = {}) => loadConfigurationTab(options),
+  calendar: (options = {}) => loadCalendar(options),
 };
 
 async function refreshActiveTab(options = {}) {
@@ -1133,6 +1516,29 @@ function setupTabs() {
   });
 }
 
+function setupCalendarEvents() {
+  const refresh = document.getElementById('refresh-calendar');
+  if (refresh) {
+    refresh.addEventListener('click', () => loadCalendar({ preserveFilters: true }));
+  }
+  const ids = [
+    'calendar-view',
+    'calendar-type',
+    'calendar-genres',
+    'calendar-rating-min',
+    'calendar-rating-max',
+    'calendar-language',
+    'calendar-country',
+  ];
+  ids
+    .map((id) => document.getElementById(id))
+    .filter(Boolean)
+    .forEach((input) => {
+      const event = input.tagName === 'SELECT' ? 'change' : 'input';
+      input.addEventListener(event, () => loadCalendar({ preserveFilters: true }));
+    });
+}
+
 function setupEventListeners() {
   setupTabs();
   document.getElementById('refresh-status').addEventListener('click', loadStatus);
@@ -1149,6 +1555,7 @@ function setupEventListeners() {
   bindEditorAction('reload-trackers', 'trackers', 'reload');
   document.getElementById('login-form').addEventListener('submit', handleLogin);
   document.getElementById('logout-button').addEventListener('click', logout);
+  setupCalendarEvents();
 }
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -51,6 +51,16 @@
           Logs
         </button>
         <button
+          id="tab-calendar"
+          class="tab-button"
+          type="button"
+          role="tab"
+          aria-selected="false"
+          data-tab="calendar"
+        >
+          Calendrier
+        </button>
+        <button
           id="tab-config"
           class="tab-button"
           type="button"
@@ -114,6 +124,57 @@
               </div>
             </div>
             <div id="logs-container" class="logs"></div>
+          </section>
+        </section>
+
+        <section
+          class="tab-panel"
+          data-tab="calendar"
+          role="tabpanel"
+          aria-labelledby="tab-calendar"
+          hidden
+        >
+          <section class="panel" id="calendar-panel">
+            <div class="panel-header">
+              <h2>Calendrier</h2>
+              <div class="actions calendar-actions">
+                <label for="calendar-view">Vue</label>
+                <select id="calendar-view" name="view">
+                  <option value="week">Semaine</option>
+                  <option value="month">Mois</option>
+                </select>
+                <button id="refresh-calendar" type="button">Actualiser</button>
+              </div>
+            </div>
+
+            <div class="calendar-filters" aria-label="Filtres calendrier">
+              <label for="calendar-type">Type</label>
+              <select id="calendar-type" name="type">
+                <option value="">Tous</option>
+                <option value="movie">Films</option>
+                <option value="show">Séries</option>
+              </select>
+
+              <label for="calendar-genres">Genres</label>
+              <select id="calendar-genres" name="genres" multiple></select>
+
+              <label for="calendar-rating-min">Note IMDB (min/max)</label>
+              <div class="calendar-range">
+                <input id="calendar-rating-min" name="rating-min" type="number" step="0.1" min="0" max="10" />
+                <span>–</span>
+                <input id="calendar-rating-max" name="rating-max" type="number" step="0.1" min="0" max="10" />
+              </div>
+
+              <label for="calendar-language">Langue</label>
+              <input id="calendar-language" name="language" type="text" />
+
+              <label for="calendar-country">Pays</label>
+              <input id="calendar-country" name="country" type="text" />
+            </div>
+
+            <div id="calendar-content" class="calendar-content">
+              <p class="hint">Aucun contenu calendrier pour le moment.</p>
+            </div>
           </section>
         </section>
 


### PR DESCRIPTION
## Summary
- add a Calendrier tab to the dashboard with week/month toggles and filtering controls for type, genres, IMDb range, language, and country
- consume the /calendar endpoint to render grouped entries with download/watchlist badges and an action to add items to the watchlist
- style the new calendar layout to match the existing web interface

## Testing
- bundle exec rake test *(fails: existing TrackerQueryServiceTest errors around temporary directories and daemon queue concurrency; see test log for details)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c3bdb3aa48327a6901aa362b742b2)