### PR TITLE
Log warning when IMDb calendar returns no entries

### DIFF
--- a/app/media_librarian/services/calendar_feed_service.rb
+++ b/app/media_librarian/services/calendar_feed_service.rb
@@ -778,8 +778,15 @@ module MediaLibrarian
         def fetch_entries(date_range, limit)
           return [] unless @fetcher
 
-          Array(@fetcher.call(date_range: date_range, limit: limit))
-            .filter_map { |record| build_entry(record) }
+          entries =
+            Array(@fetcher.call(date_range: date_range, limit: limit))
+              .filter_map { |record| build_entry(record) }
+
+          if entries.empty?
+            @speaker&.speak_up("Calendar provider #{source} returned no entries for #{date_range.first}..#{date_range.last}")
+          end
+
+          entries
         rescue StandardError => e
           @speaker&.tell_error(e, 'Calendar IMDb fetch failed')
           []


### PR DESCRIPTION
## Summary
- log a warning with date range when the IMDb calendar provider returns no entries
- add coverage confirming the warning is emitted when the IMDb fetcher yields no results

## Testing
- bundle exec ruby -Itest test/services/calendar_feed_service_test.rb

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69331b6a040c8327be6c2bb863b2ee90)