### PR TITLE
Handle Torznab network errors gracefully

### DIFF
--- a/lib/torznab_tracker.rb
+++ b/lib/torznab_tracker.rb
@@ -64,6 +64,9 @@ class TorznabTracker
       }
     end
     result
+  rescue Torznab::Errors::HttpError, SocketError, Timeout::Error, Errno::ECONNREFUSED, Errno::ECONNRESET => e
+    MediaLibrarian.app.speaker.speak_up "Tracker '#{name}' network issue: #{e.message}"
+    []
   rescue => e
     MediaLibrarian.app.speaker.tell_error(e, Utils.arguments_dump(binding))
     []


### PR DESCRIPTION
## Summary
- rescue Torznab HTTP and related network errors during tracker searches
- log a concise warning and return an empty result so other trackers continue

## Testing
- bundle exec ruby -Itest test/services/tracker_query_service_test.rb


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69388e3c8cd48327ab5ec718821ebe82)