### PR TITLE
Add downloads tab

### DIFF
--- a/app/web/app.js
+++ b/app/web/app.js
@@ -1496,6 +1496,9 @@ async function loadConfigurationTab(options = {}) {
     return;
   }
   await loadEditor('trackers', options);
+}
+
+async function loadDownloadsTab() {
   await loadDownloadList();
 }
 
@@ -1540,6 +1543,7 @@ const TAB_LOADERS = {
   logs: () => loadLogs(),
   config: (options = {}) => loadConfigurationTab(options),
   calendar: (options = {}) => loadCalendar(options),
+  downloads: () => loadDownloadsTab(),
 };
 
 async function refreshActiveTab(options = {}) {
@@ -1567,6 +1571,10 @@ async function refreshAll(options = {}) {
       return;
     }
     await loadConfigurationTab(options);
+    if (!state.authenticated) {
+      return;
+    }
+    await loadDownloadsTab();
   } finally {
     state.isRefreshing = false;
   }

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -61,6 +61,16 @@
           Calendrier
         </button>
         <button
+          id="tab-downloads"
+          class="tab-button"
+          type="button"
+          role="tab"
+          aria-selected="false"
+          data-tab="downloads"
+        >
+          Intérêts
+        </button>
+        <button
           id="tab-config"
           class="tab-button"
           type="button"
@@ -244,7 +254,15 @@
             <textarea id="trackers-editor" spellcheck="false" placeholder="Configuration YAML du tracker"></textarea>
             <p class="hint" id="trackers-hint">Sélectionnez un tracker pour l'éditer.</p>
           </section>
+        </section>
 
+        <section
+          class="tab-panel"
+          data-tab="downloads"
+          role="tabpanel"
+          aria-labelledby="tab-downloads"
+          hidden
+        >
           <section class="panel" id="download-list-panel">
             <div class="panel-header">
               <h2>Liste d'intérêt</h2>


### PR DESCRIPTION
## Summary
- add a dedicated "Intérêts" tab and panel to host the download list UI
- wire the downloads tab into the tab loader registry and keep the list refreshed during global refreshes

## Testing
- `bundle exec rake test` *(fails: existing suite reports 2 failures and 6 errors; see log for details)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dd908b4b483279e5c174be4c0d670)