### PR TITLE
Add vote badges to calendar entries

### DIFF
--- a/app/web/app.css
+++ b/app/web/app.css
@@ -516,6 +516,15 @@ button:disabled {
   gap: 0.5rem;
 }
 
+.calendar-range input {
+  flex: 1;
+  min-width: 0;
+}
+
+.calendar-range span {
+  color: var(--muted);
+}
+
 .calendar-content {
   display: grid;
   gap: 1rem;

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -184,9 +184,25 @@
 
               <label for="calendar-votes-min">Votes IMDB (min/max)</label>
               <div class="calendar-range">
-                <input id="calendar-votes-min" name="votes-min" type="number" step="100" min="0" />
+                <input
+                  id="calendar-votes-min"
+                  name="votes-min"
+                  type="number"
+                  step="100"
+                  min="0"
+                  inputmode="numeric"
+                  placeholder="0"
+                />
                 <span>–</span>
-                <input id="calendar-votes-max" name="votes-max" type="number" step="100" min="0" />
+                <input
+                  id="calendar-votes-max"
+                  name="votes-max"
+                  type="number"
+                  step="100"
+                  min="0"
+                  inputmode="numeric"
+                  placeholder="20000"
+                />
               </div>
 
               <label for="calendar-language">Langue</label>


### PR DESCRIPTION
## Summary
- show IMDb vote counts as formatted badges on calendar cards and retain fetched entries in calendar state for re-renders
- add numeric placeholders/input modes to IMDb vote filters and refine calendar range styling

## Testing
- bundle exec rake test *(fails: existing Zeitwerk conflict and tracker login/service errors)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692de3ad476483278eb449233bd5722a)