### PR TITLE
Refactor TMDB calendar provider to use gem client

### DIFF
--- a/app/media_librarian/services/calendar_feed_service.rb
+++ b/app/media_librarian/services/calendar_feed_service.rb
@@ -494,7 +494,7 @@ module MediaLibrarian
           page = 1
           results = []
           loop do
-            payload = fetch_page(path, page)
+            payload = fetch_page(path, kind, page)
             break unless payload
 
             Array(payload['results']).each do |item|
@@ -514,10 +514,18 @@ module MediaLibrarian
           results
         end
 
-        def fetch_page(path, page)
-          search = client::Search.new(path)
-          search.filter(page: page)
-          search.fetch_response
+        def fetch_page(path, kind, page)
+          payload =
+            case kind
+            when :movie
+              client::Movie.upcoming(page)
+            when :tv
+              client::TV.on_the_air(page)
+            else
+              raise ArgumentError, "Unsupported kind: #{kind}"
+            end
+
+          payload
         rescue StandardError => e
           report_error(e, "Calendar TMDB fetch failed for #{path}")
           nil


### PR DESCRIPTION
## Summary
- refactor the TMDB calendar provider to rely on the themoviedb gem client and configure language/region on initialization
- fetch upcoming movies and on-the-air shows through gem search endpoints with detail lookups while preserving normalized entry structure
- guard against over-fetching by honoring limits and delegating error reporting through the provider speaker

## Testing
- bundle exec rake test *(fails: existing suite reports 1 failure and 6 errors unrelated to this change)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e1f9cba98832793519ec3e1f3e4d8)