### PR TITLE
Add DB-backed calendar entries repository

### DIFF
--- a/app/calendar.rb
+++ b/app/calendar.rb
@@ -4,6 +4,7 @@ require 'set'
 require 'time'
 
 require_relative '../lib/watchlist_store'
+require_relative 'calendar_entries_repository'
 
 class Calendar
   include MediaLibrarian::AppContainerSupport
@@ -22,9 +23,8 @@ class Calendar
   end
 
   def entries(filters = {})
-    filtered = apply_filters(cached_entries, filters)
-    sorted = sort_entries(filtered, filters[:sort])
-    paginate_entries(sorted, filters[:page], filters[:per_page])
+    result = repository.entries(filters, entries: cached_entries)
+    result.merge(entries: result[:entries].map { |entry| serialize_entry(entry) })
   end
 
   private
@@ -48,175 +48,52 @@ class Calendar
   end
 
   def build_entries
-    WatchlistStore.fetch.filter_map do |entry|
-      type = normalize_entry_type(entry)
-      next unless type
+    base_entries = repository.load_entries
+    interest_lookup = build_interest_lookup
 
-      metadata = normalize_metadata(entry)
-      ids = extract_ids(metadata)
-      medium = load_medium(type, ids)
-      next unless medium
+    base_entries.map { |entry| annotate_entry(entry, interest_lookup) }
+  end
 
-      {
-        type: type == 'movies' ? 'movie' : 'show',
-        title: medium.name,
-        year: medium.year,
-        genres: Array(medium.genres).compact,
-        language: medium.language,
-        country: medium.country,
-        imdb_rating: safe_rating(medium),
-        release_date: release_date_from(metadata, medium, type),
-        downloaded: downloaded_from(metadata),
-        in_interest_list: true,
-        ids: ids
-      }
+  def annotate_entry(entry, interest_lookup)
+    languages = Array(entry[:languages])
+    countries = Array(entry[:countries])
+    entry.merge(
+      year: entry[:year] || entry[:release_date]&.year,
+      language: entry[:language] || languages.find { |lang| !lang.to_s.empty? },
+      country: entry[:country] || countries.find { |country| !country.to_s.empty? },
+      in_interest_list: interest_lookup.include?(normalize_interest_key(entry[:external_id]))
+    )
+  end
+
+  def build_interest_lookup
+    rows = WatchlistStore.fetch
+    rows.each_with_object(Set.new) do |row, memo|
+      external_id = normalize_interest_key(row[:external_id] || row['external_id'])
+      memo << external_id unless external_id.empty?
+
+      metadata = normalize_metadata(row[:metadata] || row['metadata'])
+      calendar_entries = metadata[:calendar_entries] || metadata['calendar_entries']
+      next unless calendar_entries.is_a?(Array)
+
+      calendar_entries.each do |entry|
+        entry_id = normalize_interest_key(entry[:external_id] || entry['external_id'])
+        memo << entry_id unless entry_id.empty?
+      end
     end
+  rescue StandardError
+    Set.new
   end
 
-  def normalize_entry_type(entry)
-    raw = entry[:type] || entry['type']
-    return unless raw
-
-    value = raw.to_s.downcase
-    return 'movies' if value.start_with?('movie')
-    return 'shows' if value.start_with?('show')
-  end
-
-  def normalize_metadata(entry)
-    metadata = entry[:metadata] || entry['metadata'] || {}
+  def normalize_metadata(metadata)
     metadata.is_a?(Hash) ? metadata : {}
   end
 
-  def extract_ids(metadata)
-    ids = metadata[:ids] || metadata['ids'] || {}
-    ids.is_a?(Hash) ? ids : {}
+  def normalize_interest_key(value)
+    value.to_s.strip.downcase
   end
 
-  def release_date_from(metadata, medium, type)
-    raw = metadata[:release_date] || metadata['release_date']
-    raw ||= metadata[:first_aired] || metadata['first_aired']
-    raw ||= type == 'movies' ? medium.release_date : medium.first_aired
-    parse_date(raw)
-  end
-
-  def downloaded_from(metadata)
-    return !!metadata[:downloaded] if metadata.key?(:downloaded)
-    return !!metadata['downloaded'] if metadata.key?('downloaded')
-
-    !!metadata[:downloaded_at] || !!metadata['downloaded_at']
-  end
-
-  def safe_rating(medium)
-    value = medium.respond_to?(:rating) ? medium.rating : nil
-    value.to_f if value
-  end
-
-  def load_medium(type, ids)
-    type == 'movies' ? Movie.movie_get(ids, 'movie_get', nil, app: app)[1] : TvSeries.tv_show_get(ids, app: app)[1]
-  rescue StandardError
-    nil
-  end
-
-  def parse_date(value)
-    return nil if value.nil?
-    return value if value.is_a?(Time)
-
-    Time.parse(value.to_s)
-  rescue ArgumentError
-    nil
-  end
-
-  def apply_filters(entries, filters)
-    entries.select do |entry|
-      type_match?(entry, filters[:type]) &&
-        genres_match?(entry, filters[:genres]) &&
-        rating_match?(entry, filters[:imdb_min], filters[:imdb_max]) &&
-        language_match?(entry, filters[:language]) &&
-        country_match?(entry, filters[:country]) &&
-        flag_match?(entry[:downloaded], filters[:downloaded]) &&
-        flag_match?(entry[:in_interest_list], filters[:interest])
-    end
-  end
-
-  def type_match?(entry, type_filter)
-    return true if type_filter.to_s.empty?
-
-    normalized = type_filter.to_s.downcase
-    entry[:type] == normalized || entry[:type] == normalized.chomp('s')
-  end
-
-  def genres_match?(entry, genres_filter)
-    return true if genres_filter.nil? || genres_filter.empty?
-
-    genres = Array(genres_filter).flat_map { |g| g.to_s.downcase.split(',') }.map(&:strip).reject(&:empty?)
-    return true if genres.empty?
-
-    entry_genres = Array(entry[:genres]).map { |g| g.to_s.downcase }
-    genres.all? { |genre| entry_genres.include?(genre) }
-  end
-
-  def rating_match?(entry, min_rating, max_rating)
-    rating = entry[:imdb_rating]
-    return true if rating.nil?
-
-    min_ok = min_rating.to_s.empty? || rating >= min_rating.to_f
-    max_ok = max_rating.to_s.empty? || rating <= max_rating.to_f
-    min_ok && max_ok
-  end
-
-  def language_match?(entry, language)
-    return true if language.to_s.empty?
-
-    entry[:language].to_s.casecmp?(language.to_s)
-  end
-
-  def country_match?(entry, country)
-    return true if country.to_s.empty?
-
-    entry[:country].to_s.casecmp?(country.to_s)
-  end
-
-  def flag_match?(value, filter)
-    return true if filter.nil? || filter.to_s.empty?
-
-    normalized = %w[1 true yes on].include?(filter.to_s.downcase)
-    value == normalized
-  end
-
-  def sort_entries(entries, sort)
-    order = sort.to_s.downcase == 'desc' ? -1 : 1
-    entries.sort_by do |entry|
-      date = entry[:release_date]
-      timestamp = date ? date.to_i : Float::INFINITY
-      key = if date
-              order == -1 ? -timestamp : timestamp
-            else
-              Float::INFINITY
-            end
-      key
-    end
-  end
-
-  def paginate_entries(entries, page, per_page)
-    per_page = clamp_per_page(per_page)
-    page = [page.to_i, 1].max
-    offset = (page - 1) * per_page
-    slice = entries.slice(offset, per_page) || []
-    total = entries.size
-
-    {
-      entries: slice.map { |entry| serialize_entry(entry) },
-      page: page,
-      per_page: per_page,
-      total: total,
-      total_pages: (total.to_f / per_page).ceil
-    }
-  end
-
-  def clamp_per_page(per_page)
-    value = per_page.to_i
-    value = 50 if value <= 0
-    [value, 200].min
+  def repository
+    @repository ||= CalendarEntriesRepository.new(app: app)
   end
 
   def serialize_entry(entry)

--- a/app/calendar_entries_repository.rb
+++ b/app/calendar_entries_repository.rb
@@ -1,0 +1,210 @@
+# frozen_string_literal: true
+
+require 'time'
+
+class CalendarEntriesRepository
+  include MediaLibrarian::AppContainerSupport
+
+  def initialize(app: self.class.app)
+    self.class.configure(app: app)
+  end
+
+  def entries(filters = {}, entries: nil)
+    data = Array(entries || load_entries)
+    filtered = apply_filters(data, filters)
+    sorted = sort_entries(filtered, filters[:sort])
+    paginate_entries(sorted, filters[:page], filters[:per_page])
+  end
+
+  def load_entries
+    rows = app.respond_to?(:db) ? Array(app.db&.get_rows(:calendar_entries)) : []
+    rows.filter_map { |row| normalize_row(row) }
+  rescue StandardError
+    []
+  end
+
+  private
+
+  def apply_filters(entries, filters)
+    entries.select do |entry|
+      type_match?(entry, filters[:type]) &&
+        genres_match?(entry, filters[:genres]) &&
+        rating_match?(entry, filters[:imdb_min], filters[:imdb_max]) &&
+        language_match?(entry, filters[:language]) &&
+        country_match?(entry, filters[:country]) &&
+        flag_match?(entry[:downloaded], filters[:downloaded]) &&
+        flag_match?(entry[:in_interest_list], filters[:interest])
+    end
+  end
+
+  def type_match?(entry, type_filter)
+    return true if type_filter.to_s.empty?
+
+    normalized = type_filter.to_s.downcase
+    entry[:type] == normalized || entry[:type] == normalized.chomp('s')
+  end
+
+  def genres_match?(entry, genres_filter)
+    return true if genres_filter.nil? || genres_filter.empty?
+
+    genres = Array(genres_filter)
+             .flat_map { |g| g.to_s.downcase.split(',') }
+             .map(&:strip)
+             .reject(&:empty?)
+    return true if genres.empty?
+
+    entry_genres = Array(entry[:genres]).map { |g| g.to_s.downcase }
+    genres.all? { |genre| entry_genres.include?(genre) }
+  end
+
+  def rating_match?(entry, min_rating, max_rating)
+    rating = entry[:imdb_rating]
+    return true if rating.nil?
+
+    min_ok = min_rating.to_s.empty? || rating >= min_rating.to_f
+    max_ok = max_rating.to_s.empty? || rating <= max_rating.to_f
+    min_ok && max_ok
+  end
+
+  def language_match?(entry, language)
+    return true if language.to_s.empty?
+
+    entry[:language].to_s.casecmp?(language.to_s)
+  end
+
+  def country_match?(entry, country)
+    return true if country.to_s.empty?
+
+    entry[:country].to_s.casecmp?(country.to_s)
+  end
+
+  def flag_match?(value, filter)
+    return true if filter.nil? || filter.to_s.empty?
+
+    normalized = %w[1 true yes on].include?(filter.to_s.downcase)
+    value == normalized
+  end
+
+  def sort_entries(entries, sort)
+    order = sort.to_s.downcase == 'desc' ? -1 : 1
+    entries.sort_by do |entry|
+      date = entry[:release_date]
+      timestamp = date ? date.to_i : Float::INFINITY
+      order == -1 ? -timestamp : timestamp
+    end
+  end
+
+  def paginate_entries(entries, page, per_page)
+    per_page = clamp_per_page(per_page)
+    page = [page.to_i, 1].max
+    offset = (page - 1) * per_page
+    slice = entries.slice(offset, per_page) || []
+    total = entries.size
+
+    {
+      entries: slice,
+      page: page,
+      per_page: per_page,
+      total: total,
+      total_pages: (total.to_f / per_page).ceil
+    }
+  end
+
+  def clamp_per_page(per_page)
+    value = per_page.to_i
+    value = 50 if value <= 0
+    [value, 200].min
+  end
+
+  def normalize_row(row)
+    type = normalize_type(row[:media_type] || row['media_type'] || row[:type] || row['type'])
+    title = (row[:title] || row['title']).to_s.strip
+    return unless type && !title.empty?
+
+    release_date = parse_time(row[:release_date] || row['release_date'])
+    genres = normalize_list(row[:genres] || row['genres'])
+    languages = normalize_list(row[:languages] || row['languages'])
+    countries = normalize_list(row[:countries] || row['countries'])
+    ids = normalize_ids(row[:ids] || row['ids'])
+    ids = build_default_ids(row, ids) if ids.empty?
+
+    {
+      type: type,
+      title: title,
+      year: release_date&.year,
+      genres: genres,
+      languages: languages,
+      countries: countries,
+      language: languages.find { |lang| !lang.to_s.empty? },
+      country: countries.find { |country| !country.to_s.empty? },
+      imdb_rating: parse_rating(row[:rating] || row['rating']),
+      release_date: release_date,
+      downloaded: !!(row[:downloaded] || row['downloaded']),
+      in_interest_list: !!(row[:in_interest_list] || row['in_interest_list']),
+      ids: ids,
+      source: (row[:source] || row['source']).to_s,
+      external_id: (row[:external_id] || row['external_id']).to_s
+    }
+  end
+
+  def normalize_type(value)
+    case value.to_s.downcase
+    when 'movie', 'movies', 'film', 'films'
+      'movie'
+    when 'show', 'shows', 'tv', 'series'
+      'show'
+    else
+      nil
+    end
+  end
+
+  def normalize_list(value)
+    case value
+    when Array
+      value.map { |entry| entry.to_s.strip }.reject(&:empty?)
+    when String
+      value.split(',').map { |entry| entry.to_s.strip }.reject(&:empty?)
+    else
+      []
+    end
+  end
+
+  def parse_rating(value)
+    return nil if value.nil? || value.to_s.strip.empty?
+
+    value.to_f
+  end
+
+  def parse_time(value)
+    case value
+    when Time
+      value
+    when Date
+      Time.utc(value.year, value.month, value.day)
+    when String
+      return if value.strip.empty?
+
+      Time.parse(value)
+    else
+      nil
+    end
+  rescue ArgumentError
+    nil
+  end
+
+  def normalize_ids(value)
+    return {} unless value.is_a?(Hash)
+
+    value.each_with_object({}) do |(key, val), memo|
+      memo[key.to_s] = val
+    end
+  end
+
+  def build_default_ids(row, ids)
+    source = (row[:source] || row['source']).to_s
+    external_id = (row[:external_id] || row['external_id']).to_s
+    return ids if source.empty? || external_id.empty?
+
+    ids.merge(source => external_id)
+  end
+end


### PR DESCRIPTION
## Summary
- add a CalendarEntriesRepository that loads calendar rows from the local database and exposes the same filtering, sorting, and pagination helpers
- update Calendar to rely on the repository, annotate rows with watchlist interest metadata, and surface language/country arrays for the API
- refresh the calendar tests to exercise the DB-backed flow and verify filtering plus interest flags

## Testing
- `bundle exec ruby -Itest test/app/calendar_test.rb`
- `bundle exec rake test` *(fails: existing DaemonQueueConcurrencyTest#test_enqueue_retries_until_executor_accepts_job assertion and TorrentRssTest#test_links_use_global_agent_without_metadata Zeitwerk loader error)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d9dc514748327a1bc14f71230453f)