### PR TITLE
Pass in_mail numeric to tell_error delegate

### DIFF
--- a/app/media_librarian/services/base_service.rb
+++ b/app/media_librarian/services/base_service.rb
@@ -40,7 +40,7 @@ module MediaLibrarian
                   else
                     options
                   end
-        delegate&.tell_error(error, context, { in_mail: in_mail }, *args)
+        delegate&.tell_error(error, context, (in_mail.to_i if in_mail), *args)
       end
 
       private


### PR DESCRIPTION
## Summary
- forward the resolved in_mail option directly to the speaker delegate
- coerce provided in_mail values to integers before calling tell_error to match the SimpleSpeaker signature

## Testing
- bundle exec rake test *(fails: existing suite reports 3 failures, 9 errors unrelated to this change; see logs for details)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934533c02b88327938014564ed69df6)