### PR TITLE
Handle TMDB pagination via API request

### DIFF
--- a/app/media_librarian/services/calendar_feed_service.rb
+++ b/app/media_librarian/services/calendar_feed_service.rb
@@ -393,13 +393,15 @@ module MediaLibrarian
         end
 
         def fetch_page(path, kind, page)
-          case kind
-          when :movie
-            return client::Movie.upcoming(page) if client.const_defined?(:Movie) &&
-                                                   client::Movie.respond_to?(:upcoming)
-          when :tv
-            return client::TV.on_the_air(page) if client.const_defined?(:TV) &&
-                                                 client::TV.respond_to?(:on_the_air)
+          if page.to_i == 1
+            case kind
+            when :movie
+              return client::Movie.upcoming if client.const_defined?(:Movie) &&
+                                               client::Movie.respond_to?(:upcoming)
+            when :tv
+              return client::TV.on_the_air if client.const_defined?(:TV) &&
+                                               client::TV.respond_to?(:on_the_air)
+            end
           end
 
           params = { page: page }.compact


### PR DESCRIPTION
## Summary
- avoid passing page params into TMDB helper methods and rely on API requests for pagination
- add coverage ensuring TMDB calendar pagination works for both movies and shows

## Testing
- bundle exec ruby -Itest test/services/calendar_feed_service_test.rb

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922f501fff883278764f48865ee95f6)