### PR TITLE
Stop storing TMDB vote counts in calendar entries

### DIFF
--- a/app/media_librarian/services/calendar_feed_service.rb
+++ b/app/media_librarian/services/calendar_feed_service.rb
@@ -618,8 +618,6 @@ module MediaLibrarian
         end
 
         def build_entry(details, kind, release_date)
-          vote_count = value_from(details, :vote_count, 'vote_count').to_s.strip
-
           {
             source: source,
             external_id: "#{kind}-#{details['id']}",
@@ -630,7 +628,7 @@ module MediaLibrarian
             languages: extract_languages(details),
             countries: extract_countries(details),
             rating: details['vote_average'],
-            imdb_votes: vote_count.empty? ? nil : vote_count.to_i,
+            imdb_votes: nil,
             poster_url: image_url(details['poster_path'], 'w342'),
             backdrop_url: image_url(details['backdrop_path'], 'w780'),
             release_date: release_date,


### PR DESCRIPTION
## Summary
- remove vote count lookups from TMDB calendar feed entries so imdb_votes remains unset

## Testing
- bundle exec rake test *(fails: existing suite has multiple pre-existing failures/errors unrelated to this change)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932e4eeccc88327a2ae7f62c3eb2ca1)