### PR TITLE
Update IMDb calendar endpoint and add calendar test

### DIFF
--- a/lib/imdb_api.rb
+++ b/lib/imdb_api.rb
@@ -35,7 +35,7 @@ class ImdbApi
   attr_reader :http_client, :base_url, :region, :api_key, :speaker
 
   def fetch_calendar_for(date)
-    path = "#{base_url}/calendar/"
+    path = "#{base_url}/imdb-api/calendar"
     response = http_client.get(
       path,
       query: { date: format_date(date), region: region },
@@ -55,9 +55,18 @@ class ImdbApi
   end
 
   def headers
-    return {} if api_key.empty?
+    return {
+      'x-imdb-client-name' => 'imdb-web-next',
+      'x-imdb-client-platform' => 'Desktop',
+      'Accept' => 'application/json'
+    } if api_key.empty?
 
-    { 'x-imdb-api-key' => api_key }
+    {
+      'x-imdb-api-key' => api_key,
+      'x-imdb-client-name' => 'imdb-web-next',
+      'x-imdb-client-platform' => 'Desktop',
+      'Accept' => 'application/json'
+    }
   end
 
   def parse_calendar_response(body, fallback_date, path, status)

--- a/test/fixtures/imdb_calendar.json
+++ b/test/fixtures/imdb_calendar.json
@@ -1,0 +1,7 @@
+[{
+  "id": "tt0000123",
+  "title": "Sample Calendar Movie",
+  "titleType": "movie",
+  "releaseDate": "2024-12-05",
+  "isReleased": false
+}]

--- a/test/lib/imdb_api_test.rb
+++ b/test/lib/imdb_api_test.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+require 'json'
+require 'date'
+require_relative '../../lib/imdb_api'
+
+class ImdbApiTest < Minitest::Test
+  FIXTURE_PATH = File.expand_path('../fixtures/imdb_calendar.json', __dir__)
+
+  def test_calendar_returns_entries_from_fixture_response
+    date = Date.new(2024, 12, 5)
+    api = ImdbApi.new(http_client: fake_client, api_key: 'sample-key')
+
+    entries = api.calendar(date_range: date..date)
+
+    refute_empty entries
+    assert_equal 'Sample Calendar Movie', entries.first['title']
+    assert_equal '2024-12-05', entries.first['releaseDate']
+  end
+
+  private
+
+  def fake_client
+    body = File.read(FIXTURE_PATH)
+
+    Class.new do
+      define_method(:get) do |_path, **_opts|
+        Struct.new(:code, :body).new(200, body)
+      end
+    end.new
+  end
+end


### PR DESCRIPTION
## Summary
- update the IMDb calendar client to call the imdb-api calendar endpoint with required headers
- add a fixture-based contract test for `ImdbApi#calendar`

## Testing
- bundle exec ruby test/lib/imdb_api_test.rb

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693330725b148327b13e66769274ccab)