### PR TITLE
Update calendar refresh logging with window details

### DIFF
--- a/app/calendar_feed.rb
+++ b/app/calendar_feed.rb
@@ -31,7 +31,7 @@ class CalendarFeed
       sources_label = provider_list ? provider_list.join(',') : 'all'
       speaker&.speak_up(
         "Refreshing calendar feed from #{date_range.first} to #{date_range.last} " \
-        "(limit: #{max_entries}, sources: #{sources_label})"
+        "(past: #{past_days}d, future: #{future_days}d, limit: #{max_entries}, sources: #{sources_label})"
       )
 
       calendar_service.refresh(date_range: date_range, limit: max_entries, sources: provider_list)


### PR DESCRIPTION
## Summary
- include past and future window lengths in the calendar refresh log message
- keep existing calendar refresh behavior while clarifying the spoken context

## Testing
- bundle exec ruby -Itest test/app/calendar_feed_test.rb
- bundle exec ruby -Itest test/services/calendar_feed_service_test.rb

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935ac9ea21c83278ade5f855b816f69)