### PR TITLE
Display pending torrents in web downloads tab

### DIFF
--- a/app/web/index.html
+++ b/app/web/index.html
@@ -293,6 +293,55 @@
           aria-labelledby="tab-downloads"
           hidden
         >
+          <section class="panel" id="pending-torrents-panel">
+            <div class="panel-header">
+              <h2>Torrents en attente</h2>
+              <div class="panel-tools">
+                <div class="actions">
+                  <button id="refresh-pending-torrents" type="button">Rafraîchir</button>
+                </div>
+              </div>
+            </div>
+
+            <div class="download-list-table">
+              <div class="table-wrapper">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Nom</th>
+                      <th>Tracker</th>
+                      <th>Catégorie</th>
+                      <th>Ajouté</th>
+                      <th>Disponible le</th>
+                      <th>Identifiant</th>
+                    </tr>
+                  </thead>
+                  <tbody id="pending-validation-rows"></tbody>
+                </table>
+              </div>
+              <p class="hint" id="pending-validation-empty">Aucun torrent en attente de validation.</p>
+            </div>
+
+            <div class="download-list-table">
+              <div class="table-wrapper">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Nom</th>
+                      <th>Tracker</th>
+                      <th>Catégorie</th>
+                      <th>Ajouté</th>
+                      <th>Disponible le</th>
+                      <th>Identifiant</th>
+                    </tr>
+                  </thead>
+                  <tbody id="pending-download-rows"></tbody>
+                </table>
+              </div>
+              <p class="hint" id="pending-download-empty">Aucun torrent en attente de téléchargement.</p>
+            </div>
+          </section>
+
           <section class="panel" id="watchlist-panel">
             <div class="panel-header">
               <h2>Liste d'intérêt</h2>


### PR DESCRIPTION
## Summary
- add an authenticated control endpoint that returns torrents waiting for validation or download
- surface pending torrents in the downloads tab with dedicated tables and refresh controls
- format dates client-side for clearer display of pending torrent metadata

## Testing
- bundle exec rake test *(fails: existing calendar service and loader conflicts in test suite)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a801799d083279d41042c1d1517f3)