### PR TITLE
Use OMDb search fallback for missing IMDb IDs

### DIFF
--- a/lib/omdb_api.rb
+++ b/lib/omdb_api.rb
@@ -42,6 +42,20 @@ class OmdbApi
     nil
   end
 
+  def find_by_title(title:, year: nil, type: 'movie')
+    return nil if @api_key.empty?
+    return nil if title.to_s.strip.empty?
+
+    query = { t: title, plot: 'short' }
+    query[:y] = year if year
+    query[:type] = type if type
+
+    normalize_detail(request(query))
+  rescue StandardError => e
+    report_error(e, 'OMDb title search failed')
+    nil
+  end
+
   private
 
   def years(date_range)


### PR DESCRIPTION
## Summary
- remove TMDB external ID lookups during calendar enrichment when IMDb IDs are missing
- add OMDb title/year search fallback to populate IMDb IDs and enrich movie entries
- update calendar feed tests to cover OMDb search behavior for TMDB and Trakt entries

## Testing
- bundle exec ruby -Itest test/services/calendar_feed_service_test.rb

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693805b1d8e4832781a5ffa2897512cf)