### PR TITLE
Fix speaker error handling options

### DIFF
--- a/app/media_librarian/services/base_service.rb
+++ b/app/media_librarian/services/base_service.rb
@@ -34,8 +34,9 @@ module MediaLibrarian
         delegate&.ask_if_needed(question, no_prompt, default)
       end
 
-      def tell_error(error, context = nil, *_args)
-        delegate&.tell_error(error, context)
+      def tell_error(error, context = nil, options = nil, *args)
+        safe_options = options.is_a?(Hash) ? options : {}
+        delegate&.tell_error(error, context, safe_options, *args)
       end
 
       private


### PR DESCRIPTION
## Summary
- ensure speaker adapter always passes an options hash to tell_error
- maintain compatibility with additional arguments while preventing nil errors

## Testing
- bundle exec rake test *(fails: sqlite3-1.5.3 gem missing; native extension build stalled)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69332a0162588327b6c5b1490d97bb5e)