### PR TITLE
Adjust calendar card widths

### DIFF
--- a/app/web/app.css
+++ b/app/web/app.css
@@ -547,7 +547,7 @@ button:disabled {
 
 .calendar-items {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(420px, 1fr));
   gap: 0.75rem;
 }
 
@@ -557,7 +557,7 @@ button:disabled {
   background: rgba(255, 255, 255, 0.04);
   border: 1px solid rgba(255, 255, 255, 0.12);
   display: grid;
-  grid-template-columns: minmax(200px, 260px) 1fr;
+  grid-template-columns: minmax(180px, 220px) 1fr;
   gap: 0.75rem;
   align-items: start;
 }


### PR DESCRIPTION
## Summary
- increase calendar card grid minimum width to keep text inside
- rebalance card column widths to give details more space on desktop

## Testing
- bundle exec rake test *(fails: bundle install required for archive-zip dependency)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932aeb5213c832785960a918b24af22)