### PR TITLE
Add calendar providers for IMDb and Trakt

### DIFF
--- a/test/services/calendar_feed_service_test.rb
+++ b/test/services/calendar_feed_service_test.rb
@@ -13,9 +13,10 @@ class CalendarFeedServiceTest < Minitest::Test
   class FakeProvider
     attr_reader :calls
 
-    def initialize(entries)
+    def initialize(entries, source: 'fake')
       @entries = entries
       @calls = []
+      @source = source
     end
 
     def upcoming(date_range:, limit:)
@@ -24,14 +25,15 @@ class CalendarFeedServiceTest < Minitest::Test
     end
 
     def source
-      'fake'
+      @source
     end
   end
 
   def setup
     @tmp_dir = Dir.mktmpdir('calendar-feed')
     @db_path = File.join(@tmp_dir, 'librarian.db')
-    @db = Storage::Db.new(@db_path)
+    @db = Storage::Db.new(@db_path, migrations_path: nil)
+    ensure_calendar_table
     @speaker = TestSupport::Fakes::Speaker.new
   end
 
@@ -83,6 +85,100 @@ class CalendarFeedServiceTest < Minitest::Test
     assert_equal ['fr'], rows.first[:languages]
   end
 
+  def test_refresh_filters_to_requested_sources
+    first_provider = FakeProvider.new([
+      base_entry.merge(source: 'first', external_id: 'movie-1', title: 'First Title')
+    ], source: 'first')
+    second_provider = FakeProvider.new([
+      base_entry.merge(source: 'second', external_id: 'movie-2', title: 'Second Title')
+    ], source: 'second')
+
+    service = MediaLibrarian::Services::CalendarFeedService.new(
+      app: nil,
+      speaker: @speaker,
+      db: @db,
+      providers: [first_provider, second_provider]
+    )
+
+    service.refresh(date_range: Date.today..(Date.today + 3), limit: 5, sources: ['second'])
+
+    assert_empty first_provider.calls
+    refute_empty second_provider.calls
+    rows = @db.get_rows(:calendar_entries)
+    assert_equal %w[second], rows.map { |row| row[:source] }.uniq
+  end
+
+  def test_refresh_handles_provider_failures
+    failing_provider = Class.new do
+      def source = 'failing'
+
+      def upcoming(**)
+        raise 'boom'
+      end
+    end.new
+    working_provider = FakeProvider.new([
+      base_entry.merge(source: 'working', external_id: 'movie-1', title: 'Working Title')
+    ], source: 'working')
+
+    service = MediaLibrarian::Services::CalendarFeedService.new(
+      app: nil,
+      speaker: @speaker,
+      db: @db,
+      providers: [failing_provider, working_provider]
+    )
+
+    service.refresh(date_range: Date.today..(Date.today + 1), limit: 5)
+
+    assert @speaker.messages.any? { |msg| msg.first == :error && msg.last.to_s.include?('Calendar provider failure') }
+    rows = @db.get_rows(:calendar_entries)
+    assert_equal 1, rows.count
+    assert_equal 'working', rows.first[:source]
+  end
+
+  def test_default_providers_come_from_config
+    config = {
+      'tmdb' => { 'api_key' => '123', 'language' => 'en', 'region' => 'US' },
+      'imdb' => { 'user' => 'user', 'list' => 'watchlist' },
+      'trakt' => { 'client_id' => 'id', 'client_secret' => 'secret' }
+    }
+    app = Struct.new(:config, :db).new(config, @db)
+
+    service = MediaLibrarian::Services::CalendarFeedService.new(app: app, speaker: @speaker)
+
+    sources = service.send(:default_providers).map(&:source)
+    assert_includes sources, 'tmdb'
+    assert_includes sources, 'imdb'
+    assert_includes sources, 'trakt'
+  end
+
+  def test_normalization_downcases_sources
+    date = Date.today + 1
+    tmdb_provider = FakeProvider.new([
+      base_entry.merge(source: 'TMDB', external_id: 'tmdb-1', title: 'TMDB Title')
+    ], source: 'TMDB')
+    imdb_provider = MediaLibrarian::Services::CalendarFeedService::ImdbCalendarProvider.new(
+      user: 'user', list: 'list', speaker: @speaker,
+      fetcher: ->(**_) { [{ external_id: 'imdb-1', title: 'IMDb Title', media_type: 'movie', release_date: date }] }
+    )
+    trakt_provider = MediaLibrarian::Services::CalendarFeedService::TraktCalendarProvider.new(
+      client_id: 'id', client_secret: 'secret', speaker: @speaker,
+      fetcher: ->(**_) { [{ external_id: 'trakt-1', title: 'Trakt Title', media_type: 'show', release_date: date }] }
+    )
+
+    service = MediaLibrarian::Services::CalendarFeedService.new(
+      app: nil,
+      speaker: @speaker,
+      db: @db,
+      providers: [tmdb_provider, imdb_provider, trakt_provider]
+    )
+
+    service.refresh(date_range: Date.today..(Date.today + 3), limit: 10)
+
+    rows = @db.get_rows(:calendar_entries).sort_by { |row| row[:external_id] }
+    assert_equal %w[imdb tmdb trakt], rows.map { |row| row[:source] }.uniq.sort
+    assert_equal %w[movie movie show], rows.map { |row| row[:media_type] }
+  end
+
   private
 
   def base_entry
@@ -97,5 +193,27 @@ class CalendarFeedServiceTest < Minitest::Test
       rating: 7.1,
       release_date: Date.today + 1
     }
+  end
+
+  def ensure_calendar_table
+    return if @db.database.table_exists?(:calendar_entries)
+
+    @db.database.create_table :calendar_entries do
+      primary_key :id
+      String :source, size: 50, null: false
+      String :external_id, size: 200, null: false
+      String :title, size: 500, null: false
+      String :media_type, size: 50, null: false
+      Text :genres
+      Text :languages
+      Text :countries
+      Float :rating
+      Date :release_date
+      DateTime :created_at
+      DateTime :updated_at
+
+      index %i[source external_id], unique: true
+      index :release_date
+    end
   end
 end


### PR DESCRIPTION
## Summary
- add IMDb and Trakt calendar provider classes and include them in default provider selection
- normalize calendar sources consistently and extend tests for provider filtering and error handling
- cover normalization for TMDB, IMDb, and Trakt entries in calendar feed

## Testing
- bundle exec ruby -Itest test/services/calendar_feed_service_test.rb


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cc9c8b9e48327a3196e24874fb331)