### PR TITLE
Add calendar date filters and navigation controls

### DIFF
--- a/app/calendar_entries_repository.rb
+++ b/app/calendar_entries_repository.rb
@@ -26,8 +26,12 @@ class CalendarEntriesRepository
   private
 
   def apply_filters(entries, filters)
+    start_date = parse_time(filters[:start_date])
+    end_date = parse_time(filters[:end_date])
+
     entries.select do |entry|
-      type_match?(entry, filters[:type]) &&
+      release_date_match?(entry[:release_date], start_date, end_date) &&
+        type_match?(entry, filters[:type]) &&
         genres_match?(entry, filters[:genres]) &&
         rating_match?(entry, filters[:imdb_min], filters[:imdb_max]) &&
         language_match?(entry, filters[:language]) &&
@@ -70,6 +74,15 @@ class CalendarEntriesRepository
     return true if language.to_s.empty?
 
     entry[:language].to_s.casecmp?(language.to_s)
+  end
+
+  def release_date_match?(release_date, start_date, end_date)
+    return true unless start_date || end_date
+    return false unless release_date
+
+    after_start = start_date.nil? || release_date >= start_date
+    before_end = end_date.nil? || release_date <= end_date
+    after_start && before_end
   end
 
   def country_match?(entry, country)

--- a/app/web/app.js
+++ b/app/web/app.js
@@ -24,6 +24,10 @@ const state = {
   },
 };
 
+const calendarWindow = typeof createCalendarWindowManager === 'function'
+  ? createCalendarWindowManager({ windowLengthForView: (view) => (view === 'month' ? 30 : 7) })
+  : null;
+
 const fileEditors = new Map();
 
 const API_BASE_PATH = (() => {
@@ -1051,6 +1055,46 @@ function readCalendarFilters() {
   return filters;
 }
 
+function resolveCalendarWindow(options = {}) {
+  const view = state.calendar.view || 'week';
+  if (!calendarWindow) {
+    return null;
+  }
+  if (options.resetWindow) {
+    return calendarWindow.reset(view);
+  }
+  if (options.startDate) {
+    return calendarWindow.setStart(view, options.startDate);
+  }
+  if (options.offsetDelta) {
+    return calendarWindow.shift(view, options.offsetDelta);
+  }
+  return calendarWindow.current(view);
+}
+
+function formatCalendarDate(date) {
+  return date ? date.toISOString().slice(0, 10) : '';
+}
+
+function updateCalendarWindowDisplay(range) {
+  if (!range) {
+    return;
+  }
+  const label = document.getElementById('calendar-window-label');
+  if (label) {
+    const formatter = new Intl.DateTimeFormat('fr-FR', {
+      day: 'numeric',
+      month: 'short',
+      year: 'numeric',
+    });
+    label.textContent = `${formatter.format(range.start)} – ${formatter.format(range.end)}`;
+  }
+  const startInput = document.getElementById('calendar-start-date');
+  if (startInput) {
+    startInput.value = formatCalendarDate(range.start);
+  }
+}
+
 function entryMatchesFilters(entry, filters) {
   const type = (pickEntryValue(entry, ['type', 'kind', 'category']) || '').toString().toLowerCase();
   if (filters.type && filters.type !== type) {
@@ -1304,6 +1348,8 @@ async function loadCalendar(options = {}) {
     return;
   }
   const filters = readCalendarFilters();
+  const range = resolveCalendarWindow(options);
+  updateCalendarWindowDisplay(range);
   const search = new URLSearchParams();
   if (filters.type) search.set('type', filters.type);
   if (filters.genres.length) search.set('genres', filters.genres.join(','));
@@ -1311,6 +1357,12 @@ async function loadCalendar(options = {}) {
   if (filters.ratingMax !== '') search.set('imdb_max', filters.ratingMax);
   if (filters.language) search.set('language', filters.language);
   if (filters.country) search.set('country', filters.country);
+  if (range) {
+    search.set('start_date', formatCalendarDate(range.start));
+    search.set('end_date', formatCalendarDate(range.end));
+    search.set('window', range.days);
+    search.set('offset', range.offset);
+  }
   const path = `/calendar${search.toString() ? `?${search.toString()}` : ''}`;
   try {
     const data = await fetchJson(path);
@@ -1670,8 +1722,11 @@ function setupCalendarEvents() {
   if (refresh) {
     refresh.addEventListener('click', () => loadCalendar({ preserveFilters: true }));
   }
+  const calendarView = document.getElementById('calendar-view');
+  if (calendarView) {
+    calendarView.addEventListener('change', () => loadCalendar({ preserveFilters: true, resetWindow: true }));
+  }
   const ids = [
-    'calendar-view',
     'calendar-type',
     'calendar-genres',
     'calendar-rating-min',
@@ -1686,6 +1741,14 @@ function setupCalendarEvents() {
       const event = input.tagName === 'SELECT' ? 'change' : 'input';
       input.addEventListener(event, () => loadCalendar({ preserveFilters: true }));
     });
+  wireCalendarNavigation(
+    {
+      previous: document.getElementById('calendar-prev'),
+      next: document.getElementById('calendar-next'),
+      dateInput: document.getElementById('calendar-start-date'),
+    },
+    (options) => loadCalendar(options),
+  );
 }
 
 function setupEventListeners() {

--- a/app/web/app.js
+++ b/app/web/app.js
@@ -1073,7 +1073,13 @@ function resolveCalendarWindow(options = {}) {
 }
 
 function formatCalendarDate(date) {
-  return date ? date.toISOString().slice(0, 10) : '';
+  if (!date) {
+    return '';
+  }
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, '0');
+  const day = `${date.getDate()}`.padStart(2, '0');
+  return `${year}-${month}-${day}`;
 }
 
 function updateCalendarWindowDisplay(range) {

--- a/app/web/calendar_window.js
+++ b/app/web/calendar_window.js
@@ -1,0 +1,83 @@
+;(function attachCalendarWindow(global) {
+  const ONE_DAY_MS = 86_400_000;
+
+  function truncateDate(input) {
+    if (!input) return null;
+    const value = new Date(input);
+    if (Number.isNaN(value.getTime())) return null;
+    value.setHours(0, 0, 0, 0);
+    return value;
+  }
+
+  function addDays(date, days) {
+    return new Date(date.getTime() + days * ONE_DAY_MS);
+  }
+
+  function createCalendarWindowManager(options = {}) {
+    const now = options.now || (() => new Date());
+    const windowLengthForView = options.windowLengthForView || ((view) => (view === 'month' ? 30 : 7));
+
+    let customStart = null;
+    let offset = 0;
+
+    function currentWindow(view) {
+      const days = windowLengthForView(view);
+      const start = addDays(truncateDate(customStart) || truncateDate(now()), offset * days);
+      return { start, end: addDays(start, days - 1), days, offset };
+    }
+
+    return {
+      current(view) {
+        return currentWindow(view);
+      },
+      shift(view, delta) {
+        offset += delta;
+        return currentWindow(view);
+      },
+      setStart(view, date) {
+        customStart = truncateDate(date);
+        offset = 0;
+        return currentWindow(view);
+      },
+      reset(view) {
+        customStart = null;
+        offset = 0;
+        return currentWindow(view);
+      },
+    };
+  }
+
+  function wireCalendarNavigation(elements, loadCalendar) {
+    if (!elements || typeof loadCalendar !== 'function') {
+      return;
+    }
+    const { previous, next, dateInput } = elements;
+    if (previous?.addEventListener) {
+      previous.addEventListener('click', () => loadCalendar({ offsetDelta: -1, preserveFilters: true }));
+    }
+    if (next?.addEventListener) {
+      next.addEventListener('click', () => loadCalendar({ offsetDelta: 1, preserveFilters: true }));
+    }
+    if (dateInput?.addEventListener) {
+      dateInput.addEventListener('change', () => {
+        if (dateInput.value) {
+          loadCalendar({ startDate: dateInput.value, preserveFilters: true });
+        }
+      });
+    }
+  }
+
+  if (global && typeof global === 'object') {
+    global.createCalendarWindowManager = createCalendarWindowManager;
+    global.wireCalendarNavigation = wireCalendarNavigation;
+  }
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = {
+      addDays,
+      truncateDate,
+      createCalendarWindowManager,
+      wireCalendarNavigation,
+    };
+  }
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -153,6 +153,12 @@
                   <option value="week">Semaine</option>
                   <option value="month">Mois</option>
                 </select>
+                <div class="calendar-window-tools" aria-label="Navigation calendrier">
+                  <button id="calendar-prev" type="button" aria-label="Fenêtre précédente">◀</button>
+                  <input id="calendar-start-date" name="start_date" type="date" aria-label="Date de début" />
+                  <span id="calendar-window-label" class="calendar-window-label" aria-live="polite"></span>
+                  <button id="calendar-next" type="button" aria-label="Fenêtre suivante">▶</button>
+                </div>
                 <button id="refresh-calendar" type="button">Actualiser</button>
               </div>
             </div>
@@ -347,6 +353,7 @@
     <div id="notification" role="status" aria-live="polite"></div>
 
     <script src="path_utils.js" defer></script>
+    <script src="calendar_window.js" defer></script>
     <script src="app.js" defer></script>
   </body>
 </html>

--- a/test/app/calendar_test.rb
+++ b/test/app/calendar_test.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
 require 'test_helper'
+require 'ostruct'
 require_relative '../../lib/watchlist_store'
 require_relative '../../app/calendar'
+require_relative '../../app/daemon'
 
 class CalendarTest < Minitest::Test
   def setup
@@ -88,6 +90,42 @@ class CalendarTest < Minitest::Test
     db.verify
   end
 
+  def test_filters_by_release_date_range
+    db = stub_calendar_rows([
+      { source: 'tmdb', external_id: 'movie-1', title: 'Alpha', media_type: 'movie', release_date: '2024-01-05' },
+      { source: 'tmdb', external_id: 'movie-2', title: 'Bravo', media_type: 'movie', release_date: '2024-01-20' },
+      { source: 'tmdb', external_id: 'movie-3', title: 'Charlie', media_type: 'movie', release_date: '2024-02-01' }
+    ])
+
+    WatchlistStore.stub(:fetch, []) do
+      calendar = Calendar.new(app: @environment.application)
+      result = calendar.entries(start_date: '2024-01-10', end_date: '2024-01-31')
+
+      assert_equal ['Bravo'], result[:entries].map { |entry| entry[:title] }
+    end
+
+    db.verify
+  end
+
+  def test_handle_calendar_request_uses_offset_and_window
+    Daemon.configure(app: @environment.application)
+    response = FakeResponse.new
+    filters = nil
+
+    Time.stub(:now, Time.utc(2024, 1, 1, 12, 0, 0)) do
+      Calendar.stub(:new, ->(app:) { FakeCalendar.new(app: app, on_entries: ->(args) { filters = args }) }) do
+        request = OpenStruct.new(request_method: 'GET', query: { 'offset' => '1', 'window' => '7' }, path: '/calendar')
+        Daemon.send(:handle_calendar_request, request, response)
+      end
+    end
+
+    assert_equal 200, response.status
+    assert_kind_of Time, filters[:start_date]
+    assert_kind_of Time, filters[:end_date]
+    assert_equal Time.utc(2024, 1, 8), filters[:start_date]
+    assert_equal Time.utc(2024, 1, 14), filters[:end_date]
+  end
+
   private
 
   def stub_calendar_rows(rows)
@@ -95,6 +133,32 @@ class CalendarTest < Minitest::Test
     db.expect(:get_rows, rows, [:calendar_entries])
     attach_db(db)
     db
+  end
+
+  class FakeResponse
+    attr_accessor :status, :body
+
+    def initialize
+      @headers = {}
+      @status = nil
+      @body = nil
+    end
+
+    def []=(key, value)
+      @headers[key] = value
+    end
+  end
+
+  class FakeCalendar
+    def initialize(app:, on_entries: nil)
+      @app = app
+      @on_entries = on_entries
+    end
+
+    def entries(filters)
+      @on_entries.call(filters) if @on_entries
+      { entries: [], page: 1, per_page: 50, total: 0, total_pages: 0 }
+    end
   end
 
   def attach_db(db)

--- a/test/web/calendar_window.test.js
+++ b/test/web/calendar_window.test.js
@@ -1,0 +1,37 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { wireCalendarNavigation } = require('../../app/web/calendar_window.js');
+
+function stubElement() {
+  const handlers = {};
+  return {
+    addEventListener: (event, handler) => {
+      handlers[event] = handler;
+    },
+    dispatch: (event) => {
+      handlers[event]?.();
+    },
+    value: '',
+  };
+}
+
+test('navigation controls delegate to loadCalendar with offsets and dates', () => {
+  const calls = [];
+  const previous = stubElement();
+  const next = stubElement();
+  const dateInput = stubElement();
+  dateInput.value = '2024-01-05';
+
+  wireCalendarNavigation({ previous, next, dateInput }, (options) => calls.push(options));
+
+  previous.dispatch('click');
+  next.dispatch('click');
+  dateInput.dispatch('change');
+
+  assert.deepEqual(calls, [
+    { offsetDelta: -1, preserveFilters: true },
+    { offsetDelta: 1, preserveFilters: true },
+    { startDate: '2024-01-05', preserveFilters: true },
+  ]);
+});


### PR DESCRIPTION
## Summary
- add release date window parsing to the calendar endpoint and repository filtering
- expose calendar window navigation controls with preserved query parameters on the dashboard
- cover the new date filters and navigation helpers with server and frontend tests

## Testing
- bundle exec ruby -Itest test/app/calendar_test.rb
- node test/web/calendar_window.test.js


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e0d92bad88327854a6f78c126faa8)