### PR TITLE
Refactor Trakt calendar fetching

### DIFF
--- a/test/support/container_helpers.rb
+++ b/test/support/container_helpers.rb
@@ -37,6 +37,8 @@ module TestSupport
                   :env_flags, :config_dir, :config_file, :config_example,
                   :tracker_dir, :api_config_file
 
+      attr_accessor :trakt
+
       def initialize(root:, speaker:, args_dispatch:)
         @root = root
         @loader = NullLoader.new


### PR DESCRIPTION
## Summary
- update calendar fetching to rely on the configured Trakt client or an injected fetcher rather than direct HTTP calls
- simplify calendar client resolution and remove custom SSL/HTTP fallback logic
- adjust test helpers and add coverage to ensure calendar retrieval uses the client abstraction

## Testing
- bundle exec ruby -Itest test/lib/trakt_agent_test.rb

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926fccdc21c83279a86fb5d9e9fe984)