### PR TITLE
Add IMDb identifiers to watchlist entries

### DIFF
--- a/app/library.rb
+++ b/app/library.rb
@@ -415,13 +415,15 @@ class Library
         ids = metadata[:ids] || metadata['ids'] || {}
         ids = {} unless ids.is_a?(Hash)
         ids = ids.each_with_object({}) { |(k, v), memo| memo[k.to_s] = v }
+        imdb_id = row[:imdb_id] || row['imdb_id'] || ids['imdb'] || row[:external_id] || row['external_id']
+        ids['imdb'] ||= imdb_id
         year = metadata[:year] || metadata['year']
         attrs = {
           obj_title: title,
           obj_year: year,
           obj_url: metadata[:url] || metadata['url'],
           watchlist: 1,
-          external_id: row[:external_id] || row['external_id'],
+          external_id: imdb_id,
         }
         attrs[:metadata] = metadata unless metadata.empty?
         name = type == 'movies' && year.to_i > 0 ? "#{title} (#{year})" : title

--- a/app/media_librarian/services/list_management_service.rb
+++ b/app/media_librarian/services/list_management_service.rb
@@ -62,11 +62,15 @@ module MediaLibrarian
           rows.each do |row|
             meta = normalize_metadata(row[:metadata])
             ids = meta[:ids] || {}
-            attrs = { already_followed: 1, watchlist: 1, external_id: row[:external_id] }
+            ids = {} unless ids.is_a?(Hash)
+            imdb_id = row[:imdb_id] || ids[:imdb] || ids['imdb'] || row[:external_id]
+            ids = ids.transform_keys { |k| k.is_a?(String) ? k : k.to_s }
+            ids['imdb'] ||= imdb_id
+            attrs = { already_followed: 1, watchlist: 1, external_id: imdb_id }
             attrs[:metadata] = meta unless meta.empty?
             title = build_watchlist_title(row[:title], meta[:year])
             search_list[cache_name] = Library.parse_media({ type: 'lists', name: title }, request.category, request.no_prompt, search_list[cache_name] || {}, {}, {}, attrs, '', ids)
-            calendar_entries.concat(build_calendar_entries(meta[:calendar_entries], ids, row[:external_id], request.category))
+            calendar_entries.concat(build_calendar_entries(meta[:calendar_entries], ids, imdb_id, request.category))
           end
           search_list[:calendar_entries] = calendar_entries unless calendar_entries.empty?
         when 'lists'

--- a/lib/db/migrations/008_add_imdb_id_to_watchlist.rb
+++ b/lib/db/migrations/008_add_imdb_id_to_watchlist.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'json'
+
+Sequel.migration do
+  up do
+    alter_table(:watchlist) do
+      add_column :imdb_id, Text, null: false, default: ''
+    end
+
+    self[:watchlist].each do |row|
+      metadata = row[:metadata]
+      parsed_metadata = begin
+        JSON.parse(metadata) if metadata.is_a?(String) && metadata.strip.start_with?('{', '[')
+      rescue StandardError
+        nil
+      end
+
+      imdb_id = if parsed_metadata.is_a?(Hash)
+                  ids = parsed_metadata['ids'] || parsed_metadata[:ids] || {}
+                  ids = ids.is_a?(Hash) ? ids : {}
+                  ids['imdb'] || ids[:imdb] || parsed_metadata['imdb_id'] || parsed_metadata['imdbID'] ||
+                    parsed_metadata[:imdb_id]
+                end
+      imdb_id ||= row[:external_id]
+      imdb_id = imdb_id.to_s.strip
+
+      self[:watchlist].where(external_id: row[:external_id], type: row[:type]).update(imdb_id: imdb_id)
+    end
+
+    alter_table(:watchlist) do
+      set_column_default :imdb_id, nil
+      drop_index [:external_id, :type], name: :idx_watchlist_external_type
+      add_index :imdb_id, unique: true, name: :idx_watchlist_imdb_id
+    end
+  end
+
+  down do
+    alter_table(:watchlist) do
+      drop_index :imdb_id, name: :idx_watchlist_imdb_id
+      add_index [:external_id, :type], unique: true, name: :idx_watchlist_external_type
+      drop_column :imdb_id
+    end
+  end
+end

--- a/lib/watchlist_store.rb
+++ b/lib/watchlist_store.rb
@@ -21,8 +21,11 @@ module WatchlistStore
     []
   end
 
-  def delete(external_id:, type: nil)
-    conditions = { external_id: external_id.to_s }
+  def delete(external_id: nil, imdb_id: nil, type: nil)
+    conditions = {}
+    conditions[:imdb_id] = imdb_id.to_s if imdb_id && !imdb_id.to_s.empty?
+    conditions[:external_id] = external_id.to_s if conditions.empty?
+    return 0 if conditions.empty?
     conditions[:type] = type if type && !type.to_s.empty?
     MediaLibrarian.app.db.delete_rows('watchlist', conditions).to_i
   rescue StandardError => e
@@ -34,16 +37,18 @@ module WatchlistStore
     Array(entries).filter_map do |entry|
       next unless entry
 
-      external_id = entry[:external_id] || entry['external_id']
+      metadata = normalize_metadata(entry[:metadata] || entry['metadata'])
+      imdb_id = imdb_id_for(entry, metadata)
+      external_id = (entry[:external_id] || entry['external_id'] || imdb_id).to_s
+      imdb_id = external_id if imdb_id.to_s.empty?
+
       title = entry[:title] || entry['title']
       type = entry[:type] || entry['type'] || 'movies'
-      next if external_id.to_s.empty? || title.to_s.empty?
-
-      metadata = entry[:metadata] || entry['metadata'] || {}
-      metadata = {} unless metadata.is_a?(Hash)
+      next if imdb_id.to_s.empty? || title.to_s.empty?
 
       {
-        external_id: external_id.to_s,
+        external_id: external_id,
+        imdb_id: imdb_id,
         type: type.to_s,
         title: title.to_s,
         metadata: metadata,
@@ -51,5 +56,21 @@ module WatchlistStore
       }
     end
   end
-  private_class_method :normalize_entries
+
+  def normalize_metadata(metadata)
+    return {} unless metadata.is_a?(Hash)
+
+    metadata
+  end
+
+  def imdb_id_for(entry, metadata)
+    explicit_imdb = entry[:imdb_id] || entry['imdb_id']
+    return explicit_imdb.to_s if explicit_imdb
+
+    ids = metadata[:ids] || metadata['ids'] || {}
+    return '' unless ids.is_a?(Hash)
+
+    (ids[:imdb] || ids['imdb']).to_s
+  end
+  private_class_method :normalize_entries, :normalize_metadata, :imdb_id_for
 end

--- a/test/services/list_management_service_test.rb
+++ b/test/services/list_management_service_test.rb
@@ -70,9 +70,10 @@ class ListManagementServiceTest < Minitest::Test
       WatchlistStore.upsert([
         {
           external_id: 'tmdb-42',
+          imdb_id: 'tt0042',
           type: 'movies',
           title: 'Sample',
-          metadata: { year: 2024, ids: { 'tmdb' => '42' }, calendar_entries: [{ external_id: 'tmdb-42' }] }
+          metadata: { year: 2024, ids: { 'tmdb' => '42', 'imdb' => 'tt0042' }, calendar_entries: [{ external_id: 'tmdb-42' }] }
         }
       ])
 
@@ -82,16 +83,16 @@ class ListManagementServiceTest < Minitest::Test
         source: { 'existing_folder' => { 'movies' => '/media/movies' } }
       )
 
-      parsed_media = { 'tmdb-42' => { already_followed: 1 } }
+      parsed_media = { 'tt0042' => { already_followed: 1 } }
       Library.stub(:parse_media, parsed_media) do
         existing = { 'tmdb-42' => { identifier: 'tmdb-42' } }
         Library.stub(:process_folder, existing) do
           files, search_list = @service.get_search_list(request)
 
           assert_equal existing, files['movies']
-          assert_equal parsed_media['tmdb-42'], search_list['tmdb-42']
+          assert_equal parsed_media['tt0042'], search_list['tt0042']
           assert_equal true, search_list[:calendar_entries].first[:downloaded]
-          assert_equal 'tmdb-42', search_list[:calendar_entries].first[:external_id]
+          assert_equal 'tt0042', search_list[:calendar_entries].first[:external_id]
         end
       end
     ensure


### PR DESCRIPTION
## Summary
- add a migration introducing a required `imdb_id` column on watchlist rows, backfilling existing data and replacing the old composite index with a unique IMDb index
- update watchlist ingestion paths and services to populate and propagate IMDb identifiers instead of relying on external_id uniqueness
- align watchlist-driven library/search flows and tests with the new canonical IMDb identifiers

## Testing
- bundle exec rake test *(fails: existing suite errors around Zeitwerk loader conflicts and calendar feed expectations, see console output)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939e0952fcc8327a81a61f6436b997e)