### PR TITLE
Enable OMDb calendar provider and alias

### DIFF
--- a/app/media_librarian/services/calendar_feed_service.rb
+++ b/app/media_librarian/services/calendar_feed_service.rb
@@ -104,6 +104,7 @@ module MediaLibrarian
 
         tokens = Array(value).flat_map { |src| src.to_s.split(SOURCES_SEPARATOR) }
                               .map { |src| src.strip.downcase }
+                              .map { |src| src == 'imdb' ? 'omdb' : src }
                               .reject(&:empty?)
         tokens.empty? ? nil : tokens
       end
@@ -257,6 +258,8 @@ module MediaLibrarian
         return [] unless config.respond_to?(:[])
 
         providers = []
+        omdb_config = config['omdb']
+        providers << omdb_provider(omdb_config) if omdb_config.is_a?(Hash)
         tmdb_config = config['tmdb']
         if tmdb_config.is_a?(Hash)
           providers << TmdbCalendarProvider.new(


### PR DESCRIPTION
## Summary
- add OMDb calendar provider to the default provider list when configured
- normalize provider selections to treat `imdb` as an alias for `omdb`

## Testing
- bundle exec ruby -Itest test/services/calendar_feed_service_test.rb (fails: missing dependency checkout)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69372f38117c83278f034f75ccde6f7c)