### PR TITLE
Add IMDb vote filtering to calendar

### DIFF
--- a/app/calendar_entries_repository.rb
+++ b/app/calendar_entries_repository.rb
@@ -34,6 +34,7 @@ class CalendarEntriesRepository
         type_match?(entry, filters[:type]) &&
         genres_match?(entry, filters[:genres]) &&
         rating_match?(entry, filters[:imdb_min], filters[:imdb_max]) &&
+        votes_match?(entry, filters[:imdb_votes_min], filters[:imdb_votes_max]) &&
         language_match?(entry, filters[:language]) &&
         country_match?(entry, filters[:country]) &&
         flag_match?(entry[:downloaded], filters[:downloaded]) &&
@@ -67,6 +68,15 @@ class CalendarEntriesRepository
 
     min_ok = min_rating.to_s.empty? || rating >= min_rating.to_f
     max_ok = max_rating.to_s.empty? || rating <= max_rating.to_f
+    min_ok && max_ok
+  end
+
+  def votes_match?(entry, min_votes, max_votes)
+    votes = entry[:imdb_votes]
+    return min_votes.to_s.empty? && max_votes.to_s.empty? if votes.nil?
+
+    min_ok = min_votes.to_s.empty? || votes >= min_votes.to_i
+    max_ok = max_votes.to_s.empty? || votes <= max_votes.to_i
     min_ok && max_ok
   end
 

--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -1152,6 +1152,8 @@ class Daemon
         genres: normalize_list_param(req.query['genres']),
         imdb_min: req.query['imdb_min'],
         imdb_max: req.query['imdb_max'],
+        imdb_votes_min: req.query['imdb_votes_min'],
+        imdb_votes_max: req.query['imdb_votes_max'],
         language: req.query['language'],
         country: req.query['country'],
         downloaded: req.query['downloaded'],

--- a/app/web/app.js
+++ b/app/web/app.js
@@ -18,6 +18,8 @@ const state = {
       genres: [],
       ratingMin: '',
       ratingMax: '',
+      votesMin: '',
+      votesMax: '',
       language: '',
       country: '',
     },
@@ -1079,6 +1081,13 @@ function readCalendarFilters() {
   filters.ratingMin = Number.isFinite(ratingMin) ? ratingMin : '';
   filters.ratingMax = Number.isFinite(ratingMax) ? ratingMax : '';
 
+  const votesMinRaw = document.getElementById('calendar-votes-min')?.value || '';
+  const votesMaxRaw = document.getElementById('calendar-votes-max')?.value || '';
+  const votesMin = votesMinRaw === '' ? '' : Number(votesMinRaw);
+  const votesMax = votesMaxRaw === '' ? '' : Number(votesMaxRaw);
+  filters.votesMin = Number.isFinite(votesMin) ? votesMin : '';
+  filters.votesMax = Number.isFinite(votesMax) ? votesMax : '';
+
   filters.language = (document.getElementById('calendar-language')?.value || '').trim();
   filters.country = (document.getElementById('calendar-country')?.value || '').trim();
   return filters;
@@ -1155,6 +1164,14 @@ function entryMatchesFilters(entry, filters) {
     return false;
   }
   if (filters.ratingMax !== '' && rating > filters.ratingMax) {
+    return false;
+  }
+
+  const votes = Number(pickEntryValue(entry, ['imdb_votes', 'votes', 'vote_count']));
+  if (filters.votesMin !== '' && (!Number.isFinite(votes) || votes < filters.votesMin)) {
+    return false;
+  }
+  if (filters.votesMax !== '' && (!Number.isFinite(votes) || votes > filters.votesMax)) {
     return false;
   }
 
@@ -1421,6 +1438,8 @@ async function loadCalendar(options = {}) {
   if (filters.genres.length) search.set('genres', filters.genres.join(','));
   if (filters.ratingMin !== '') search.set('imdb_min', filters.ratingMin);
   if (filters.ratingMax !== '') search.set('imdb_max', filters.ratingMax);
+  if (filters.votesMin !== '') search.set('imdb_votes_min', filters.votesMin);
+  if (filters.votesMax !== '') search.set('imdb_votes_max', filters.votesMax);
   if (filters.language) search.set('language', filters.language);
   if (filters.country) search.set('country', filters.country);
   if (range) {
@@ -1817,6 +1836,8 @@ function setupCalendarEvents() {
     'calendar-genres',
     'calendar-rating-min',
     'calendar-rating-max',
+    'calendar-votes-min',
+    'calendar-votes-max',
     'calendar-language',
     'calendar-country',
   ];

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -182,6 +182,13 @@
                 <input id="calendar-rating-max" name="rating-max" type="number" step="0.1" min="0" max="10" />
               </div>
 
+              <label for="calendar-votes-min">Votes IMDB (min/max)</label>
+              <div class="calendar-range">
+                <input id="calendar-votes-min" name="votes-min" type="number" step="100" min="0" />
+                <span>–</span>
+                <input id="calendar-votes-max" name="votes-max" type="number" step="100" min="0" />
+              </div>
+
               <label for="calendar-language">Langue</label>
               <input id="calendar-language" name="language" type="text" />
 

--- a/test/app/calendar_test.rb
+++ b/test/app/calendar_test.rb
@@ -107,6 +107,23 @@ class CalendarTest < Minitest::Test
     db.verify
   end
 
+  def test_filters_by_imdb_vote_range
+    db = stub_calendar_rows([
+      { source: 'tmdb', external_id: 'movie-1', title: 'Alpha', media_type: 'movie', imdb_votes: 500 },
+      { source: 'tmdb', external_id: 'movie-2', title: 'Bravo', media_type: 'movie', imdb_votes: 1200 },
+      { source: 'tmdb', external_id: 'movie-3', title: 'Charlie', media_type: 'movie', imdb_votes: nil }
+    ])
+
+    WatchlistStore.stub(:fetch, []) do
+      calendar = Calendar.new(app: @environment.application)
+      result = calendar.entries(imdb_votes_min: '800', imdb_votes_max: '1500')
+
+      assert_equal ['Bravo'], result[:entries].map { |entry| entry[:title] }
+    end
+
+    db.verify
+  end
+
   def test_handle_calendar_request_uses_offset_and_window
     Daemon.configure(app: @environment.application)
     response = FakeResponse.new


### PR DESCRIPTION
## Summary
- add IMDb vote bound parameters to the calendar endpoint and repository filtering
- extend calendar UI and client logic to include IMDb vote ranges and local filtering
- cover vote filtering with calendar tests

## Testing
- bundle exec ruby -Itest test/app/calendar_test.rb

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d8b8c09f483279039d431c5701032)