### PR TITLE
Add scheduler tab for scheduler tasks

### DIFF
--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -1297,7 +1297,20 @@ class Daemon
       path = scheduler_template_path
       return error_response(res, status: 404, message: 'scheduler_not_configured') unless path
 
-      handle_file_request(req, res, path, scheduler_mutex, 'GET, PUT')
+      case req.request_method
+      when 'GET'
+        content = scheduler_mutex.synchronize { File.exist?(path) ? File.read(path) : nil }
+        parsed =
+          begin
+            content ? YAML.safe_load(content, aliases: true) : nil
+          rescue Psych::SyntaxError
+            nil
+          end
+
+        json_response(res, body: { 'content' => content, 'entries' => parsed })
+      else
+        handle_file_request(req, res, path, scheduler_mutex, 'GET, PUT')
+      end
     end
 
     def handle_watchlist_request(req, res)

--- a/app/web/app.css
+++ b/app/web/app.css
@@ -351,6 +351,43 @@ button.danger:hover {
   background: rgba(15, 23, 42, 0.6);
 }
 
+.scheduler-tasks {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.scheduler-task {
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 1rem;
+  padding: 0.75rem 1rem;
+  background: rgba(15, 23, 42, 0.6);
+  display: flex;
+  gap: 0.75rem;
+  justify-content: space-between;
+  align-items: flex-start;
+  flex-wrap: wrap;
+}
+
+.scheduler-task .task-body {
+  display: grid;
+  gap: 0.35rem;
+  min-width: 0;
+}
+
+.scheduler-task .task-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 0.75rem;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.scheduler-task .task-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
 .job-children {
   list-style: none;
   margin: 0.75rem 0 0;

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -51,6 +51,16 @@
           Logs
         </button>
         <button
+          id="tab-scheduler"
+          class="tab-button"
+          type="button"
+          role="tab"
+          aria-selected="false"
+          data-tab="scheduler"
+        >
+          Scheduler
+        </button>
+        <button
           id="tab-calendar"
           class="tab-button"
           type="button"
@@ -134,6 +144,26 @@
               </div>
             </div>
             <div id="logs-container" class="logs"></div>
+          </section>
+        </section>
+
+        <section
+          class="tab-panel"
+          data-tab="scheduler"
+          role="tabpanel"
+          aria-labelledby="tab-scheduler"
+          hidden
+        >
+          <section class="panel" id="scheduler-tasks-panel">
+            <div class="panel-header">
+              <h2>Scheduler</h2>
+              <div class="actions">
+                <button id="refresh-scheduler-tasks" type="button">Actualiser</button>
+              </div>
+            </div>
+            <div id="scheduler-task-list" class="scheduler-tasks">
+              <p class="hint">Aucun scheduler configuré.</p>
+            </div>
           </section>
         </section>
 


### PR DESCRIPTION
## Summary
- add a Scheduler tab that lists parsed scheduler tasks with manual run buttons
- expose parsed scheduler YAML from the daemon and wire job submission from the UI
- cover scheduler task enqueuing with an integration test

## Testing
- bundle exec ruby -Itest test/daemon_integration_test.rb


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a809a3b288327b9c783bafe36cebf)