### PR TITLE
Ensure direct commands log command preamble

### DIFF
--- a/librarian.rb
+++ b/librarian.rb
@@ -252,15 +252,20 @@ class Librarian
     def run_command(cmd, direct = 0, object = '', &block)
       original_cmd = Array(cmd).dup
       cmd = sanitize_arguments(original_cmd)
-      sanitized_cmd = cmd.dup
 
       if direct.to_i.zero? && cmd.empty?
         notify_missing_command(original_cmd)
         cmd = ['help']
       end
 
+      sanitized_cmd = cmd.dup
+      running_command = sanitized_cmd.map { |a| a.gsub(/--?([^=\s]+)(?:=(.+))?/, '--\1=\'\2\'') }.join(' ')
+
       object = cmd[0..1].join(' ') if object.to_s.empty? || object == 'rcv'
       init_thread(Thread.current, object, direct, &block)
+
+      app.speaker.speak_up(String.new('Running command: '), 0)
+      app.speaker.speak_up("#{running_command}\n\n", 0)
 
       thread_value =
         if direct.to_i > 0
@@ -277,8 +282,6 @@ class Librarian
             cmd.empty? ? p.call : p.call(*cmd)
           end
         else
-          app.speaker.speak_up(String.new('Running command: '), 0)
-          app.speaker.speak_up("#{cmd.map { |a| a.gsub(/--?([^=\s]+)(?:=(.+))?/, '--\1=\'\2\'') }.join(' ')}\n\n", 0)
           app.args_dispatch.dispatch(MediaLibrarian::APP_NAME, cmd, command_registry.actions, nil, app.template_dir)
         end
 


### PR DESCRIPTION
## Summary
- always announce the running command before handling direct invocations so email buffers include the command lines
- reuse the sanitized command string for both direct and non-direct execution paths
- add a daemon job test that verifies email notifications include the command preamble for direct runs

## Testing
- bundle exec ruby -Itest test/daemon_job_control_test.rb -n test_daemon_emails_include_command_lines_for_direct_jobs

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932d18474688327b4016316237bbc22)