### PR TITLE
Handle missing tvdb_party dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem 'themoviedb', :require => false
 gem 'torznab-client', :git => 'https://github.com/raphyduck/torznab-client', branch: "master", :require => false
 gem 'trakt', :git => 'https://github.com/raphyduck/trakt.git', :require => false
 gem 'tvmaze', :git => 'https://github.com/raphyduck/tvmaze.git', :require => false
+gem 'tvdb_party', require: false
 gem 'unrar', :git => 'https://github.com/raphyduck/unrar.git', :require => false
 gem 'xbmc-client', :git => 'https://github.com/raphyduck/xbmc-client.git', :require => false
 gem 'zeitwerk'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -208,6 +208,8 @@ GEM
     timeout (0.4.3)
     titleize (1.4.1)
     transproc (1.1.1)
+    tvdb_party (0.9.3)
+      httparty (>= 0.6.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     webrick (1.9.1)
@@ -245,6 +247,7 @@ DEPENDENCIES
   titleize
   torznab-client!
   trakt!
+  tvdb_party
   tvmaze!
   unrar!
   xbmc-client!

--- a/init/thetvdb.rb
+++ b/init/thetvdb.rb
@@ -1,7 +1,14 @@
 # Start thetvdb client
-require 'tvdb_party'
 require_relative '../boot/librarian'
 
 app = MediaLibrarian::Boot.application
 config = app.config
+begin
+  require 'tvdb_party'
+rescue LoadError => e
+  app.speaker.speak_up("TVDB support disabled: #{e.message}")
+  app.tvdb = nil
+  return
+end
+
 app.tvdb = config['tvdb'] && config['tvdb']['api_key'] ? TvdbParty::Search.new(config['tvdb']['api_key']) : nil


### PR DESCRIPTION
## Summary
- add tvdb_party to the Gemfile so bundler installs the TVDB client
- guard the TVDB initialization to log a warning and disable the client when the gem is missing

## Testing
- bundle exec ruby librarian.rb daemon start
- bundle exec ruby librarian.rb daemon stop
- (tvdb_party gem temporarily removed) bundle exec ruby librarian.rb daemon start
- (tvdb_party gem temporarily removed) bundle exec ruby librarian.rb daemon stop


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933e9cd85c48327b78ea8ca61561152)