### PR TITLE
Make Trakt CRL validation opt-in

### DIFF
--- a/config/conf.yml.example
+++ b/config/conf.yml.example
@@ -43,7 +43,8 @@ trakt:
   client_id: client_id
   client_secret: client_secret
   ca_path: /path/to/ca-certificates # Optional override; defaults to system trust store
-  disable_crl_checks: false # Set to true only if your environment lacks CRL support
+  enable_crl_checks: false # Opt-in CRL checking; will fall back if unsupported
+  disable_crl_checks: false # Legacy override to forcefully disable CRL checks
 tmdb:
   api_key: api_key
 tvdb:


### PR DESCRIPTION
## Summary
- make Trakt CRL validation opt-in with a warning-based fallback when unavailable
- add configuration guidance for enabling or disabling CRL checks
- expand calendar HTTP tests to cover SSL negotiation with CRL checks enabled and disabled

## Testing
- bundle exec ruby -Itest test/lib/trakt_agent_test.rb

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926ee44263483279cf4e935ebc1d80f)