### PR TITLE
Extend calendar range and strengthen OMDb enrichment

### DIFF
--- a/app/media_librarian/services/calendar_feed_service.rb
+++ b/app/media_librarian/services/calendar_feed_service.rb
@@ -13,7 +13,7 @@ module MediaLibrarian
   module Services
     class CalendarFeedService < BaseService
       AuthenticationError = Class.new(StandardError)
-      DEFAULT_WINDOW_DAYS = 30
+      DEFAULT_WINDOW_DAYS = 365
       SOURCES_SEPARATOR = /[\s,|]+/.freeze
 
       def initialize(app: self.class.app, speaker: nil, file_system: nil, db: nil, providers: nil)
@@ -353,6 +353,11 @@ module MediaLibrarian
           entry[:imdb_votes] = details[:imdb_votes] unless details[:imdb_votes].nil?
           entry[:poster_url] ||= details[:poster_url]
           entry[:backdrop_url] ||= details[:backdrop_url]
+          entry[:release_date] ||= details[:release_date]
+
+          entry[:genres] = details[:genres] if Array(entry[:genres]).empty? && details[:genres].is_a?(Array) && details[:genres].any?
+          entry[:languages] = details[:languages] if Array(entry[:languages]).empty? && details[:languages].is_a?(Array) && details[:languages].any?
+          entry[:countries] = details[:countries] if Array(entry[:countries]).empty? && details[:countries].is_a?(Array) && details[:countries].any?
 
           omdb_enrichment_debug(
             "OMDb enrichment applied to #{entry[:title] || entry[:external_id]} (imdb=#{entry[:ids]['imdb']}, rating=#{entry[:rating].inspect}, votes=#{entry[:imdb_votes].inspect})"

--- a/config/conf.yml.example
+++ b/config/conf.yml.example
@@ -28,8 +28,8 @@ ffmpeg_settings:
 calendar:
   refresh_every: 12 hours
   refresh_on_start: true
-  window_past_days: 30
-  window_future_days: 45
+  window_past_days: 60
+  window_future_days: 365
   refresh_limit: 200
   providers: imdb|trakt|tmdb
 # imdb:

--- a/test/services/calendar_feed_service_test.rb
+++ b/test/services/calendar_feed_service_test.rb
@@ -76,7 +76,11 @@ class CalendarFeedServiceTest < Minitest::Test
       rating: nil,
       imdb_votes: nil,
       poster_url: nil,
-      backdrop_url: nil
+      backdrop_url: nil,
+      genres: [],
+      languages: [],
+      countries: [],
+      release_date: nil
     )
     provider = FakeProvider.new([entry])
     omdb_client = Class.new do
@@ -88,7 +92,16 @@ class CalendarFeedServiceTest < Minitest::Test
 
       def title(id)
         @calls << id
-        { rating: 9.3, imdb_votes: 234_567, poster_url: 'https://omdb.test/poster.jpg', backdrop_url: 'https://omdb.test/backdrop.jpg' }
+        {
+          rating: 9.3,
+          imdb_votes: 234_567,
+          poster_url: 'https://omdb.test/poster.jpg',
+          backdrop_url: 'https://omdb.test/backdrop.jpg',
+          genres: ['Drama'],
+          languages: ['fr'],
+          countries: ['FR'],
+          release_date: Date.new(2025, 12, 31)
+        }
       end
     end.new
 
@@ -105,6 +118,10 @@ class CalendarFeedServiceTest < Minitest::Test
     assert_equal 234_567, row[:imdb_votes]
     assert_equal 'https://omdb.test/poster.jpg', row[:poster_url]
     assert_equal 'https://omdb.test/backdrop.jpg', row[:backdrop_url]
+    assert_equal ['Drama'], row[:genres]
+    assert_equal ['fr'], row[:languages]
+    assert_equal ['FR'], row[:countries]
+    assert_equal Date.new(2025, 12, 31), row[:release_date]
   end
 
   def test_enriches_tmdb_entries_without_imdb_ids_using_omdb_search


### PR DESCRIPTION
## Summary
- extend the default calendar window and example configuration to cover a year ahead by default
- backfill calendar entries with OMDb genres, languages, countries, and release dates when missing

## Testing
- bundle exec ruby -Itest test/app/calendar_feed_test.rb test/services/calendar_feed_service_test.rb


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69383981815083279066db4ead5e2d8e)