### PR TITLE
Handle TMDB calendar fetch fallbacks

### DIFF
--- a/app/media_librarian/services/calendar_feed_service.rb
+++ b/app/media_librarian/services/calendar_feed_service.rb
@@ -3,6 +3,8 @@
 require 'date'
 require 'themoviedb'
 require 'imdb_party'
+require 'json'
+require 'net/http'
 
 module MediaLibrarian
   module Services
@@ -427,14 +429,21 @@ module MediaLibrarian
             end
           end
 
-          if client.const_defined?(:Api) && client::Api.respond_to?(:request)
-            return client::Api.request(path, params)
-          end
+          return client::Api.request(path, params) if client.const_defined?(:Api) && client::Api.respond_to?(:request)
 
-          raise ArgumentError, "Unsupported TMDB fetch for #{path}"
+          http_request(path, params)
         rescue StandardError => e
           report_error(e, "Calendar TMDB fetch failed for #{path}")
           nil
+        end
+
+        def http_request(path, params)
+          uri = URI("https://api.themoviedb.org/3#{path}")
+          query = params.merge(api_key: @api_key, language: language, region: region).compact
+          uri.query = URI.encode_www_form(query)
+
+          response = Net::HTTP.get_response(uri)
+          response.is_a?(Net::HTTPSuccess) ? JSON.parse(response.body) : nil
         end
 
         def release_from(item, kind)

--- a/test/services/calendar_feed_service_test.rb
+++ b/test/services/calendar_feed_service_test.rb
@@ -386,6 +386,22 @@ class CalendarFeedServiceTest < Minitest::Test
     assert_equal [['/tv/on_the_air', { page: 2 }]], client::Api.requests
   end
 
+  def test_tmdb_fetch_page_uses_http_fallback_for_discover_paths
+    client = Module.new
+    provider = MediaLibrarian::Services::CalendarFeedService::TmdbCalendarProvider.new(
+      api_key: '123', language: 'en', region: 'US', speaker: @speaker, client: client
+    )
+
+    query = { page: 1, 'primary_release_date.gte' => Date.today.to_s }
+    calls = []
+
+    provider.stub(:http_request, ->(path, params) { calls << [path, params]; { 'results' => [] } }) do
+      provider.send(:fetch_page, '/discover/movie', :movie, 1, query.dup)
+    end
+
+    assert_equal [['/discover/movie', query]], calls
+  end
+
   def test_tmdb_fetch_titles_accepts_array_payloads_without_total_pages
     client = Module.new do
       movie_mod = Module.new do


### PR DESCRIPTION
## Summary
- add TMDB HTTP fallback when helper methods are unavailable for discover and tv calendar paths
- use a minimal HTTP request path when low-level API requests are not exposed
- cover the new fallback behavior with a dedicated test

## Testing
- bundle exec ruby -Itest test/services/calendar_feed_service_test.rb


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b3b2a1e208327a9d8015d6a1c0d4e)