### PR TITLE
Stop treating Trakt votes as IMDb votes

### DIFF
--- a/app/media_librarian/services/calendar_feed_service.rb
+++ b/app/media_librarian/services/calendar_feed_service.rb
@@ -330,7 +330,7 @@ module MediaLibrarian
           languages: wrap_string(record['language']),
           countries: wrap_string(record['country']),
           rating: safe_float(record['rating']),
-          imdb_votes: record['votes'],
+          imdb_votes: nil,
           poster_url: trakt_image(record, %w[images poster full], %w[images poster medium], %w[poster]),
           backdrop_url: trakt_image(record, %w[images fanart full], %w[images backdrop full], %w[fanart], %w[backdrop]),
           release_date: release_date,

--- a/test/services/calendar_feed_service_test.rb
+++ b/test/services/calendar_feed_service_test.rb
@@ -380,8 +380,8 @@ class CalendarFeedServiceTest < Minitest::Test
     assert_equal 555, movie[:ids][:tmdb]
     assert_equal 'trakt-show', show[:ids][:slug]
     assert_equal 2222, show[:ids][:trakt]
-    assert_equal 50, movie[:imdb_votes]
-    assert_equal 75, show[:imdb_votes]
+    assert_nil movie[:imdb_votes]
+    assert_nil show[:imdb_votes]
   end
 
   def test_trakt_movies_rejects_non_hash_items


### PR DESCRIPTION
## Summary
- stop assigning Trakt vote counts to the `imdb_votes` field when building Trakt calendar entries
- update Trakt calendar feed test expectations to reflect missing IMDb votes

## Testing
- bundle exec ruby -Itest test/services/calendar_feed_service_test.rb

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69306b9a861883278140e1769d21c782)