### PR TITLE
Add logging around calendar feed refresh

### DIFF
--- a/app/calendar_feed.rb
+++ b/app/calendar_feed.rb
@@ -26,6 +26,12 @@ class CalendarFeed
       today = Date.today
       date_range = (today - past_days)..(today + future_days)
 
+      speaker = app.respond_to?(:speaker) ? app.speaker : nil
+      sources_label = provider_list ? provider_list.join(',') : 'all'
+      speaker&.speak_up(
+        "Refreshing calendar feed (past: #{past_days}d, future: #{future_days}d, limit: #{max_entries}, sources: #{sources_label})"
+      )
+
       calendar_service.refresh(date_range: date_range, limit: max_entries, sources: provider_list)
     end
   end

--- a/app/media_librarian/services/calendar_feed_service.rb
+++ b/app/media_librarian/services/calendar_feed_service.rb
@@ -20,7 +20,9 @@ module MediaLibrarian
         return [] unless calendar_table_available?
 
         normalized = collect_entries(date_range, limit, normalize_sources(sources))
+        speaker.speak_up("Calendar feed collected #{normalized.length} items")
         persist_entries(normalized)
+        speaker.speak_up("Calendar feed persisted #{normalized.length} items")
         normalized
       end
 

--- a/test/services/calendar_feed_service_test.rb
+++ b/test/services/calendar_feed_service_test.rb
@@ -68,6 +68,19 @@ class CalendarFeedServiceTest < Minitest::Test
     assert_equal 'https://example.test/poster.jpg', rows.first[:poster_url]
   end
 
+  def test_refresh_logs_collection_and_persistence_counts
+    provider = FakeProvider.new([
+      base_entry.merge(external_id: 'movie-1', title: 'Logged Movie')
+    ])
+
+    service = MediaLibrarian::Services::CalendarFeedService.new(app: nil, speaker: @speaker, db: @db, providers: [provider])
+
+    service.refresh(date_range: Date.today..(Date.today + 1), limit: 5)
+
+    assert_includes @speaker.messages, 'Calendar feed collected 1 items'
+    assert_includes @speaker.messages, 'Calendar feed persisted 1 items'
+  end
+
   def test_refresh_replaces_duplicates
     initial_provider = FakeProvider.new([
       base_entry.merge(external_id: 'movie-1', title: 'First Title', rating: 6.4)


### PR DESCRIPTION
## Summary
- log the calendar refresh window, limits, and sources before dispatching refreshes
- emit concise collection and persistence counts in CalendarFeedService and cover the behavior with tests
- ensure logging expectations are captured in calendar feed unit coverage

## Testing
- bundle exec ruby -Itest test/app/calendar_feed_test.rb
- bundle exec ruby -Itest test/services/calendar_feed_service_test.rb

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929865a4f38832795ee57f7735cb476)