### PR TITLE
Adjust calendar calendar media sizing

### DIFF
--- a/app/web/app.css
+++ b/app/web/app.css
@@ -557,7 +557,7 @@ button:disabled {
   background: rgba(255, 255, 255, 0.04);
   border: 1px solid rgba(255, 255, 255, 0.12);
   display: grid;
-  grid-template-columns: 110px 1fr;
+  grid-template-columns: clamp(140px, 20%, 180px) 1fr;
   gap: 0.75rem;
   align-items: stretch;
 }
@@ -566,7 +566,8 @@ button:disabled {
   border-radius: 0.75rem;
   overflow: hidden;
   background: linear-gradient(135deg, rgba(37, 99, 235, 0.18), rgba(255, 255, 255, 0.06));
-  min-height: 150px;
+  width: 100%;
+  aspect-ratio: 2 / 3;
 }
 
 .calendar-media img {


### PR DESCRIPTION
## Summary
- widen the calendar item thumbnail column using a responsive clamp width
- enforce consistent thumbnail proportions with aspect ratio styling

## Testing
- bundle exec rake test *(fails: archive-zip dependency not installed; run `bundle install` first)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930689920a883278e97a2a74fd3d4a1)