### PR TITLE
Add imdb votes to calendar entries

### DIFF
--- a/app/calendar_entries_repository.rb
+++ b/app/calendar_entries_repository.rb
@@ -153,6 +153,7 @@ class CalendarEntriesRepository
       language: languages.find { |lang| !lang.to_s.empty? },
       country: countries.find { |country| !country.to_s.empty? },
       imdb_rating: parse_rating(row[:rating] || row['rating']),
+      imdb_votes: parse_integer(row[:imdb_votes] || row['imdb_votes']),
       release_date: release_date,
       downloaded: !!(row[:downloaded] || row['downloaded']),
       in_interest_list: !!(row[:in_interest_list] || row['in_interest_list']),
@@ -195,6 +196,12 @@ class CalendarEntriesRepository
     return nil if value.nil? || value.to_s.strip.empty?
 
     value.to_f
+  end
+
+  def parse_integer(value)
+    return nil if value.nil? || value.to_s.strip.empty?
+
+    value.to_i
   end
 
   def parse_time(value)

--- a/lib/db/migrations/006_add_imdb_votes_to_calendar_entries.rb
+++ b/lib/db/migrations/006_add_imdb_votes_to_calendar_entries.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'json'
+
+Sequel.migration do
+  up do
+    alter_table(:calendar_entries) do
+      add_column :imdb_votes, Integer
+    end
+
+    self[:calendar_entries].each do |row|
+      raw_ids = row[:ids]
+      next if raw_ids.to_s.strip.empty?
+
+      votes = begin
+        parsed = JSON.parse(raw_ids)
+        parsed['imdb_votes'] || parsed['votes']
+      rescue StandardError
+        nil
+      end
+
+      next unless votes
+
+      self[:calendar_entries].where(id: row[:id]).update(imdb_votes: votes.to_i)
+    end
+  end
+
+  down do
+    alter_table(:calendar_entries) do
+      drop_column :imdb_votes
+    end
+  end
+end

--- a/test/services/calendar_feed_service_test.rb
+++ b/test/services/calendar_feed_service_test.rb
@@ -66,6 +66,7 @@ class CalendarFeedServiceTest < Minitest::Test
     assert_equal 'Test Show', rows.last[:title]
     assert_equal %w[en fr], rows.last[:languages]
     assert_equal 'https://example.test/poster.jpg', rows.first[:poster_url]
+    assert_equal 321, rows.first[:imdb_votes]
   end
 
   def test_refresh_logs_collection_and_persistence_counts
@@ -83,13 +84,13 @@ class CalendarFeedServiceTest < Minitest::Test
 
   def test_refresh_replaces_duplicates
     initial_provider = FakeProvider.new([
-      base_entry.merge(external_id: 'movie-1', title: 'First Title', rating: 6.4)
+      base_entry.merge(external_id: 'movie-1', title: 'First Title', rating: 6.4, imdb_votes: 10)
     ])
     service = MediaLibrarian::Services::CalendarFeedService.new(app: nil, speaker: @speaker, db: @db, providers: [initial_provider])
     service.refresh(date_range: Date.today..(Date.today + 3), limit: 5)
 
     updated_provider = FakeProvider.new([
-      base_entry.merge(external_id: 'movie-1', title: 'First Title', rating: 8.2, languages: ['fr'])
+      base_entry.merge(external_id: 'movie-1', title: 'First Title', rating: 8.2, languages: ['fr'], imdb_votes: 12)
     ])
     service = MediaLibrarian::Services::CalendarFeedService.new(app: nil, speaker: @speaker, db: @db, providers: [updated_provider])
     service.refresh(date_range: Date.today..(Date.today + 3), limit: 5)
@@ -98,6 +99,7 @@ class CalendarFeedServiceTest < Minitest::Test
     assert_equal 1, rows.count
     assert_in_delta 8.2, rows.first[:rating]
     assert_equal ['fr'], rows.first[:languages]
+    assert_equal 12, rows.first[:imdb_votes]
   end
 
   def test_refresh_filters_to_requested_sources
@@ -237,7 +239,7 @@ class CalendarFeedServiceTest < Minitest::Test
         'genres' => { 'genres' => [{ 'text' => 'Drama' }] },
         'spokenLanguages' => [{ 'text' => 'English' }],
         'countriesOfOrigin' => [{ 'text' => 'United States' }],
-        'ratingsSummary' => { 'aggregateRating' => 9.3 }
+        'ratingsSummary' => { 'aggregateRating' => 9.3, 'voteCount' => 123_456 }
       },
       {
         'id' => 'tt7654321',
@@ -247,7 +249,7 @@ class CalendarFeedServiceTest < Minitest::Test
         'genres' => { 'genres' => [{ 'text' => 'Sci-Fi' }] },
         'spokenLanguages' => [{ 'text' => 'French' }],
         'countriesOfOrigin' => [{ 'text' => 'Canada' }],
-        'ratingsSummary' => { 'aggregateRating' => 7.5 }
+        'ratingsSummary' => { 'aggregateRating' => 7.5, 'voteCount' => 6_789 }
       }
     ]
 
@@ -277,10 +279,12 @@ class CalendarFeedServiceTest < Minitest::Test
     assert_equal ['Drama'], rows.first[:genres]
     assert_equal ['English'], rows.first[:languages]
     assert_equal ['United States'], rows.first[:countries]
+    assert_equal 123_456, rows.first[:imdb_votes]
     assert_equal 'show', rows.last[:media_type]
     assert_equal ['Sci-Fi'], rows.last[:genres]
     assert_equal ['French'], rows.last[:languages]
     assert_equal ['Canada'], rows.last[:countries]
+    assert_equal 6_789, rows.last[:imdb_votes]
   end
 
   def test_imdb_provider_falls_back_to_tmdb_when_feed_empty
@@ -323,7 +327,8 @@ class CalendarFeedServiceTest < Minitest::Test
           'genres' => ['drama'],
           'language' => 'en',
           'country' => 'us',
-          'rating' => 7.3
+          'rating' => 7.3,
+          'votes' => 50
         }
       }
     ]
@@ -336,7 +341,8 @@ class CalendarFeedServiceTest < Minitest::Test
           'genres' => ['sci-fi'],
           'language' => 'en',
           'country' => 'gb',
-          'rating' => 8.1
+          'rating' => 8.1,
+          'votes' => 75
         }
       }
     ]
@@ -374,6 +380,8 @@ class CalendarFeedServiceTest < Minitest::Test
     assert_equal 555, movie[:ids][:tmdb]
     assert_equal 'trakt-show', show[:ids][:slug]
     assert_equal 2222, show[:ids][:trakt]
+    assert_equal 50, movie[:imdb_votes]
+    assert_equal 75, show[:imdb_votes]
   end
 
   def test_trakt_movies_rejects_non_hash_items
@@ -459,6 +467,7 @@ class CalendarFeedServiceTest < Minitest::Test
             'spoken_languages' => [],
             'origin_country' => [],
             'production_countries' => [],
+            'vote_count' => id * 10,
             'imdb_id' => format('tt%07d', id)
           }
         end
@@ -480,6 +489,7 @@ class CalendarFeedServiceTest < Minitest::Test
       [{ 'tmdb' => 10, 'imdb' => 'tt0000010' }, { 'tmdb' => 11, 'imdb' => 'tt0000011' }],
       results.map { |entry| entry[:ids] }
     )
+    assert_equal [100, 110], results.map { |entry| entry[:imdb_votes] }
   end
 
   def test_tmdb_fetch_titles_accepts_tmdb_model_objects
@@ -504,6 +514,7 @@ class CalendarFeedServiceTest < Minitest::Test
             'spoken_languages' => [],
             'origin_country' => [],
             'production_countries' => [],
+            'vote_count' => id + 1,
             'imdb_id' => format('tt%07d', id)
           }
         end
@@ -529,6 +540,7 @@ class CalendarFeedServiceTest < Minitest::Test
             'spoken_languages' => [],
             'origin_country' => [],
             'production_countries' => [],
+            'vote_count' => id + 2,
             'imdb_id' => format('tt%07d', id)
           }
         end
@@ -552,6 +564,7 @@ class CalendarFeedServiceTest < Minitest::Test
       [{ 'tmdb' => 21, 'imdb' => 'tt0000021' }, { 'tmdb' => 31, 'imdb' => 'tt0000031' }],
       results.map { |entry| entry[:ids] }
     )
+    assert_equal [22, 33], results.map { |entry| entry[:imdb_votes] }
   end
 
   private
@@ -566,6 +579,7 @@ class CalendarFeedServiceTest < Minitest::Test
       languages: ['en'],
       countries: ['US'],
       rating: 7.1,
+      imdb_votes: 321,
       poster_url: 'https://example.test/poster.jpg',
       backdrop_url: 'https://example.test/backdrop.jpg',
       release_date: Date.today + 1
@@ -587,6 +601,7 @@ class CalendarFeedServiceTest < Minitest::Test
       Text :ids
       String :poster_url, size: 500
       String :backdrop_url, size: 500
+      Integer :imdb_votes
       Float :rating
       Date :release_date
       DateTime :created_at


### PR DESCRIPTION
## Summary
- add an imdb_votes column to calendar_entries and attempt to backfill from stored IDs
- extract vote counts from IMDb, TMDB, and Trakt payloads and normalize them into calendar entries
- expose imdb_votes via calendar entry normalization and persistence with updated tests

## Testing
- bundle exec ruby test/services/calendar_feed_service_test.rb
- bundle exec rake test *(fails: existing suite issues including Mechanize cookie handling, Zeitwerk loader conflicts, and daemon connection expectations)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d86e5cf348327be34df4a8a90a355)