### PR TITLE
Fix TMDB calendar vote counts

### DIFF
--- a/app/media_librarian/services/calendar_feed_service.rb
+++ b/app/media_librarian/services/calendar_feed_service.rb
@@ -560,7 +560,7 @@ module MediaLibrarian
         end
 
         def build_entry(details, kind, release_date)
-          vote_count = details['vote_count'].to_s.strip
+          vote_count = value_from(details, :vote_count, 'vote_count').to_s.strip
 
           {
             source: source,

--- a/test/services/calendar_feed_service_test.rb
+++ b/test/services/calendar_feed_service_test.rb
@@ -489,7 +489,7 @@ class CalendarFeedServiceTest < Minitest::Test
       [{ 'tmdb' => 10, 'imdb' => 'tt0000010' }, { 'tmdb' => 11, 'imdb' => 'tt0000011' }],
       results.map { |entry| entry[:ids] }
     )
-    assert_equal [nil, nil], results.map { |entry| entry[:imdb_votes] }
+    assert_equal [100, 110], results.map { |entry| entry[:imdb_votes] }
   end
 
   def test_tmdb_fetch_titles_accepts_tmdb_model_objects
@@ -564,7 +564,7 @@ class CalendarFeedServiceTest < Minitest::Test
       [{ 'tmdb' => 21, 'imdb' => 'tt0000021' }, { 'tmdb' => 31, 'imdb' => 'tt0000031' }],
       results.map { |entry| entry[:ids] }
     )
-    assert_equal [nil, nil], results.map { |entry| entry[:imdb_votes] }
+    assert_equal [22, 33], results.map { |entry| entry[:imdb_votes] }
   end
 
   private


### PR DESCRIPTION
## Summary
- read TMDB vote counts using flexible key lookup so upcoming items keep vote totals
- update calendar feed tests to expect stored vote counts from TMDB details

## Testing
- bundle exec rake test TEST=test/services/calendar_feed_service_test.rb


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932c9c0467883279234a43b5363bc1c)