### PR TITLE
Fix TMDB calendar fetch pagination

### DIFF
--- a/app/media_librarian/services/calendar_feed_service.rb
+++ b/app/media_librarian/services/calendar_feed_service.rb
@@ -375,18 +375,10 @@ module MediaLibrarian
           results
         end
 
-        def fetch_page(path, kind, page)
-          payload =
-            case kind
-            when :movie
-              client::Movie.upcoming(page)
-            when :tv
-              client::TV.on_the_air(page)
-            else
-              raise ArgumentError, "Unsupported kind: #{kind}"
-            end
-
-          payload
+        def fetch_page(path, _kind, page)
+          search = client::Search.new(path)
+          search.filter(page: page) if page
+          search.fetch_response
         rescue StandardError => e
           report_error(e, "Calendar TMDB fetch failed for #{path}")
           nil


### PR DESCRIPTION
## Summary
- switch TMDB calendar page fetches to use the Search API with query pagination
- remove reliance on missing `TV.on_the_air` helper while keeping movie and TV calendar requests aligned with supported endpoints

## Testing
- bundle exec rake test *(fails: existing suite errors including Zeitwerk conflicting directory setup and DaemonQueueConcurrencyTest expectation)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ecc100c5c8327b6eb652e32c33257)