### PR TITLE
Fix tell_error mail flag handling

### DIFF
--- a/app/media_librarian/services/base_service.rb
+++ b/app/media_librarian/services/base_service.rb
@@ -35,8 +35,12 @@ module MediaLibrarian
       end
 
       def tell_error(error, context = nil, options = nil, *args)
-        safe_options = options.is_a?(Hash) ? options : {}
-        delegate&.tell_error(error, context, safe_options, *args)
+        in_mail = if options.is_a?(Hash)
+                    options[:in_mail] || options['in_mail']
+                  else
+                    options
+                  end
+        delegate&.tell_error(error, context, in_mail, *args)
       end
 
       private


### PR DESCRIPTION
## Summary
- update SpeakerAdapter#tell_error to pass through the in_mail flag instead of coercing options to an empty hash
- allow hash options to specify in_mail via symbol or string keys to align with SimpleSpeaker expectations

## Testing
- bundle exec rake test *(fails: existing test failures unrelated to this change, including conflicts from Zeitwerk loader and NoMethodError in `LibrarianCliTest#test_direct_route_cmd_restores_parent_thread_state`)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933e01102908327bf810db04b660baf)