### PR TITLE
Bootstrap calendar refresh on daemon start

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ The daemon logs to `~/.medialibrarian/logs/` by default, and jobs are queued acc
 ```yaml
 calendar:
   refresh_every: 12 hours        # Scheduler interval (e.g. "6h", "1 day")
+  refresh_on_start: true         # Prime the table on daemon boot when it's empty
   window_past_days: 3            # How far back from today to keep entries
   window_future_days: 45         # How far into the future to fetch releases
   refresh_limit: 200             # Maximum number of entries persisted per refresh
@@ -90,7 +91,7 @@ trakt:
 #   enabled: false               # Optional toggle if you want to skip the IMDb feed entirely
 ```
 
-`refresh_every` overrides the scheduler interval so the daemon automatically re-hydrates the calendar at the requested cadence. `window_past_days` and `window_future_days` define the rolling window of dates that will be fetched on each run (`refresh_days` remains a backward-compatible alias for the future window), while `refresh_limit` caps the number of entries persisted per refresh. `providers` can be specified as a delimited string (`imdb|trakt|tmdb`, `imdb trakt`, etc.) or as a YAML array, and only the enabled fetchers are queried on each refresh.
+`refresh_every` overrides the scheduler interval so the daemon automatically re-hydrates the calendar at the requested cadence. `window_past_days` and `window_future_days` define the rolling window of dates that will be fetched on each run (`refresh_days` remains a backward-compatible alias for the future window), while `refresh_limit` caps the number of entries persisted per refresh. `refresh_on_start` ensures the daemon performs an immediate refresh when the calendar table is empty (set it to `false` to disable that bootstrap). `providers` can be specified as a delimited string (`imdb|trakt|tmdb`, `imdb trakt`, etc.) or as a YAML array, and only the enabled fetchers are queried on each refresh.
 
 The IMDb fetcher now uses the public release calendar and does not require per-user configuration. Leave the `imdb` block out of `conf.yml` (or set `imdb.enabled: false`) to disable it entirely. Trakt access still requires an API application; `client_id`/`client_secret` identify the app and the calendar endpoints live under `https://api.trakt.tv/calendars/all/...`. Public calendars work with only the client id, but supplying an OAuth `access_token` allows the service to reuse authenticated calls if you later point it at user-specific scopes.
 

--- a/config/conf.yml.example
+++ b/config/conf.yml.example
@@ -27,6 +27,7 @@ ffmpeg_settings:
   preset: medium
 calendar:
   refresh_every: 12 hours
+  refresh_on_start: true
   window_past_days: 0
   window_future_days: 45
   refresh_limit: 200

--- a/test/daemon_calendar_bootstrap_test.rb
+++ b/test/daemon_calendar_bootstrap_test.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require_relative '../app/daemon'
+require_relative '../app/calendar_feed'
+
+class DaemonCalendarBootstrapTest < Minitest::Test
+  def setup
+    reset_librarian_state!
+    @environment = build_stubbed_environment
+    MediaLibrarian.application = @environment.application
+    Daemon.configure(app: @environment.application)
+    Thread.current[:current_daemon] = :test_client
+  end
+
+  def teardown
+    Thread.current[:current_daemon] = nil
+    MediaLibrarian.application = nil
+    cleanup_daemon_state
+    @environment.cleanup if @environment
+  end
+
+  def test_bootstrap_refresh_runs_when_calendar_is_empty
+    apply_calendar_config(refresh_on_start: true)
+    attach_calendar_db(entry: nil)
+
+    refreshes = 0
+    CalendarFeed.stub(:refresh_feed, ->(*) { refreshes += 1 }) do
+      Daemon.send(:bootstrap_calendar_feed_if_needed)
+    end
+
+    assert_equal 1, refreshes
+  end
+
+  def test_bootstrap_refresh_skipped_when_entries_exist
+    apply_calendar_config(refresh_on_start: true)
+    attach_calendar_db(entry: { id: 1 })
+
+    CalendarFeed.stub(:refresh_feed, ->(*) { flunk('unexpected refresh') }) do
+      Daemon.send(:bootstrap_calendar_feed_if_needed)
+    end
+  end
+
+  def test_bootstrap_refresh_skipped_when_disabled
+    apply_calendar_config(refresh_on_start: false)
+    attach_calendar_db(entry: nil)
+
+    CalendarFeed.stub(:refresh_feed, ->(*) { flunk('unexpected refresh') }) do
+      Daemon.send(:bootstrap_calendar_feed_if_needed)
+    end
+  end
+
+  private
+
+  def apply_calendar_config(refresh_on_start: true)
+    config = {
+      'daemon' => { 'workers_pool_size' => 1, 'queue_slots' => 1 },
+      'calendar' => {
+        'refresh_every' => '12 hours',
+        'refresh_on_start' => refresh_on_start,
+        'refresh_days' => 10,
+        'refresh_limit' => 25,
+        'providers' => 'imdb|trakt'
+      }
+    }
+    @environment.container.reload_config!(config)
+  end
+
+  def attach_calendar_db(entry: nil)
+    dataset = FakeDataset.new(entry)
+    database = FakeDatabase.new(dataset)
+    db = FakeDb.new(database)
+    @environment.application.define_singleton_method(:db) { db }
+  end
+
+  def cleanup_daemon_state
+    %i[@running @template_cache @last_execution @queue_limits @calendar_refresh_mutex].each do |name|
+      Daemon.instance_variable_set(name, nil)
+    end
+  end
+
+  class FakeDb
+    attr_reader :database
+
+    def initialize(database)
+      @database = database
+    end
+
+    def table_exists?(table)
+      table.to_sym == :calendar_entries
+    end
+  end
+
+  class FakeDatabase
+    def initialize(dataset)
+      @dataset = dataset
+    end
+
+    def [](_table)
+      @dataset
+    end
+  end
+
+  class FakeDataset
+    def initialize(entry)
+      @entry = entry
+    end
+
+    def first
+      @entry
+    end
+  end
+end

--- a/test/support/dependency_stubs.rb
+++ b/test/support/dependency_stubs.rb
@@ -215,6 +215,7 @@ module SimpleConfigMan
     },
     'calendar' => {
       'refresh_every' => '12 hours',
+      'refresh_on_start' => true,
       'refresh_days' => 45,
       'refresh_limit' => 200,
       'providers' => 'imdb|trakt|tmdb'


### PR DESCRIPTION
## Summary
- prime the calendar feed when the daemon starts and the `calendar_entries` table is empty, with a config flag to turn it off
- serialize all refreshes through a mutex so scheduler runs never overlap with the bootstrap run
- document the new flag and cover the bootstrap logic with a daemon-level test

## Testing
- `bundle exec ruby -Itest test/daemon_calendar_bootstrap_test.rb test/daemon_scheduler_calendar_test.rb test/app/calendar_feed_test.rb`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e0397a7f883278a852233f88a6f02)