### PR TITLE
Stop treating TMDB votes as IMDb votes

### DIFF
--- a/app/media_librarian/services/calendar_feed_service.rb
+++ b/app/media_librarian/services/calendar_feed_service.rb
@@ -548,7 +548,7 @@ module MediaLibrarian
           languages: extract_languages(details),
           countries: extract_countries(details),
           rating: details['vote_average'],
-          imdb_votes: details['vote_count'],
+          imdb_votes: nil,
           poster_url: image_url(details['poster_path'], 'w342'),
           backdrop_url: image_url(details['backdrop_path'], 'w780'),
           release_date: release_date,

--- a/test/app/calendar_test.rb
+++ b/test/app/calendar_test.rb
@@ -108,9 +108,9 @@ class CalendarTest < Minitest::Test
 
   def test_filters_by_imdb_vote_range
     db = stub_calendar_rows([
-      { source: 'tmdb', external_id: 'movie-1', title: 'Alpha', media_type: 'movie', imdb_votes: 500 },
-      { source: 'tmdb', external_id: 'movie-2', title: 'Bravo', media_type: 'movie', imdb_votes: 1200 },
-      { source: 'tmdb', external_id: 'movie-3', title: 'Charlie', media_type: 'movie', imdb_votes: nil }
+      { source: 'imdb', external_id: 'movie-1', title: 'Alpha', media_type: 'movie', imdb_votes: 500 },
+      { source: 'imdb', external_id: 'movie-2', title: 'Bravo', media_type: 'movie', imdb_votes: 1200 },
+      { source: 'imdb', external_id: 'movie-3', title: 'Charlie', media_type: 'movie', imdb_votes: nil }
     ])
 
     WatchlistStore.stub(:fetch, []) do

--- a/test/services/calendar_feed_service_test.rb
+++ b/test/services/calendar_feed_service_test.rb
@@ -489,7 +489,7 @@ class CalendarFeedServiceTest < Minitest::Test
       [{ 'tmdb' => 10, 'imdb' => 'tt0000010' }, { 'tmdb' => 11, 'imdb' => 'tt0000011' }],
       results.map { |entry| entry[:ids] }
     )
-    assert_equal [100, 110], results.map { |entry| entry[:imdb_votes] }
+    assert_equal [nil, nil], results.map { |entry| entry[:imdb_votes] }
   end
 
   def test_tmdb_fetch_titles_accepts_tmdb_model_objects
@@ -564,7 +564,7 @@ class CalendarFeedServiceTest < Minitest::Test
       [{ 'tmdb' => 21, 'imdb' => 'tt0000021' }, { 'tmdb' => 31, 'imdb' => 'tt0000031' }],
       results.map { |entry| entry[:ids] }
     )
-    assert_equal [22, 33], results.map { |entry| entry[:imdb_votes] }
+    assert_equal [nil, nil], results.map { |entry| entry[:imdb_votes] }
   end
 
   private


### PR DESCRIPTION
## Summary
- avoid mapping TMDB vote counts to the imdb_votes field in the calendar feed
- update calendar vote filter expectations to rely on IMDb-provided data
- adjust TMDB provider tests to reflect absent IMDb vote counts

## Testing
- bundle exec ruby -Itest test/services/calendar_feed_service_test.rb
- bundle exec ruby -Itest test/app/calendar_test.rb

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69306b0235dc8327bd7c1e449e11dc1b)