### PR TITLE
Suppress banner for email/report commands

### DIFF
--- a/librarian.rb
+++ b/librarian.rb
@@ -266,8 +266,10 @@ class Librarian
       object = cmd[0..1].join(' ') if object.to_s.empty? || object == 'rcv'
       init_thread(Thread.current, object, direct, &block)
 
-      app.speaker.speak_up(String.new('Running command: '), 0)
-      app.speaker.speak_up("#{running_command}\n\n", 0)
+      unless internal_email_command?(object, sanitized_cmd)
+        app.speaker.speak_up(String.new('Running command: '), 0)
+        app.speaker.speak_up("#{running_command}\n\n", 0)
+      end
 
       thread_value =
         if direct.to_i > 0
@@ -335,6 +337,11 @@ class Librarian
       token.to_s.match?(/\A[a-z]/)
     end
     private :cli_direct_invocation?
+
+    def internal_email_command?(object, command)
+      object.to_s == 'email' || Array(command).map(&:to_s).first(2) == %w[Report push_email]
+    end
+    private :internal_email_command?
 
     def find_action(tokens)
       names = Array(tokens).take_while { |arg| arg.to_s !~ /^-/ }

--- a/test/librarian_cli_test.rb
+++ b/test/librarian_cli_test.rb
@@ -182,6 +182,21 @@ class LibrarianCliTest < Minitest::Test
     assert_includes messages, 'Job job-42 completed'
   end
 
+  def test_email_commands_do_not_emit_running_banner
+    env = use_environment(speaker: TestSupport::Fakes::Speaker.new)
+    MediaLibrarian.application = env.application
+    Librarian.new(container: env.container, args: [])
+
+    Report.stub(:push_email, ->(*) { :pushed }) do
+      Librarian.run_command(['Report', 'push_email', 'subject', 'body'], 1, 'email')
+    end
+
+    refute_includes env.application.speaker.messages, 'Running command: '
+    refute_includes env.application.speaker.messages, "Report push_email\n\n"
+  ensure
+    MediaLibrarian.application = nil
+  end
+
   def test_direct_route_cmd_restores_parent_thread_state
     env = use_environment
     old_application = MediaLibrarian.application


### PR DESCRIPTION
## Summary
- suppress the "Running command" banner when executing internal email or report delivery commands
- add regression coverage to ensure push_email executions stay quiet while keeping normal command logging unchanged

## Testing
- bundle exec rake test *(fails due to pre-existing Zeitwerk loader conflicts, mechanize cookie handling expectations, and SpeakerAdapter tell_error argument mocks)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936d774f8bc8327996c161e812a81aa)