### PR TITLE
Handle TMDB fallback when on_the_air is unavailable

### DIFF
--- a/app/media_librarian/services/calendar_feed_service.rb
+++ b/app/media_librarian/services/calendar_feed_service.rb
@@ -395,18 +395,25 @@ module MediaLibrarian
         end
 
         def fetch_page(path, kind, page)
+          params = { page: page }.compact
+
           if page.to_i == 1
-            case kind
-            when :movie
-              return client::Movie.upcoming if client.const_defined?(:Movie) &&
-                                               client::Movie.respond_to?(:upcoming)
-            when :tv
-              return client::TV.on_the_air if client.const_defined?(:TV) &&
-                                               client::TV.respond_to?(:on_the_air)
-            end
+            first_page =
+              begin
+                case kind
+                when :movie
+                  client::Movie.upcoming if client.const_defined?(:Movie) &&
+                                            client::Movie.respond_to?(:upcoming)
+                when :tv
+                  client::TV.on_the_air if client.const_defined?(:TV) &&
+                                           client::TV.respond_to?(:on_the_air)
+                end
+              rescue StandardError
+                nil
+              end
+            return first_page if first_page
           end
 
-          params = { page: page }.compact
           if client.const_defined?(:Api) && client::Api.respond_to?(:request)
             return client::Api.request(path, params)
           end


### PR DESCRIPTION
## Summary
- adjust CalendarFeedService TMDB fetch logic to attempt Api.request when the first-page shortcut is unavailable
- guard the first-page calls so missing on_the_air doesn’t raise before the fallback runs

## Testing
- bundle exec rake test *(fails: existing Zeitwerk loader conflict in TorrentRssTest)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69271198beb883278b2fd5f0ad8d5440)