### PR TITLE
Thread Trakt token into calendar fetcher

### DIFF
--- a/app/media_librarian/services/calendar_feed_service.rb
+++ b/app/media_librarian/services/calendar_feed_service.rb
@@ -5,6 +5,7 @@ require 'themoviedb'
 require 'imdb_party'
 require 'json'
 require 'httparty'
+require 'trakt'
 
 module MediaLibrarian
   module Services
@@ -342,21 +343,29 @@ module MediaLibrarian
         nil
       end
 
-      def build_trakt_fetcher(client_id, client_secret, _token)
+      def build_trakt_fetcher(client_id, client_secret, token)
         return nil if client_id.to_s.empty? || client_secret.to_s.empty?
 
         lambda do |date_range:, limit:|
-          fetch_trakt_entries(date_range: date_range, limit: limit)
+          fetch_trakt_entries(
+            date_range: date_range,
+            limit: limit,
+            client_id: client_id,
+            client_secret: client_secret,
+            token: token
+          )
         end
       end
 
-      def fetch_trakt_entries(date_range:, limit:)
+      def fetch_trakt_entries(date_range:, limit:, client_id:, client_secret:, token: nil)
         start_date = (date_range.first || Date.today)
         end_date = (date_range.last || start_date)
         days = [(end_date - start_date).to_i + 1, 1].max
 
-        movies = TraktAgent.calendars__all_movies(start_date, days)
-        shows = TraktAgent.calendars__all_shows(start_date, days)
+        fetcher = trakt_calendar_client(client_id: client_id, client_secret: client_secret, token: token)
+
+        movies = TraktAgent.fetch_calendar_entries(:movies, start_date, days, fetcher: fetcher)
+        shows = TraktAgent.fetch_calendar_entries(:shows, start_date, days, fetcher: fetcher)
 
         parsed_movies = parse_trakt_movies(movies)
         parsed_shows = parse_trakt_shows(shows)
@@ -365,6 +374,22 @@ module MediaLibrarian
       rescue StandardError => e
         speaker&.tell_error(e, 'Calendar Trakt fetch failed')
         []
+      end
+
+      def trakt_calendar_client(client_id:, client_secret:, token: nil)
+        Trakt.new(
+          client_id: client_id,
+          client_secret: client_secret,
+          token: normalize_trakt_token(token),
+          speaker: speaker
+        )
+      end
+
+      def normalize_trakt_token(token)
+        return token if token.is_a?(Hash)
+
+        token_value = token.to_s.strip
+        token_value.empty? ? nil : { access_token: token_value }
       end
 
       def parse_trakt_movies(payload)
@@ -636,7 +661,7 @@ module MediaLibrarian
             languages: extract_languages(details),
             countries: extract_countries(details),
             rating: details['vote_average'],
-            imdb_votes: nil,
+            imdb_votes: details['vote_count'],
             poster_url: image_url(details['poster_path'], 'w342'),
             backdrop_url: image_url(details['backdrop_path'], 'w780'),
             release_date: release_date,

--- a/test/services/calendar_feed_service_test.rb
+++ b/test/services/calendar_feed_service_test.rb
@@ -387,27 +387,50 @@ class CalendarFeedServiceTest < Minitest::Test
       }
     ]
 
-    movie_calls = []
-    show_calls = []
+    fetcher_instance = nil
+    calendars = Class.new do
+      attr_reader :calls
 
-    TraktAgent.stub(
-      :calendars__all_movies,
-      ->(start_date, days) { movie_calls << [start_date, days]; movie_payload }
-    ) do
-      TraktAgent.stub(
-        :calendars__all_shows,
-        ->(start_date, days) { show_calls << [start_date, days]; show_payload }
-      ) do
-        config = { 'trakt' => { 'client_id' => 'id', 'client_secret' => 'secret' } }
-        app = Struct.new(:config, :db).new(config, @db)
-        service = MediaLibrarian::Services::CalendarFeedService.new(app: app, speaker: @speaker)
+      def initialize(movie_payload, show_payload)
+        @movie_payload = movie_payload
+        @show_payload = show_payload
+        @calls = []
+      end
 
-        service.refresh(date_range: date_range, limit: 10, sources: ['trakt'])
+      def all_movies(start_date, days)
+        @calls << [:movies, start_date, days]
+        @movie_payload
+      end
+
+      def all_shows(start_date, days)
+        @calls << [:shows, start_date, days]
+        @show_payload
+      end
+    end.new(movie_payload, show_payload)
+
+    fake_fetcher_class = Class.new do
+      attr_reader :token
+
+      def initialize(token, calendars)
+        @token = token
+        @calendars = calendars
+      end
+
+      def calendars
+        @calendars
       end
     end
 
-    assert_equal [[start_date, days]], movie_calls
-    assert_equal [[start_date, days]], show_calls
+    Trakt.stub(:new, ->(opts) { fetcher_instance = fake_fetcher_class.new(opts[:token], calendars) }) do
+      config = { 'trakt' => { 'client_id' => 'id', 'client_secret' => 'secret', 'access_token' => 'tok' } }
+      app = Struct.new(:config, :db).new(config, @db)
+      service = MediaLibrarian::Services::CalendarFeedService.new(app: app, speaker: @speaker)
+
+      service.refresh(date_range: date_range, limit: 10, sources: ['trakt'])
+    end
+
+    assert_equal [[:movies, start_date, days], [:shows, start_date, days]], calendars.calls
+    assert_equal({ access_token: 'tok' }, fetcher_instance.token)
     rows = @db.get_rows(:calendar_entries, { source: 'trakt' })
     assert_equal 2, rows.count
     movie = rows.find { |row| row[:media_type] == 'movie' }


### PR DESCRIPTION
## Summary
- thread configured Trakt access tokens through the calendar fetcher and normalize tokens when creating the client
- route calendar lookups through a token-aware Trakt client so authenticated requests are used for movies and shows
- keep TMDB calendar entries’ vote counts when building calendar rows and update tests for the new fetcher

## Testing
- bundle exec ruby -Itest test/services/calendar_feed_service_test.rb


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933032e5f10832793dc5578549bf8a0)