### PR TITLE
Mark calendar entries as downloaded from local inventory

### DIFF
--- a/app/web/app.css
+++ b/app/web/app.css
@@ -676,6 +676,17 @@ button:disabled {
   font-size: 0.85rem;
 }
 
+.calendar-badge--success {
+  background: rgba(34, 197, 94, 0.18);
+  border-color: rgba(34, 197, 94, 0.35);
+  color: #dcfce7;
+}
+
+.calendar-item--downloaded {
+  border-color: rgba(34, 197, 94, 0.45);
+  box-shadow: 0 0 0 1px rgba(34, 197, 94, 0.25);
+}
+
 .calendar-meta {
   color: var(--muted);
   font-size: 0.9rem;

--- a/app/web/app.js
+++ b/app/web/app.js
@@ -1309,7 +1309,11 @@ function resolveIdentifier(entry) {
 }
 
 function isDownloaded(entry) {
-  const flag = pickEntryValue(entry, ['downloaded', 'is_downloaded', 'download_status', 'status']);
+  const downloaded = pickEntryValue(entry, ['downloaded']);
+  if (downloaded !== undefined && downloaded !== null) {
+    return Boolean(downloaded);
+  }
+  const flag = pickEntryValue(entry, ['is_downloaded', 'download_status', 'status']);
   if (typeof flag === 'string') {
     return flag.toLowerCase().includes('download');
   }
@@ -1409,6 +1413,11 @@ function renderCalendar(data = null) {
         const item = document.createElement('article');
         item.className = 'calendar-item';
 
+        const downloaded = isDownloaded(entry);
+        if (downloaded) {
+          item.classList.add('calendar-item--downloaded');
+        }
+
         const titleText = pickEntryValue(entry, ['title', 'name']) || 'Titre inconnu';
         const mediaUrl = pickEntryValue(entry, ['poster_url', 'poster', 'backdrop_url', 'backdrop']);
         const media = document.createElement('div');
@@ -1483,8 +1492,10 @@ function renderCalendar(data = null) {
         if (genres.length) {
           badges.appendChild(makeCalendarBadge(genres.slice(0, 3).join(', ')));
         }
-        if (isDownloaded(entry)) {
-          badges.appendChild(makeCalendarBadge('Téléchargé'));
+        if (downloaded) {
+          const badge = makeCalendarBadge('Téléchargé');
+          badge.classList.add('calendar-badge--success');
+          badges.appendChild(badge);
         }
         const inWatchlist = isInWatchlist(entry);
         if (inWatchlist) {

--- a/test/app/calendar_entries_repository_test.rb
+++ b/test/app/calendar_entries_repository_test.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require_relative '../../app/calendar_entries_repository'
+
+class CalendarEntriesRepositoryTest < Minitest::Test
+  class FakeDb
+    def initialize(calendar_rows:, local_rows:, tables: [:calendar_entries, :local_media])
+      @calendar_rows = calendar_rows
+      @local_rows = local_rows
+      @tables = tables
+    end
+
+    def get_rows(table, *_args)
+      case table.to_sym
+      when :calendar_entries
+        @calendar_rows
+      when :local_media
+        @local_rows
+      else
+        []
+      end
+    end
+
+    def table_exists?(table)
+      @tables.include?(table.to_sym)
+    end
+  end
+
+  def setup
+    @app = Struct.new(:db).new(nil)
+  end
+
+  def test_marks_entries_downloaded_when_inventory_matches_imdb
+    calendar_rows = [
+      { media_type: 'movie', title: 'Alpha', ids: { 'imdb' => 'tt1234' } }
+    ]
+    local_rows = [
+      { media_type: 'movies', external_id: 'tt1234', external_source: 'imdb', title: 'Alpha', local_path: '/tmp/a' }
+    ]
+    @app.db = FakeDb.new(calendar_rows: calendar_rows, local_rows: local_rows)
+
+    entries = CalendarEntriesRepository.new(app: @app).load_entries
+
+    assert_equal 1, entries.length
+    assert entries.first[:downloaded]
+  end
+
+  def test_skips_download_flag_when_local_media_table_missing
+    calendar_rows = [
+      { media_type: 'show', title: 'Bravo', ids: { 'tmdb' => '42' } }
+    ]
+    @app.db = FakeDb.new(calendar_rows: calendar_rows, local_rows: [], tables: [:calendar_entries])
+
+    entries = CalendarEntriesRepository.new(app: @app).load_entries
+
+    refute entries.first[:downloaded]
+  end
+end


### PR DESCRIPTION
## Summary
- derive calendar entry downloaded state from the local_media inventory using IMDb/TMDb identifiers
- use the derived flag on the calendar UI with a dedicated badge and styling
- add coverage for the repository’s integration with the local inventory

## Testing
- bundle exec ruby -Itest test/app/calendar_entries_repository_test.rb

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693aece9dad08327a721be15f57359c2)