### PR TITLE
Add artwork metadata to calendar entries

### DIFF
--- a/app/calendar_entries_repository.rb
+++ b/app/calendar_entries_repository.rb
@@ -138,6 +138,8 @@ class CalendarEntriesRepository
     genres = normalize_list(row[:genres] || row['genres'])
     languages = normalize_list(row[:languages] || row['languages'])
     countries = normalize_list(row[:countries] || row['countries'])
+    poster_url = normalize_url(row[:poster_url] || row['poster_url'])
+    backdrop_url = normalize_url(row[:backdrop_url] || row['backdrop_url'])
     ids = normalize_ids(row[:ids] || row['ids'])
     ids = build_default_ids(row, ids) if ids.empty?
 
@@ -154,6 +156,8 @@ class CalendarEntriesRepository
       release_date: release_date,
       downloaded: !!(row[:downloaded] || row['downloaded']),
       in_interest_list: !!(row[:in_interest_list] || row['in_interest_list']),
+      poster_url: poster_url,
+      backdrop_url: backdrop_url,
       ids: ids,
       source: (row[:source] || row['source']).to_s,
       external_id: (row[:external_id] || row['external_id']).to_s
@@ -180,6 +184,11 @@ class CalendarEntriesRepository
     else
       []
     end
+  end
+
+  def normalize_url(value)
+    url = value.to_s.strip
+    url.empty? ? nil : url
   end
 
   def parse_rating(value)

--- a/app/web/app.css
+++ b/app/web/app.css
@@ -548,10 +548,43 @@ button:disabled {
   background: rgba(255, 255, 255, 0.04);
   border: 1px solid rgba(255, 255, 255, 0.12);
   display: grid;
-  gap: 0.35rem;
+  grid-template-columns: 110px 1fr;
+  gap: 0.75rem;
+  align-items: stretch;
 }
 
-.calendar-item header {
+.calendar-media {
+  border-radius: 0.75rem;
+  overflow: hidden;
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.18), rgba(255, 255, 255, 0.06));
+  min-height: 150px;
+}
+
+.calendar-media img {
+  width: 100%;
+  height: 100%;
+  display: block;
+  object-fit: cover;
+}
+
+.calendar-media-fallback {
+  width: 100%;
+  height: 100%;
+  display: grid;
+  place-items: center;
+  color: #cbd5e1;
+  font-weight: 700;
+  font-size: 1.5rem;
+  letter-spacing: 0.02em;
+}
+
+.calendar-body {
+  display: grid;
+  gap: 0.35rem;
+  align-content: start;
+}
+
+.calendar-body header {
   display: flex;
   justify-content: space-between;
   align-items: baseline;

--- a/app/web/app.js
+++ b/app/web/app.js
@@ -1273,9 +1273,29 @@ function renderCalendar(data = {}) {
         const item = document.createElement('article');
         item.className = 'calendar-item';
 
+        const titleText = pickEntryValue(entry, ['title', 'name']) || 'Titre inconnu';
+        const mediaUrl = pickEntryValue(entry, ['poster_url', 'poster', 'backdrop_url', 'backdrop']);
+        const media = document.createElement('div');
+        media.className = 'calendar-media';
+        if (mediaUrl) {
+          const img = document.createElement('img');
+          img.loading = 'lazy';
+          img.src = mediaUrl;
+          img.alt = `${titleText} - visuel`;
+          media.appendChild(img);
+        } else {
+          const placeholder = document.createElement('div');
+          placeholder.className = 'calendar-media-fallback';
+          placeholder.textContent = titleText.charAt(0) || '?';
+          media.appendChild(placeholder);
+        }
+
+        const body = document.createElement('div');
+        body.className = 'calendar-body';
+
         const header = document.createElement('header');
         const titleEl = document.createElement('h4');
-        titleEl.textContent = pickEntryValue(entry, ['title', 'name']) || 'Titre inconnu';
+        titleEl.textContent = titleText;
         const dateLabel = document.createElement('span');
         dateLabel.className = 'calendar-meta';
         dateLabel.textContent = date
@@ -1286,7 +1306,7 @@ function renderCalendar(data = {}) {
             }).format(date)
           : 'Date inconnue';
         header.append(titleEl, dateLabel);
-        item.appendChild(header);
+        body.appendChild(header);
 
         const badges = document.createElement('div');
         badges.className = 'calendar-badges';
@@ -1309,7 +1329,7 @@ function renderCalendar(data = {}) {
           badges.appendChild(makeCalendarBadge("Dans la liste d’intérêt"));
         }
         if (badges.childElementCount) {
-          item.appendChild(badges);
+          body.appendChild(badges);
         }
 
         const metaSegments = [];
@@ -1325,7 +1345,7 @@ function renderCalendar(data = {}) {
           const meta = document.createElement('div');
           meta.className = 'calendar-meta';
           meta.textContent = metaSegments.join(' · ');
-          item.appendChild(meta);
+          body.appendChild(meta);
         }
 
         if (!isInWatchlist(entry)) {
@@ -1336,9 +1356,10 @@ function renderCalendar(data = {}) {
           button.textContent = 'Ajouter à la liste d’intérêt';
           button.addEventListener('click', () => addToWatchlist(entry, button));
           actions.appendChild(button);
-          item.appendChild(actions);
+          body.appendChild(actions);
         }
 
+        item.append(media, body);
         list.appendChild(item);
       });
 

--- a/lib/db/migrations/004_add_calendar_artwork.rb
+++ b/lib/db/migrations/004_add_calendar_artwork.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:calendar_entries) do
+      add_column :poster_url, String, size: 500
+      add_column :backdrop_url, String, size: 500
+    end
+  end
+end

--- a/test/services/calendar_feed_service_test.rb
+++ b/test/services/calendar_feed_service_test.rb
@@ -65,6 +65,7 @@ class CalendarFeedServiceTest < Minitest::Test
     assert_equal 'movie', rows.first[:media_type]
     assert_equal 'Test Show', rows.last[:title]
     assert_equal %w[en fr], rows.last[:languages]
+    assert_equal 'https://example.test/poster.jpg', rows.first[:poster_url]
   end
 
   def test_refresh_replaces_duplicates
@@ -373,6 +374,8 @@ class CalendarFeedServiceTest < Minitest::Test
       languages: ['en'],
       countries: ['US'],
       rating: 7.1,
+      poster_url: 'https://example.test/poster.jpg',
+      backdrop_url: 'https://example.test/backdrop.jpg',
       release_date: Date.today + 1
     }
   end
@@ -389,6 +392,8 @@ class CalendarFeedServiceTest < Minitest::Test
       Text :genres
       Text :languages
       Text :countries
+      String :poster_url, size: 500
+      String :backdrop_url, size: 500
       Float :rating
       Date :release_date
       DateTime :created_at


### PR DESCRIPTION
## Summary
- store poster and backdrop URLs from calendar providers and persist them via a new migration
- surface artwork through calendar entries and API serialization for consumer use
- render artwork thumbnails with fallbacks in the web calendar layout and adjust styling

## Testing
- bundle exec rake test *(fails: existing application test failures unrelated to this change)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ebc5dbc74832798c193027d558d68)