### PR TITLE
Add OMDb debug logging and enrichment context

### DIFF
--- a/app/media_librarian/services/calendar_feed_service.rb
+++ b/app/media_librarian/services/calendar_feed_service.rb
@@ -343,7 +343,10 @@ module MediaLibrarian
 
           unless details
             last_path = api.respond_to?(:last_request_path) ? api.last_request_path : nil
-            omdb_enrichment_debug("OMDb enrichment missing for #{entry[:title] || entry[:external_id]} (last_path=#{last_path})")
+            last_payload = api.respond_to?(:last_response_body) ? truncate_payload(api.last_response_body) : nil
+            omdb_enrichment_debug(
+              "OMDb enrichment missing for #{entry[:title] || entry[:external_id]} (last_path=#{last_path}, last_payload=#{last_payload})"
+            )
             next
           end
 
@@ -1142,6 +1145,13 @@ module MediaLibrarian
         def parse_year(value)
           year = value.to_s[/\d{4}/]
           year ? year.to_i : nil
+        end
+
+        def truncate_payload(payload)
+          payload = payload.to_s
+          return nil if payload.empty?
+
+          payload.length > 200 ? "#{payload[0, 200]}...[truncated]" : payload
         end
 
         def votes(value)


### PR DESCRIPTION
## Summary
- add debug logging in `OmdbApi#request` to capture the resolved request path and response payload when debugging is enabled
- retain the last OMDb response body for downstream access and use it in calendar enrichment diagnostics

## Testing
- bundle exec rake test *(fails: existing test errors unrelated to changes)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693953893f848327bdfe52fcea0f53aa)