### PR TITLE
Capture TMDB vote counts in calendar entries

### DIFF
--- a/app/media_librarian/services/calendar_feed_service.rb
+++ b/app/media_librarian/services/calendar_feed_service.rb
@@ -560,22 +560,24 @@ module MediaLibrarian
         end
 
         def build_entry(details, kind, release_date)
+          vote_count = details['vote_count'].to_s.strip
+
           {
             source: source,
             external_id: "#{kind}-#{details['id']}",
             title: (kind == :movie ? details['title'] : details['name']) ||
                    details['original_title'] || details['original_name'] || '',
-          media_type: kind == :movie ? 'movie' : 'show',
-          genres: Array(details['genres']).filter_map { |genre| genre['name'] },
-          languages: extract_languages(details),
-          countries: extract_countries(details),
-          rating: details['vote_average'],
-          imdb_votes: nil,
-          poster_url: image_url(details['poster_path'], 'w342'),
-          backdrop_url: image_url(details['backdrop_path'], 'w780'),
-          release_date: release_date,
-          ids: tmdb_ids(details)
-        }
+            media_type: kind == :movie ? 'movie' : 'show',
+            genres: Array(details['genres']).filter_map { |genre| genre['name'] },
+            languages: extract_languages(details),
+            countries: extract_countries(details),
+            rating: details['vote_average'],
+            imdb_votes: vote_count.empty? ? nil : vote_count.to_i,
+            poster_url: image_url(details['poster_path'], 'w342'),
+            backdrop_url: image_url(details['backdrop_path'], 'w780'),
+            release_date: release_date,
+            ids: tmdb_ids(details)
+          }
         end
 
         def tmdb_ids(details)


### PR DESCRIPTION
## Summary
- capture TMDB vote counts when building calendar feed entries and keep other normalization intact
- populate imdb_votes from vote_count only when provided, avoiding non-existent values

## Testing
- bundle exec rake test *(fails: existing suite errors/failures unrelated to change)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932b9e5ed088327a2d040e9085147c1)