### PR TITLE
Adjust calendar poster column sizing

### DIFF
--- a/app/web/app.css
+++ b/app/web/app.css
@@ -557,7 +557,7 @@ button:disabled {
   background: rgba(255, 255, 255, 0.04);
   border: 1px solid rgba(255, 255, 255, 0.12);
   display: grid;
-  grid-template-columns: clamp(140px, 20%, 180px) 1fr;
+  grid-template-columns: clamp(140px, 24%, 240px) 1fr;
   gap: 0.75rem;
   align-items: stretch;
 }


### PR DESCRIPTION
## Summary
- increase the calendar poster column clamp range so posters can scale wider on larger screens while preserving mobile layout

## Testing
- bundle exec rake test *(fails: existing failures in suite including Zeitwerk conflicting directory and daemon connection errors)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931ac60c33883279566fcd783a1c850)