### PR TITLE
Add IMDb calendar fetch logging

### DIFF
--- a/app/media_librarian/services/calendar_feed_service.rb
+++ b/app/media_librarian/services/calendar_feed_service.rb
@@ -290,11 +290,19 @@ module MediaLibrarian
 
       def build_imdb_fetcher
         client = ImdbParty::Imdb.new
+        version = (client.class.const_get(:VERSION) rescue nil) || (ImdbParty.const_get(:VERSION) rescue nil)
 
         lambda do |date_range:, limit:|
-          return [] unless client.respond_to?(:calendar)
+          unless client.respond_to?(:calendar)
+            speaker&.speak_up("IMDb calendar unavailable for #{client.class.name} #{version || 'unknown version'}")
+            return []
+          end
 
+          speaker&.speak_up("IMDb calendar fetch #{date_range.first}..#{date_range.last} (limit: #{limit})")
           Array(client.calendar(date_range: date_range, limit: limit)).first(limit)
+        rescue StandardError => e
+          speaker&.tell_error(e, 'IMDB calendar fetch failed')
+          []
         end
       end
 


### PR DESCRIPTION
## Summary
- add logging for IMDb calendar fetch attempts and warn when support is missing
- capture IMDb fetch errors before returning empty results and include client version in warnings
- extend calendar feed tests to cover new logging behavior and adjust expectations

## Testing
- bundle exec ruby test/services/calendar_feed_service_test.rb


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932de29280c8327a0a238601fe2c91e)