### PR TITLE
Ensure SpeakerAdapter tell_error passes options hash

### DIFF
--- a/app/media_librarian/services/base_service.rb
+++ b/app/media_librarian/services/base_service.rb
@@ -40,7 +40,7 @@ module MediaLibrarian
                   else
                     options
                   end
-        delegate&.tell_error(error, context, in_mail, *args)
+        delegate&.tell_error(error, context, { in_mail: in_mail }, *args)
       end
 
       private

--- a/test/services/speaker_adapter_test.rb
+++ b/test/services/speaker_adapter_test.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require_relative '../../app/media_librarian/services/base_service'
+
+module MediaLibrarian
+  module Services
+    class SpeakerAdapterTest < Minitest::Test
+      def test_tell_error_wraps_nil_options
+        delegate = Minitest::Mock.new
+        adapter = SpeakerAdapter.new(delegate)
+
+        delegate.expect(:tell_error, nil, [:error, :context, { in_mail: nil }])
+
+        adapter.tell_error(:error, :context)
+
+        assert delegate.verify
+      end
+
+      def test_tell_error_wraps_boolean_options
+        delegate = Minitest::Mock.new
+        adapter = SpeakerAdapter.new(delegate)
+
+        delegate.expect(:tell_error, nil, [:error, :context, { in_mail: false }, :extra])
+
+        adapter.tell_error(:error, :context, false, :extra)
+
+        assert delegate.verify
+      end
+
+      def test_tell_error_wraps_hash_options
+        delegate = Minitest::Mock.new
+        adapter = SpeakerAdapter.new(delegate)
+
+        delegate.expect(:tell_error, nil, [:error, :context, { in_mail: true }])
+
+        adapter.tell_error(:error, :context, { in_mail: true })
+
+        assert delegate.verify
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- ensure `SpeakerAdapter#tell_error` always forwards a hash for options while preserving current `in_mail` derivation
- add SpeakerAdapter unit tests covering nil, boolean, and hash option inputs

## Testing
- bundle exec ruby -Itest test/services/speaker_adapter_test.rb

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934383218208327b02bf5da26ce587b)