### PR TITLE
Handle non-string args when logging direct command preambles

### DIFF
--- a/librarian.rb
+++ b/librarian.rb
@@ -259,7 +259,9 @@ class Librarian
       end
 
       sanitized_cmd = cmd.dup
-      running_command = sanitized_cmd.map { |a| a.gsub(/--?([^=\s]+)(?:=(.+))?/, '--\1=\'\2\'') }.join(' ')
+      running_command = sanitized_cmd
+        .map { |a| a.is_a?(String) ? a.gsub(/--?([^=\s]+)(?:=(.+))?/, '--\1=\'\2\'') : a.inspect }
+        .join(' ')
 
       object = cmd[0..1].join(' ') if object.to_s.empty? || object == 'rcv'
       init_thread(Thread.current, object, direct, &block)


### PR DESCRIPTION
## Summary
- ensure running command preamble formatting safely stringifies non-string arguments in direct/internal invocations to avoid logging errors

## Testing
- bundle exec rake test *(fails: pre-existing failures in suite; see output for details)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932d6f459588327add9b6c4b31b146f)