### PR TITLE
Improve watchlist loading and session sync

### DIFF
--- a/app/web/app.js
+++ b/app/web/app.js
@@ -1555,7 +1555,7 @@ async function loadLogs() {
   }
 }
 
-function renderWatchlist(entries = []) {
+function renderWatchlist(entries = [], { message } = {}) {
   const tbody = document.getElementById('watchlist-rows');
   const emptyHint = document.getElementById('watchlist-empty');
   if (!tbody || !emptyHint) {
@@ -1564,6 +1564,9 @@ function renderWatchlist(entries = []) {
 
   tbody.innerHTML = '';
   const normalized = Array.isArray(entries) ? entries : [];
+  const defaultMessage = emptyHint.dataset.defaultText || emptyHint.textContent || '';
+  emptyHint.dataset.defaultText = defaultMessage;
+  emptyHint.textContent = message || defaultMessage;
   if (!normalized.length) {
     emptyHint.classList.remove('hidden');
     return;
@@ -1627,14 +1630,13 @@ function renderWatchlist(entries = []) {
 }
 
 async function loadWatchlist() {
-  if (!state.authenticated) {
-    return;
-  }
   try {
     const data = await fetchJson('/watchlist');
     renderWatchlist(data?.entries || []);
   } catch (error) {
-    showNotification(error.message, 'error');
+    const message = error?.message || 'Impossible de charger la liste.';
+    renderWatchlist([], { message });
+    showNotification(message, 'error');
   }
 }
 
@@ -1724,7 +1726,7 @@ const TAB_LOADERS = {
 };
 
 async function refreshActiveTab(options = {}) {
-  if (!state.authenticated) {
+  if (!state.authenticated && !(await syncSession())) {
     return;
   }
   const loader = TAB_LOADERS[state.activeTab];
@@ -1795,16 +1797,22 @@ async function logout() {
   }
 }
 
-async function bootstrapSession() {
+async function syncSession() {
   try {
     const session = await fetchJson('/session');
-    if (!session || !session.username) {
-      return;
+    if (session?.username) {
+      setAuthenticated(true, session.username);
+      return true;
     }
-    setAuthenticated(true, session.username);
-    await refreshAll();
   } catch (error) {
-    // Auth required or other errors already handled.
+    // Authorization failures are handled by fetchJson.
+  }
+  return state.authenticated;
+}
+
+async function bootstrapSession() {
+  if (await syncSession()) {
+    await refreshAll();
   }
 }
 


### PR DESCRIPTION
## Summary
- allow the watchlist to load and handle authorization errors even when the UI state is unauthenticated
- surface watchlist fetch failures with the existing empty-state hint instead of silently skipping
- add a session sync check before refreshing tabs to keep the UI aligned with valid cookies

## Testing
- bundle exec rake test *(fails: repository dependencies are not installed; install gems to run)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939cccc6b5c83278a0e5c57a394b368)