### PR TITLE
Handle Trakt calendar endpoints safely

### DIFF
--- a/lib/trakt_agent.rb
+++ b/lib/trakt_agent.rb
@@ -29,6 +29,8 @@ class TraktAgent
     calendars_client = MediaLibrarian.app.trakt
     if calendars_client&.respond_to?(:calendars)
       calendars = calendars_client.calendars
+      all_method = "all_#{type}".to_sym
+      return calendars.public_send(all_method, start_date, days) if calendars.respond_to?(all_method)
       return calendars.public_send(type, start_date, days) if calendars.respond_to?(type)
     end
 

--- a/lib/trakt_agent.rb
+++ b/lib/trakt_agent.rb
@@ -1,4 +1,15 @@
+require 'json'
+require 'net/http'
+
 class TraktAgent
+  def self.calendars__all_movies(start_date, days)
+    fetch_calendar_entries(:movies, start_date, days)
+  end
+
+  def self.calendars__all_shows(start_date, days)
+    fetch_calendar_entries(:shows, start_date, days)
+  end
+
   def self.method_missing(name, *args)
     segments = name.to_s.split('__')
     return unless segments[0] && segments[1]
@@ -12,5 +23,47 @@ class TraktAgent
     target.public_send(segments[1], *args)
   rescue StandardError => e
     MediaLibrarian.app.speaker.tell_error(e, "TraktAgent.#{name}")
+  end
+
+  def self.fetch_calendar_entries(type, start_date, days)
+    calendars_client = MediaLibrarian.app.trakt
+    if calendars_client&.respond_to?(:calendars)
+      calendars = calendars_client.calendars
+      return calendars.public_send(type, start_date, days) if calendars.respond_to?(type)
+    end
+
+    if calendars_client&.respond_to?(:calendar)
+      return calendars_client.calendar(type: type.to_s.delete_suffix('s'), start_date: start_date, days: days) rescue nil
+    end
+
+    fetch_calendar_from_http(type, start_date, days)
+  rescue StandardError => e
+    MediaLibrarian.app.speaker.tell_error(e, "TraktAgent.calendars__#{type}")
+    nil
+  end
+
+  def self.fetch_calendar_from_http(type, start_date, days)
+    config = MediaLibrarian.app.config['trakt'] || {}
+    client_id = config['client_id'].to_s
+    access_token = config['access_token'].to_s
+    return nil if client_id.empty?
+
+    uri = URI("https://api.trakt.tv/calendars/all/#{type}/#{start_date.strftime('%Y-%m-%d')}/#{days}")
+    request = Net::HTTP::Get.new(uri)
+    request['Content-Type'] = 'application/json'
+    request['trakt-api-version'] = '2'
+    request['trakt-api-key'] = client_id
+    request['Authorization'] = "Bearer #{access_token}" unless access_token.empty?
+
+    response = Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
+      http.request(request)
+    end
+
+    return nil unless response.is_a?(Net::HTTPSuccess)
+
+    JSON.parse(response.body)
+  rescue StandardError => e
+    MediaLibrarian.app.speaker.tell_error(e, "TraktAgent.calendar_http_#{type}")
+    nil
   end
 end


### PR DESCRIPTION
## Summary
- add explicit Trakt calendar fetchers that use available client resources or HTTP fallbacks and return nil on failure
- ensure calendar fetches surface array responses instead of raising when Trakt resources are missing
- update calendar feed tests to stub the new calendar fetch methods

## Testing
- bundle exec ruby -Itest test/services/calendar_feed_service_test.rb

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ef2dde8988327a06a1ce1e5404fa7)