### PR TITLE
Allow any matching genre in calendar filters

### DIFF
--- a/app/calendar_entries_repository.rb
+++ b/app/calendar_entries_repository.rb
@@ -59,7 +59,7 @@ class CalendarEntriesRepository
     return true if genres.empty?
 
     entry_genres = Array(entry[:genres]).map { |g| g.to_s.downcase }
-    genres.all? { |genre| entry_genres.include?(genre) }
+    (entry_genres & genres).any?
   end
 
   def rating_match?(entry, min_rating, max_rating)

--- a/test/app/calendar_test.rb
+++ b/test/app/calendar_test.rb
@@ -123,6 +123,22 @@ class CalendarTest < Minitest::Test
     db.verify
   end
 
+  def test_filters_when_any_genre_matches
+    db = stub_calendar_rows([
+      { source: 'tmdb', external_id: 'movie-1', title: 'Alpha', media_type: 'movie', genres: ['Drama'] },
+      { source: 'tmdb', external_id: 'movie-2', title: 'Bravo', media_type: 'movie', genres: ['Horror'] }
+    ])
+
+    WatchlistStore.stub(:fetch, []) do
+      calendar = Calendar.new(app: @environment.application)
+      result = calendar.entries(genres: ['Drama, Comedy'])
+
+      assert_equal ['Alpha'], result[:entries].map { |entry| entry[:title] }
+    end
+
+    db.verify
+  end
+
   def test_handle_calendar_request_uses_offset_and_window
     Daemon.configure(app: @environment.application)
     response = FakeResponse.new


### PR DESCRIPTION
## Summary
- update calendar genre matching to accept entries when any selected genre is present
- add test covering multiple selected genres where a single entry genre matches

## Testing
- bundle exec ruby -Itest test/app/calendar_test.rb

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932f2167bc08327b6bb1b619747c350)