### PR TITLE
Persist calendar synopses

### DIFF
--- a/app/calendar_entries_repository.rb
+++ b/app/calendar_entries_repository.rb
@@ -164,6 +164,7 @@ class CalendarEntriesRepository
       country: countries.find { |country| !country.to_s.empty? },
       imdb_rating: parse_rating(row[:rating] || row['rating']),
       imdb_votes: parse_integer(row[:imdb_votes] || row['imdb_votes']),
+      synopsis: normalize_synopsis(row[:synopsis] || row['synopsis']),
       release_date: release_date,
       downloaded: !!(row[:downloaded] || row['downloaded']),
       in_interest_list: !!(row[:in_interest_list] || row['in_interest_list']),
@@ -200,6 +201,11 @@ class CalendarEntriesRepository
   def normalize_url(value)
     url = value.to_s.strip
     url.empty? ? nil : url
+  end
+
+  def normalize_synopsis(value)
+    text = value.to_s.strip
+    text.empty? ? nil : text
   end
 
   def parse_rating(value)

--- a/app/web/app.css
+++ b/app/web/app.css
@@ -598,6 +598,17 @@ button:disabled {
   word-break: break-word;
 }
 
+.calendar-synopsis {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+  line-height: 1.35;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
 .calendar-body header {
   display: flex;
   justify-content: space-between;

--- a/app/web/app.js
+++ b/app/web/app.js
@@ -1388,6 +1388,17 @@ function renderCalendar(data = null) {
         header.append(titleEl, dateLabel);
         body.appendChild(header);
 
+        const synopsisText = (() => {
+          const rawSynopsis = pickEntryValue(entry, ['synopsis', 'overview', 'summary', 'description', 'plot']);
+          return rawSynopsis == null ? '' : String(rawSynopsis).trim();
+        })();
+        if (synopsisText) {
+          const synopsisEl = document.createElement('p');
+          synopsisEl.className = 'calendar-synopsis';
+          synopsisEl.textContent = synopsisText;
+          body.appendChild(synopsisEl);
+        }
+
         const badges = document.createElement('div');
         badges.className = 'calendar-badges';
         const type = pickEntryValue(entry, ['type', 'kind', 'category']);

--- a/lib/db/migrations/007_add_calendar_synopsis.rb
+++ b/lib/db/migrations/007_add_calendar_synopsis.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:calendar_entries) do
+      add_column :synopsis, :text
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add synopsis persistence to calendar entries, capturing description fields from providers
- introduce a migration to store synopsis text with calendar refresh data

## Testing
- bundle exec rake test *(fails: dependencies not installed; run `bundle install` to fetch archive-zip)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939ab2b81fc8327bc585898e766be17)