### PR TITLE
Fix Trakt calendar invocation pattern

### DIFF
--- a/lib/trakt_agent.rb
+++ b/lib/trakt_agent.rb
@@ -32,7 +32,13 @@ class TraktAgent
       return calendars.public_send(type, start_date, days) if calendars.respond_to?(type)
     end
 
-    return calendars_client.calendar(type: type.to_s.delete_suffix('s'), start_date: start_date, days: days) if calendars_client&.respond_to?(:calendar)
+    calendar = calendars_client&.respond_to?(:calendar) ? calendars_client.calendar : nil
+
+    if calendar
+      all_method = "all_#{type}".to_sym
+      return calendar.public_send(all_method, start_date, days) if calendar.respond_to?(all_method)
+      return calendar.public_send(type, start_date, days) if calendar.respond_to?(type)
+    end
   rescue StandardError => e
     MediaLibrarian.app.speaker.tell_error(e, "TraktAgent.calendars__#{type}")
     nil


### PR DESCRIPTION
## Summary
- update Trakt calendar fetcher to call the calendar client then the type-specific method to avoid argument errors
- adjust calendar-related tests to match the corrected invocation pattern

## Testing
- bundle exec ruby -Itest test/lib/trakt_agent_test.rb


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927117cc4208327b99ceebc5605a0b2)