### PR TITLE
Simplify calendar provider bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,30 +68,31 @@ The daemon logs to `~/.medialibrarian/logs/` by default, and jobs are queued acc
 
 ### Calendar feed configuration
 
-`CalendarFeedService` can hydrate the `calendar_entries` table from multiple sources. Provide the credentials in `~/.medialibrarian/conf.yml` to enable each fetcher:
+`CalendarFeedService` can hydrate the `calendar_entries` table from multiple sources. Each provider is toggled via the `calendar.providers` list in `~/.medialibrarian/conf.yml`, and the daemon scheduler uses the rest of the `calendar` keys to control refresh cadence and the window that gets persisted:
 
 ```yaml
-imdb:
-  user: ur123456   # IMDb user id (starts with "ur")
-  list: ls123456789  # The list id (starts with "ls") whose CSV export is queried
+calendar:
+  refresh_every: 12 hours        # Scheduler interval (e.g. "6h", "1 day")
+  window_past_days: 3            # How far back from today to keep entries
+  window_future_days: 45         # How far into the future to fetch releases
+  refresh_limit: 200             # Maximum number of entries persisted per refresh
+  providers: imdb|trakt|tmdb     # Pipe/comma/space separated list or array of sources to enable
+
+tmdb:
+  api_key: YOUR_TMDB_API_KEY
 
 trakt:
   client_id: YOUR_TRAKT_CLIENT_ID
   client_secret: YOUR_TRAKT_CLIENT_SECRET
   access_token: OPTIONAL_OAUTH_TOKEN
 
-calendar:
-  refresh_every: 12 hours      # Scheduler interval (e.g. "6h", "1 day")
-  refresh_days: 45             # Size of the window fetched on each run
-  refresh_limit: 200           # Maximum number of entries persisted per refresh
-  providers: imdb|trakt|tmdb   # Pipe/comma/space separated list or array of sources to enable
+# imdb:
+#   enabled: false               # Optional toggle if you want to skip the IMDb feed entirely
 ```
 
-The IMDb fetcher reads the CSV export for the configured user/list pair and extracts release dates, genres, and ratings. Make sure the account is public or that you have access to the list via a logged-in session when generating the cookie jar used by the daemon.
+`refresh_every` overrides the scheduler interval so the daemon automatically re-hydrates the calendar at the requested cadence. `window_past_days` and `window_future_days` define the rolling window of dates that will be fetched on each run (`refresh_days` remains a backward-compatible alias for the future window), while `refresh_limit` caps the number of entries persisted per refresh. `providers` can be specified as a delimited string (`imdb|trakt|tmdb`, `imdb trakt`, etc.) or as a YAML array, and only the enabled fetchers are queried on each refresh.
 
-Trakt access requires an API application; `client_id`/`client_secret` identify the app and the calendar endpoints live under `https://api.trakt.tv/calendars/all/...`. Public calendars work with only the client id, but supplying an OAuth `access_token` allows the service to reuse authenticated calls if you later point it at user-specific scopes.
-
-The `calendar` section controls when and how `calendar.refresh_feed` runs. `refresh_every` overrides the scheduler interval so the daemon automatically re-hydrates the calendar at the requested cadence, while `refresh_days`/`refresh_limit` define the rolling window and cap the persisted entries. `providers` can be specified as a delimited string (`imdb|trakt|tmdb`, `imdb trakt`, etc.) or as a YAML array, and only the enabled fetchers are queried on each refresh.
+The IMDb fetcher now uses the public release calendar and does not require per-user configuration. Leave the `imdb` block out of `conf.yml` (or set `imdb.enabled: false`) to disable it entirely. Trakt access still requires an API application; `client_id`/`client_secret` identify the app and the calendar endpoints live under `https://api.trakt.tv/calendars/all/...`. Public calendars work with only the client id, but supplying an OAuth `access_token` allows the service to reuse authenticated calls if you later point it at user-specific scopes.
 
 ### Tracker logins that require a real browser
 

--- a/app/calendar_feed.rb
+++ b/app/calendar_feed.rb
@@ -11,9 +11,11 @@ class CalendarFeed
 
   def self.refresh_feed(days: nil, limit: nil, sources: nil)
     config = calendar_config
-    window_days = positive_integer(days) ||
+    future_days = positive_integer(days) ||
+                  positive_integer(config['window_future_days']) ||
                   positive_integer(config['refresh_days']) ||
                   MediaLibrarian::Services::CalendarFeedService::DEFAULT_WINDOW_DAYS
+    past_days = positive_integer(config['window_past_days']) || 0
     max_entries = positive_integer(limit) ||
                   positive_integer(config['refresh_limit']) ||
                   DEFAULT_REFRESH_LIMIT
@@ -21,7 +23,7 @@ class CalendarFeed
     provider_list = nil if provider_list&.empty?
 
     today = Date.today
-    date_range = today..(today + window_days)
+    date_range = (today - past_days)..(today + future_days)
 
     calendar_service.refresh(date_range: date_range, limit: max_entries, sources: provider_list)
   end

--- a/config/conf.yml.example
+++ b/config/conf.yml.example
@@ -25,14 +25,14 @@ email:
 ffmpeg_settings:
   crf: 22
   preset: medium
-imdb:
-  user: user
-  list: list
 calendar:
   refresh_every: 12 hours
-  refresh_days: 45
+  window_past_days: 0
+  window_future_days: 45
   refresh_limit: 200
   providers: imdb|trakt|tmdb
+# imdb:
+#   enabled: false # Optional toggle; remove or set to false to disable the IMDb feed
 kodi:
   host: http://host:port
   username: username

--- a/test/services/calendar_feed_service_test.rb
+++ b/test/services/calendar_feed_service_test.rb
@@ -151,6 +151,45 @@ class CalendarFeedServiceTest < Minitest::Test
     assert_includes sources, 'trakt'
   end
 
+  def test_imdb_provider_enabled_with_empty_configuration
+    config = { 'imdb' => {} }
+    app = Struct.new(:config, :db).new(config, @db)
+
+    service = MediaLibrarian::Services::CalendarFeedService.new(app: app, speaker: @speaker)
+
+    sources = service.send(:default_providers).map(&:source)
+    assert_includes sources, 'imdb'
+  end
+
+  def test_imdb_provider_enabled_when_configuration_absent
+    config = {}
+    app = Struct.new(:config, :db).new(config, @db)
+
+    service = MediaLibrarian::Services::CalendarFeedService.new(app: app, speaker: @speaker)
+
+    sources = service.send(:default_providers).map(&:source)
+    assert_includes sources, 'imdb'
+  end
+
+  def test_imdb_provider_enabled_when_app_config_missing
+    app = Struct.new(:config, :db).new(nil, @db)
+
+    service = MediaLibrarian::Services::CalendarFeedService.new(app: app, speaker: @speaker)
+
+    sources = service.send(:default_providers).map(&:source)
+    assert_includes sources, 'imdb'
+  end
+
+  def test_imdb_provider_can_be_disabled
+    config = { 'imdb' => { 'enabled' => false } }
+    app = Struct.new(:config, :db).new(config, @db)
+
+    service = MediaLibrarian::Services::CalendarFeedService.new(app: app, speaker: @speaker)
+
+    sources = service.send(:default_providers).map(&:source)
+    refute_includes sources, 'imdb'
+  end
+
   def test_normalization_downcases_sources
     date = Date.today + 1
     tmdb_provider = FakeProvider.new([


### PR DESCRIPTION
## Summary
- build default providers through dedicated helpers so IMDb still initializes even when the global configuration object is missing
- add regression coverage to ensure the IMDb feed stays enabled whenever the calendar service boots without configuration

## Testing
- `bundle exec ruby -Itest test/services/calendar_feed_service_test.rb`
- `bundle exec ruby -Itest test/app/calendar_feed_test.rb`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691decf4e7d083279f2863b72c1646e0)