### PR TITLE
Improve dashboard mobile layout

### DIFF
--- a/app/web/app.css
+++ b/app/web/app.css
@@ -632,3 +632,140 @@ button:disabled {
 .calendar-actions-row button {
   margin-left: auto;
 }
+
+@media (max-width: 640px) {
+  body {
+    padding: 0 1rem 3rem;
+  }
+
+  header {
+    padding: 1.5rem 0 0.75rem;
+  }
+
+  header h1 {
+    font-size: 2rem;
+  }
+
+  .subtitle {
+    font-size: 0.95rem;
+  }
+
+  main {
+    gap: 1rem;
+  }
+
+  .tabs {
+    overflow-x: auto;
+    flex-wrap: nowrap;
+    padding: 0 0.25rem;
+    margin: 0 -0.25rem;
+    scrollbar-gutter: stable;
+  }
+
+  .tab-button {
+    flex: 0 0 auto;
+    padding: 0.45rem 1rem;
+    font-size: 0.95rem;
+  }
+
+  .panel {
+    padding: 1rem;
+  }
+
+  .panel-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .panel-header h2 {
+    font-size: 1.15rem;
+  }
+
+  .panel-tools,
+  .actions,
+  .calendar-actions {
+    width: 100%;
+    flex-wrap: wrap;
+  }
+
+  .jobs-columns {
+    grid-template-columns: 1fr !important;
+  }
+
+  .job-item header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.35rem;
+  }
+
+  .calendar-filters,
+  .download-list-form .grid {
+    grid-template-columns: 1fr;
+  }
+
+  .calendar-items {
+    grid-template-columns: 1fr;
+  }
+
+  .calendar-item {
+    grid-template-columns: 1fr;
+  }
+
+  .calendar-window-tools {
+    width: 100%;
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .download-list-table .table-wrapper {
+    overflow: visible;
+  }
+
+  .download-list-table table {
+    min-width: 0;
+  }
+
+  .download-list-table thead {
+    display: none;
+  }
+
+  .download-list-table tbody {
+    display: grid;
+    gap: 0.75rem;
+  }
+
+  .download-list-table tr {
+    display: grid;
+    gap: 0.35rem;
+    padding: 0.75rem;
+    border-radius: 0.9rem;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    background: rgba(15, 23, 42, 0.6);
+  }
+
+  .download-list-table td {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0;
+    border: none;
+  }
+
+  .download-list-table td::before {
+    content: attr(data-label);
+    color: var(--muted);
+    font-weight: 600;
+    font-size: 0.85rem;
+  }
+
+  .download-list-table td a {
+    word-break: break-all;
+  }
+
+  .download-list-table .actions-cell {
+    justify-content: flex-end;
+  }
+}

--- a/app/web/app.js
+++ b/app/web/app.js
@@ -1500,6 +1500,8 @@ function renderDownloadList(entries = []) {
   }
   emptyHint.classList.add('hidden');
 
+  const labels = ['Titre', 'Type', 'Année', 'IMDB', 'TMDB', 'URL'];
+
   normalized.forEach((entry) => {
     const row = document.createElement('tr');
     const title = entry.title || entry['title'] || '';
@@ -1518,8 +1520,9 @@ function renderDownloadList(entries = []) {
       url ? { link: url } : { text: '—' },
     ];
 
-    cells.forEach((value) => {
+    cells.forEach((value, index) => {
       const cell = document.createElement('td');
+      cell.dataset.label = labels[index];
       if (value.link) {
         const link = document.createElement('a');
         link.href = value.link;
@@ -1534,6 +1537,8 @@ function renderDownloadList(entries = []) {
     });
 
     const actionsCell = document.createElement('td');
+    actionsCell.className = 'actions-cell';
+    actionsCell.dataset.label = 'Actions';
     const removeButton = document.createElement('button');
     removeButton.type = 'button';
     removeButton.textContent = 'Supprimer';


### PR DESCRIPTION
## Summary
- add mobile media query to simplify padding, stack columns, and enable tab header scrolling on narrow screens
- convert the download list table into card-style rows with labels for small viewports
- ensure download row data is labeled in markup for responsive presentation

## Testing
- python -m http.server 8000

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d6c020d408327a2ec2da5f35e4aa0)