### PR TITLE
Add daemon_send handling to speaker adapter

### DIFF
--- a/app/media_librarian/services/base_service.rb
+++ b/app/media_librarian/services/base_service.rb
@@ -43,6 +43,10 @@ module MediaLibrarian
         delegate&.tell_error(error, context, (in_mail.to_i if in_mail), *args)
       end
 
+      def daemon_send(*args, **kwargs)
+        delegate.daemon_send(*args, **kwargs) if delegate&.respond_to?(:daemon_send)
+      end
+
       private
 
       attr_reader :delegate

--- a/test/services/speaker_adapter_test.rb
+++ b/test/services/speaker_adapter_test.rb
@@ -38,6 +38,35 @@ module MediaLibrarian
 
         assert delegate.verify
       end
+
+      def test_daemon_send_delegates
+        delegate = Class.new do
+          attr_reader :calls
+
+          def initialize
+            @calls = []
+          end
+
+          def daemon_send(*args)
+            @calls << args
+          end
+
+          def respond_to?(method_name, include_all = false)
+            method_name == :daemon_send || super
+          end
+        end.new
+        adapter = SpeakerAdapter.new(delegate)
+
+        adapter.daemon_send(:run, :now)
+
+        assert_equal [[:run, :now]], delegate.calls
+      end
+
+      def test_daemon_send_no_op_without_speaker
+        adapter = SpeakerAdapter.new(nil)
+
+        assert_nil adapter.daemon_send(:ignored)
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary
- add a daemon_send helper to SpeakerAdapter to delegate when the speaker supports it
- cover delegation and nil-speaker behavior with new unit tests

## Testing
- bundle exec ruby -Itest test/services/speaker_adapter_test.rb (fails due to existing tell_error expectations)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693546bbab88832792f3c9c8d6fb4052)