### PR TITLE
Update IMDb calendar endpoint path

### DIFF
--- a/lib/imdb_api.rb
+++ b/lib/imdb_api.rb
@@ -35,7 +35,7 @@ class ImdbApi
   attr_reader :http_client, :base_url, :region, :api_key, :speaker
 
   def fetch_calendar_for(date)
-    path = "#{base_url}/imdb-api/calendar"
+    path = "#{base_url}/imdb-api/v1/calendar"
     response = http_client.get(
       path,
       query: { date: format_date(date), region: region },


### PR DESCRIPTION
## Summary
- update the IMDb calendar API path to use the current versioned endpoint
- adjust the calendar test to verify requests target the new path while still parsing the fixture response

## Testing
- bundle exec ruby -Itest test/lib/imdb_api_test.rb

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934384151c48327981be55999763435)