### PR TITLE
Use stored Trakt token in calendar feed

### DIFF
--- a/app/media_librarian/services/calendar_feed_service.rb
+++ b/app/media_librarian/services/calendar_feed_service.rb
@@ -273,10 +273,11 @@ module MediaLibrarian
           account_id = trakt_config['account_id']
           client_id = trakt_config['client_id']
           client_secret = trakt_config['client_secret']
+          trakt_token = trakt_config['access_token'] || (app.respond_to?(:trakt) ? app.trakt&.token : nil)
           fetcher = build_trakt_fetcher(
             client_id,
             client_secret,
-            trakt_config['access_token'],
+            trakt_token,
             account_id
           )
 

--- a/test/services/calendar_feed_service_test.rb
+++ b/test/services/calendar_feed_service_test.rb
@@ -544,6 +544,56 @@ class CalendarFeedServiceTest < Minitest::Test
     assert_nil show[:imdb_votes]
   end
 
+  def test_trakt_fetcher_uses_app_token_when_config_token_missing
+    date_range = Date.today..(Date.today + 1)
+    start_date = date_range.first
+    days = (date_range.last - start_date).to_i + 1
+
+    calendars = Class.new do
+      attr_reader :calls
+
+      def initialize
+        @calls = []
+      end
+
+      def all_movies(start_date, days)
+        @calls << [:movies, start_date, days]
+        []
+      end
+
+      def all_shows(start_date, days)
+        @calls << [:shows, start_date, days]
+        []
+      end
+    end.new
+
+    fetcher_instance = nil
+    fake_fetcher_class = Class.new do
+      attr_reader :token
+
+      def initialize(token, calendars)
+        @token = token
+        @calendars = calendars
+      end
+
+      def calendars
+        @calendars
+      end
+    end
+
+    Trakt.stub(:new, ->(opts) { fetcher_instance = fake_fetcher_class.new(opts[:token], calendars) }) do
+      config = { 'trakt' => { 'account_id' => 'acc', 'client_id' => 'id', 'client_secret' => 'secret' } }
+      trakt_client = Struct.new(:token).new({ access_token: 'stored-token' })
+      app = Struct.new(:config, :db, :trakt).new(config, @db, trakt_client)
+      service = MediaLibrarian::Services::CalendarFeedService.new(app: app, speaker: @speaker)
+
+      service.refresh(date_range: date_range, limit: 10, sources: ['trakt'])
+    end
+
+    assert_equal [[:movies, start_date, days], [:shows, start_date, days]], calendars.calls
+    assert_equal({ access_token: 'stored-token' }, fetcher_instance.token)
+  end
+
   def test_trakt_movies_rejects_non_hash_items
     service = MediaLibrarian::Services::CalendarFeedService.new(app: nil, speaker: @speaker)
     payload = [


### PR DESCRIPTION
## Summary
- reuse the application's existing Trakt token when building the calendar provider to avoid re-auth prompts
- ensure provider creation tolerates apps without a `trakt` attribute while still validating credentials
- add coverage confirming the app token is passed to the Trakt client when no config token is provided

## Testing
- bundle exec ruby -Itest test/services/calendar_feed_service_test.rb

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933110cfb9c832792d4899bbb4e5f19)