### PR TITLE
Initialize speaker logging to default files

### DIFF
--- a/lib/logger.rb
+++ b/lib/logger.rb
@@ -4,9 +4,17 @@ require 'rbconfig'
 require File.join(RbConfig::CONFIG.fetch('rubylibdir'), 'logger')
 
 class Logger
+  def self.log_paths(log_dir)
+    [
+      File.join(log_dir, 'medialibrarian.log'),
+      File.join(log_dir, 'medialibrarian_errors.log')
+    ]
+  end
+
   def self.renew_logs(log_dir)
-    FileUtils.mv(log_dir + '/medialibrarian.log', log_dir + "/medialibrarian.log.old.#{DateTime.now.strftime('%Y.%m.%d_%H.%M.%S')}") if File.exist?(log_dir + '/medialibrarian.log')
-    FileUtils.mv(log_dir + '/medialibrarian_errors.log', log_dir + "/medialibrarian_errors.log.old.#{DateTime.now.strftime('%Y.%m.%d_%H.%M.%S')}") if File.exist?(log_dir + '/medialibrarian_errors.log')
-    MediaLibrarian.app.speaker = SimpleSpeaker::Speaker.new(log_dir + '/medialibrarian.log', log_dir + '/medialibrarian_errors.log')
+    log_path, error_log_path = log_paths(log_dir)
+    FileUtils.mv(log_path, "#{log_path}.old.#{DateTime.now.strftime('%Y.%m.%d_%H.%M.%S')}") if File.exist?(log_path)
+    FileUtils.mv(error_log_path, "#{error_log_path}.old.#{DateTime.now.strftime('%Y.%m.%d_%H.%M.%S')}") if File.exist?(error_log_path)
+    MediaLibrarian.app.speaker = SimpleSpeaker::Speaker.new(log_path, error_log_path)
   end
 end

--- a/lib/media_librarian/container.rb
+++ b/lib/media_librarian/container.rb
@@ -6,6 +6,7 @@ require 'io/console'
 
 require_relative '../simple_speaker'
 require_relative '../simple_args_dispatch' unless defined?(SimpleArgsDispatch)
+require_relative '../logger'
 
 require_relative '../storage/db' unless defined?(Storage::Db)
 require_relative '../torznab_tracker' unless defined?(TorznabTracker)
@@ -125,7 +126,9 @@ module MediaLibrarian
                                                   application.config_file,
                                                   application.config_example))
 
-      store(:speaker, SimpleSpeaker::Speaker.new, freeze: false)
+      log_dir = File.join(application.config_dir, 'log')
+      log_path, error_log_path = Logger.log_paths(log_dir)
+      store(:speaker, SimpleSpeaker::Speaker.new(log_path, error_log_path), freeze: false)
       store(:args_dispatch, SimpleArgsDispatch::Agent.new(speaker, application.env_flags), freeze: false)
 
       store(:db, Storage::Db.new(File.join(application.config_dir, 'librarian.db')), freeze: false)


### PR DESCRIPTION
## Summary
- add a helper to share default log file paths for the logger
- initialize the container speaker with file-backed logging using the shared paths

## Testing
- bundle exec rake test *(fails: DaemonQueueConcurrencyTest#test_enqueue_retries_until_executor_accepts_job; run interrupted after failure)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a2275b2d4832794dead597d80cb2c)