### PR TITLE
Switch client requests to HTTParty

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'bcrypt', :require => false
 gem 'fuzzy-string-match', :require => false
 gem 'get_process_mem', :require => false
 gem 'hanami-mailer', :require => false
+gem 'httparty', :require => false
 gem 'imdb_party', :git => 'https://github.com/raphyduck/imdb-party.git', :require => false
 gem 'mechanize', :require => false
 gem 'mediainfo', :git => 'https://github.com/raphyduck/mediainfo.git', :require => false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -262,6 +262,7 @@ DEPENDENCIES
   fuzzy-string-match
   get_process_mem
   hanami-mailer
+  httparty
   imdb_party!
   logger (< 1.6)
   mechanize


### PR DESCRIPTION
## Summary
- add the httparty dependency and configure the client with API base URI and SSL settings
- refactor client requests to use HTTParty with centralized headers, timeouts, and token handling
- keep existing response parsing and connection error mapping to the 503 error structure

## Testing
- bundle exec rake test *(fails: existing suite reports 2 failures and 5 errors unrelated to client changes)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d667acfe08327adea7ad31d80746a)