### PR TITLE
Add validation endpoint and UI actions for pending torrents

### DIFF
--- a/app/web/index.html
+++ b/app/web/index.html
@@ -344,6 +344,7 @@
                       <th>Ajouté</th>
                       <th>Disponible le</th>
                       <th>Identifiant</th>
+                      <th>Actions</th>
                     </tr>
                   </thead>
                   <tbody id="pending-validation-rows"></tbody>


### PR DESCRIPTION
## Summary
- add a POST /torrents/validate endpoint that marks status 1 torrents as validated
- expose a Validate button in the pending torrents list to trigger the new route and refresh the view
- update the pending validation table to include an Actions column

## Testing
- bundle exec rake test TEST=test/lib/storage_db_test.rb

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693aa44861608327bada80cd7b7a28bd)