### PR TITLE
Ensure calendar feed loads simple speaker

### DIFF
--- a/app/media_librarian/services/calendar_feed_service.rb
+++ b/app/media_librarian/services/calendar_feed_service.rb
@@ -6,6 +6,7 @@ require 'themoviedb'
 require 'json'
 require 'httparty'
 require_relative '../../../lib/omdb_api'
+require_relative '../../../lib/simple_speaker'
 require 'trakt'
 
 module MediaLibrarian


### PR DESCRIPTION
## Summary
- require `lib/simple_speaker` before loading `trakt` in `CalendarFeedService`

## Testing
- bundle exec ruby librarian.rb daemon start (stopped at interactive configuration prompt)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69346e0ad0b48327b90c910b8df1eee4)