### PR TITLE
Remove simple_speaker gem dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,6 @@ gem 'mediainfo', :git => 'https://github.com/raphyduck/mediainfo.git', :require 
 gem 'net-ssh', :require => false
 gem 'nokogiri', :require => false
 gem 'rsync', :git => 'https://github.com/raphyduck/ruby-rsync.git', :require => false
-gem 'simple_speaker', '~>0.3.0', :require => false
 gem "selenium-webdriver", require: false
 gem 'sqlite3', '1.5.3', :require => false
 gem 'streamio-ffmpeg', :require => false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,7 +40,6 @@ GIT
   specs:
     trakt (0.1.9.6)
       httparty
-      simple_speaker
 
 GIT
   remote: https://github.com/raphyduck/tvmaze.git
@@ -196,8 +195,6 @@ GEM
       websocket (~> 1.0)
     sequel (5.97.0)
       bigdecimal
-      simple_speaker (~> 0.3.0)
-    simple_speaker (0.3.0.8)
     sqlite3 (1.5.3)
       mini_portile2 (~> 2.8.0)
     streamio-ffmpeg (3.0.2)
@@ -240,7 +237,6 @@ DEPENDENCIES
   rsync!
   selenium-webdriver
   sequel
-  simple_speaker (~> 0.3.0)
   sqlite3 (= 1.5.3)
   streamio-ffmpeg
   themoviedb


### PR DESCRIPTION
## Summary
- remove the simple_speaker gem entry so the code uses the bundled SimpleSpeaker implementation
- update Gemfile.lock to drop simple_speaker from dependencies

## Testing
- bundle exec rake test *(fails: existing suite has 4 failures and 10 errors in current state)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693465e9e0a883279c90d4e3185ccb9a)