### PR TITLE
Add file system scan service for local media cataloging

### DIFF
--- a/app/file_system_scan.rb
+++ b/app/file_system_scan.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class FileSystemScan
+  include MediaLibrarian::AppContainerSupport
+
+  def self.scan(root_path:, folder_types: {})
+    request = MediaLibrarian::Services::FileSystemScanRequest.new(
+      root_path: root_path,
+      folder_types: folder_types
+    )
+    MediaLibrarian::Services::FileSystemScanService.new(app: app).scan(request)
+  end
+end

--- a/app/media_librarian/services/file_system_scan_service.rb
+++ b/app/media_librarian/services/file_system_scan_service.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require 'find'
+
+module MediaLibrarian
+  module Services
+    class FileSystemScanService < BaseService
+      def scan(request)
+        root = File.expand_path(request.root_path.to_s)
+        unless file_system.directory?(root)
+          speaker.speak_up("Root path #{root} not found")
+          return []
+        end
+
+        mapped_folders = request.folder_types
+        mapped_folders[root] ||= 'movies'
+
+        results = []
+        Find.find(root) do |path|
+          next if File.directory?(path)
+          next unless video_file?(path)
+
+          type = media_type_for(path, mapped_folders)
+          next unless type
+
+          metadata = extract_metadata(path, type, root)
+          next unless metadata
+
+          persist(metadata)
+          results << metadata
+        end
+
+        results
+      rescue StandardError => e
+        speaker.tell_error(e, Utils.arguments_dump(binding))
+        []
+      end
+
+      private
+
+      def media_type_for(path, mapped_folders)
+        expanded_path = File.expand_path(path)
+        folder = mapped_folders.keys.sort_by(&:length).reverse.find do |mapped_folder|
+          expanded_path.start_with?(mapped_folder)
+        end
+        mapped_folders[folder] if folder
+      end
+
+      def extract_metadata(path, type, base_folder)
+        item_name, item = Metadata.identify_title(path, type, 1, folder_hierarchy[type], base_folder)
+        return unless item && item_name
+
+        full_name, _ids, info = Metadata.parse_media_filename(path, type, item, item_name, 1, folder_hierarchy, base_folder)
+        subject = info[:movie] || info[:show] || item
+        external_id, source = extract_external_id(subject)
+        return if external_id.to_s.empty?
+
+        {
+          media_type: type,
+          title: full_name,
+          year: subject.respond_to?(:year) ? subject.year : Metadata.identify_release_year(full_name),
+          external_id: external_id,
+          external_source: source,
+          local_path: path
+        }
+      end
+
+      def extract_external_id(subject)
+        ids = subject.respond_to?(:ids) ? subject.ids || {} : {}
+        prioritized = %w[imdb tmdb thetvdb tvdb trakt slug]
+        key = prioritized.find { |k| ids[k] || ids[k.to_sym] }
+        [ids[key] || ids[key&.to_sym], key]
+      end
+
+      def persist(metadata)
+        app.db.insert_row('local_media', metadata, 1)
+      end
+
+      def folder_hierarchy
+        defined?(FOLDER_HIERARCHY) ? FOLDER_HIERARCHY : {}
+      end
+
+      def video_file?(path)
+        extension = File.extname(path).delete('.').downcase
+        EXTENSIONS_TYPE[:video].include?(extension)
+      end
+    end
+  end
+end

--- a/lib/db/migrations/010_create_local_media.rb
+++ b/lib/db/migrations/010_create_local_media.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    create_table?(:local_media) do
+      primary_key :id
+      Text :media_type, null: false
+      Text :title, null: false
+      Integer :year
+      Text :external_id, null: false
+      Text :external_source
+      Text :local_path, null: false
+      DateTime :created_at
+
+      index [:media_type, :external_id], unique: true, name: :idx_local_media_type_external_id
+    end
+  end
+end

--- a/lib/media_librarian/command_registry.rb
+++ b/lib/media_librarian/command_registry.rb
@@ -30,6 +30,7 @@ module MediaLibrarian
           create_custom_list: ['Library', 'create_custom_list'],
           fetch_media_box: ['Library', 'fetch_media_box'],
           handle_completed_download: ['Library', 'handle_completed_download', 4, 'handle_completed_download', 1],
+          scan_file_system: ['FileSystemScan', 'scan'],
           import_csv: ['ListStore', 'import_csv'],
           process_folder: ['Library', 'process_folder']
         },

--- a/lib/media_librarian/services/file_system_scan_request.rb
+++ b/lib/media_librarian/services/file_system_scan_request.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module MediaLibrarian
+  module Services
+    class FileSystemScanRequest
+      attr_reader :root_path, :folder_types
+
+      def initialize(root_path:, folder_types: {})
+        @root_path = root_path
+        @folder_types = normalize(folder_types)
+      end
+
+      private
+
+      def normalize(folder_types)
+        (folder_types || {}).each_with_object({}) do |(path, type), memo|
+          next if path.to_s.empty?
+
+          memo[File.expand_path(path)] = type.to_s
+        end
+      end
+    end
+  end
+end

--- a/test/services/file_system_scan_service_test.rb
+++ b/test/services/file_system_scan_service_test.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'tmpdir'
+require 'fileutils'
+
+require_relative 'service_test_helper'
+require_relative '../../lib/metadata'
+require_relative '../../lib/media_librarian/services/file_system_scan_request'
+require_relative '../../app/media_librarian/services/base_service'
+require_relative '../../app/media_librarian/services/file_system_scan_service'
+
+class FileSystemScanServiceTest < Minitest::Test
+  class RecordingDb
+    attr_reader :rows
+
+    def initialize
+      @rows = []
+    end
+
+    def insert_row(table, values, or_replace = 0)
+      @rows << values.merge(table: table, replace: or_replace)
+    end
+  end
+
+  def setup
+    @tmp_dir = Dir.mktmpdir('scan-service')
+    @file_path = File.join(@tmp_dir, 'Example (2021).mkv')
+    File.write(@file_path, '')
+
+    @speaker = TestSupport::Fakes::Speaker.new
+    @db = RecordingDb.new
+    @app = Struct.new(:db, :speaker).new(@db, @speaker)
+    @service = MediaLibrarian::Services::FileSystemScanService.new(app: @app)
+  end
+
+  def teardown
+    FileUtils.remove_entry(@tmp_dir) if @tmp_dir && Dir.exist?(@tmp_dir)
+  end
+
+  def test_reports_missing_root
+    request = MediaLibrarian::Services::FileSystemScanRequest.new(root_path: '/missing/path')
+
+    @service.scan(request)
+
+    assert_includes @speaker.messages, 'Root path /missing/path not found'
+  end
+
+  def test_persists_detected_media
+    movie = Struct.new(:ids, :year).new({ 'imdb' => 'tt1234567' }, 2021)
+    request = MediaLibrarian::Services::FileSystemScanRequest.new(
+      root_path: @tmp_dir,
+      folder_types: { @tmp_dir => 'movies' }
+    )
+
+    Metadata.stub(:identify_title, ['Example', movie]) do
+      Metadata.stub(:parse_media_filename, ['Example (2021)', ['movieExample2021'], { movie: movie }]) do
+        @service.scan(request)
+      end
+    end
+
+    assert_equal 1, @db.rows.length
+    row = @db.rows.first
+    assert_equal 'local_media', row[:table]
+    assert_equal 'movies', row[:media_type]
+    assert_equal 'Example (2021)', row[:title]
+    assert_equal 2021, row[:year]
+    assert_equal 'tt1234567', row[:external_id]
+    assert_equal @file_path, row[:local_path]
+    assert_equal 1, row[:replace]
+  end
+end


### PR DESCRIPTION
## Summary
- add a filesystem scan service and request to catalog local media files with existing metadata helpers
- store discovered entries in a new `local_media` table with a uniqueness constraint on media type and external id
- expose the scan via the command registry and cover it with service-level tests

## Testing
- bundle exec ruby -Itest test/services/file_system_scan_service_test.rb


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ae957f1388327942eed1a04fad527)