### PR TITLE
Add OMDb calendar provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,23 +77,23 @@ calendar:
   window_past_days: 30           # How far back from today to keep entries
   window_future_days: 45         # How far into the future to fetch releases
   refresh_limit: 200             # Maximum number of entries persisted per refresh
-  providers: imdb|trakt|tmdb     # Pipe/comma/space separated list or array of sources to enable
+  providers: omdb|trakt|tmdb     # Pipe/comma/space separated list or array of sources to enable
 
 tmdb:
   api_key: YOUR_TMDB_API_KEY
+
+omdb:
+  api_key: YOUR_OMDB_API_KEY
 
 trakt:
   client_id: YOUR_TRAKT_CLIENT_ID
   client_secret: YOUR_TRAKT_CLIENT_SECRET
   access_token: OPTIONAL_OAUTH_TOKEN
-
-# imdb:
-#   enabled: false               # Optional toggle if you want to skip the IMDb feed entirely
 ```
 
-`refresh_every` overrides the scheduler interval so the daemon automatically re-hydrates the calendar at the requested cadence. `window_past_days` and `window_future_days` define the rolling window of dates that will be fetched on each run (`refresh_days` remains a backward-compatible alias for the future window), while `refresh_limit` caps the number of entries persisted per refresh. `refresh_on_start` ensures the daemon performs an immediate refresh when the calendar table is empty (set it to `false` to disable that bootstrap). `providers` can be specified as a delimited string (`imdb|trakt|tmdb`, `imdb trakt`, etc.) or as a YAML array, and only the enabled fetchers are queried on each refresh.
+`refresh_every` overrides the scheduler interval so the daemon automatically re-hydrates the calendar at the requested cadence. `window_past_days` and `window_future_days` define the rolling window of dates that will be fetched on each run (`refresh_days` remains a backward-compatible alias for the future window), while `refresh_limit` caps the number of entries persisted per refresh. `refresh_on_start` ensures the daemon performs an immediate refresh when the calendar table is empty (set it to `false` to disable that bootstrap). `providers` can be specified as a delimited string (`omdb|trakt|tmdb`, `omdb trakt`, etc.) or as a YAML array, and only the enabled fetchers are queried on each refresh.
 
-The IMDb fetcher now uses the public release calendar and does not require per-user configuration. Leave the `imdb` block out of `conf.yml` (or set `imdb.enabled: false`) to disable it entirely. Trakt access still requires an API application; `client_id`/`client_secret` identify the app and the calendar endpoints live under `https://api.trakt.tv/calendars/all/...`. Public calendars work with only the client id, but supplying an OAuth `access_token` allows the service to reuse authenticated calls if you later point it at user-specific scopes.
+The OMDb fetcher relies on an API key (`omdb.api_key`) and maps OMDb/IMDb metadata into the calendar feed. Trakt access still requires an API application; `client_id`/`client_secret` identify the app and the calendar endpoints live under `https://api.trakt.tv/calendars/all/...`. Public calendars work with only the client id, but supplying an OAuth `access_token` allows the service to reuse authenticated calls if you later point it at user-specific scopes.
 
 ### Tracker logins that require a real browser
 

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -175,14 +175,14 @@
               <label for="calendar-genres">Genres</label>
               <select id="calendar-genres" name="genres" multiple></select>
 
-              <label for="calendar-rating-min">Note IMDB (min/max)</label>
+              <label for="calendar-rating-min">Note OMDb/IMDb (min/max)</label>
               <div class="calendar-range">
                 <input id="calendar-rating-min" name="rating-min" type="number" step="0.1" min="0" max="10" />
                 <span>–</span>
                 <input id="calendar-rating-max" name="rating-max" type="number" step="0.1" min="0" max="10" />
               </div>
 
-              <label for="calendar-votes-min">Votes IMDB (min/max)</label>
+              <label for="calendar-votes-min">Votes OMDb/IMDb (min/max)</label>
               <div class="calendar-range">
                 <input
                   id="calendar-votes-min"

--- a/lib/omdb_api.rb
+++ b/lib/omdb_api.rb
@@ -1,0 +1,194 @@
+# frozen_string_literal: true
+
+require 'date'
+require 'json'
+require 'uri'
+require 'httparty'
+
+class OmdbApi
+  DEFAULT_BASE_URL = 'https://www.omdbapi.com/'.freeze
+
+  attr_reader :last_request_path
+
+  def initialize(api_key:, base_url: nil, http_client: HTTParty, speaker: nil)
+    @api_key = api_key.to_s.strip
+    @base_url = (base_url || DEFAULT_BASE_URL).to_s.chomp('/')
+    @http_client = http_client
+    @speaker = speaker
+    @last_request_path = nil
+  end
+
+  def calendar(date_range:, limit: 100)
+    return [] if @api_key.empty?
+    return [] unless date_range.respond_to?(:each)
+
+    results = []
+    years(date_range).each do |year|
+      break if results.length >= limit
+
+      results.concat(fetch_year(year: year, date_range: date_range, limit: limit - results.length))
+    end
+
+    results.first(limit)
+  end
+
+  private
+
+  def years(date_range)
+    date_range.map { |date| date.respond_to?(:year) ? date.year : Date.parse(date.to_s).year }.uniq.sort
+  end
+
+  def fetch_year(year:, date_range:, limit:)
+    results = []
+    %w[movie series].each do |type|
+      page = 1
+      while results.length < limit
+        payload = request(search_query(type: type, year: year, page: page))
+        batch = normalize_search(payload, date_range)
+        break if batch.empty?
+
+        results.concat(batch)
+        total_results = payload.is_a?(Hash) ? payload['totalResults'].to_i : 0
+        break if (page * 10) >= total_results || total_results.zero?
+
+        page += 1
+      end
+    end
+    results
+  rescue StandardError => e
+    report_error(e, 'OMDb calendar fetch failed')
+    []
+  end
+
+  def search_query(type:, year:, page: 1)
+    { s: '*', type: type, y: year, page: page }
+  end
+
+  def request(query)
+    query_with_key = query.merge(apikey: @api_key, r: 'json')
+    @last_request_path = path_with_query(query_with_key)
+    response = @http_client.get(@base_url, query: query_with_key)
+    status = response.respond_to?(:code) ? response.code.to_i : nil
+    verify_response!(status)
+    parse_json(response&.body, status)
+  end
+
+  def path_with_query(query)
+    uri = URI(@base_url)
+    uri.query = URI.encode_www_form(query)
+    uri.to_s
+  end
+
+  def parse_json(body, status)
+    raise StandardError, "OMDb calendar response was empty (status #{status || 'unknown'})" if body.to_s.strip.empty?
+
+    JSON.parse(body)
+  rescue JSON::ParserError => e
+    raise StandardError, "OMDb calendar response was invalid JSON (status #{status || 'unknown'}): #{e.message}"
+  end
+
+  def verify_response!(status)
+    return if status && status.between?(200, 299)
+
+    raise StandardError, "OMDb calendar request failed with status #{status || 'unknown'}"
+  end
+
+  def normalize_search(payload, date_range)
+    return [] unless payload.is_a?(Hash)
+    return [] if payload['Response'] == 'False'
+
+    records = payload['Search'] || payload['search'] || payload
+    Array(records).filter_map { |record| normalize_record(record, date_range) }
+  end
+
+  def normalize_record(record, date_range)
+    return unless record.is_a?(Hash)
+
+    release_date = parse_date(record[:release_date] || record['release_date'] || record['Released'] || record['DVD'])
+    return unless release_date && date_range.cover?(release_date)
+
+    imdb_id = value_from(record, :external_id, :imdb_id, :imdbID)
+    title = value_from(record, :title, :Title)
+    media_type = normalize_type(value_from(record, :media_type, :Type))
+    return if imdb_id.to_s.strip.empty? || title.to_s.strip.empty? || media_type.empty?
+
+    {
+      source: 'omdb',
+      external_id: imdb_id.to_s,
+      title: title.to_s,
+      media_type: media_type,
+      genres: list_from(record, :genres, :Genre),
+      languages: list_from(record, :languages, :Language),
+      countries: list_from(record, :countries, :Country),
+      rating: float_value(value_from(record, :rating, :imdbRating)),
+      imdb_votes: votes_value(value_from(record, :imdb_votes, :imdbVotes)),
+      poster_url: url_value(value_from(record, :poster_url, :Poster)),
+      backdrop_url: url_value(value_from(record, :backdrop_url, :Backdrop)),
+      release_date: release_date,
+      ids: ids_for(imdb_id)
+    }
+  end
+
+  def normalize_type(value)
+    normalized = value.to_s.downcase
+    return 'movie' if normalized == 'movie'
+    return 'show' if normalized == 'series' || normalized.include?('series')
+
+    normalized.empty? ? 'movie' : normalized
+  end
+
+  def list_from(record, *keys)
+    value = value_from(record, *keys)
+    return [] if value.nil?
+
+    Array(value.is_a?(String) ? value.split(',') : value)
+      .map { |item| item.to_s.strip }
+      .reject(&:empty?)
+  end
+
+  def float_value(value)
+    return nil if value.nil? || value.to_s.strip.empty?
+
+    value.to_f
+  rescue StandardError
+    nil
+  end
+
+  def votes_value(value)
+    return nil if value.nil?
+
+    value.to_s.delete(',').to_i
+  rescue StandardError
+    nil
+  end
+
+  def url_value(value)
+    url = value.to_s.strip
+    url.empty? ? nil : url
+  end
+
+  def ids_for(imdb_id)
+    imdb_id.to_s.empty? ? {} : { 'imdb' => imdb_id }
+  end
+
+  def value_from(record, *keys)
+    keys.each do |key|
+      next unless key
+      value = record[key] || record[key.to_s] || record[key.to_sym]
+      return value unless value.nil?
+    end
+    nil
+  end
+
+  def parse_date(value)
+    return value if value.is_a?(Date)
+
+    Date.parse(value.to_s)
+  rescue StandardError
+    nil
+  end
+
+  def report_error(error, message)
+    @speaker&.tell_error(error, message)
+  end
+end

--- a/test/daemon_scheduler_calendar_test.rb
+++ b/test/daemon_scheduler_calendar_test.rb
@@ -63,7 +63,7 @@ class DaemonSchedulerCalendarTest < Minitest::Test
         'refresh_every' => refresh_every,
         'refresh_days' => 10,
         'refresh_limit' => 25,
-        'providers' => 'imdb|trakt'
+        'providers' => 'omdb|trakt'
       }
     }
     @environment.container.reload_config!(config)


### PR DESCRIPTION
## Summary
- add an OmdbApi client and OmdbCalendarProvider to replace the IMDb calendar feed wiring
- map OMDb fields into calendar normalization and update UI/docs to reference OMDb configuration
- refresh calendar feed tests and scheduler defaults to exercise the new provider

## Testing
- bundle exec ruby -Ilib -Itest test/services/calendar_feed_service_test.rb


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693467eb986483278a41ff5cb368088b)