### PR TITLE
Use local media repository for existing sources

### DIFF
--- a/app/library.rb
+++ b/app/library.rb
@@ -1,3 +1,5 @@
+require_relative 'local_media_repository'
+
 class Library
   include MediaLibrarian::AppContainerSupport
 
@@ -439,12 +441,7 @@ class Library
           ids
         )
       end
-      existing_path = source.dig('existing_folder', category)
-      if existing_path.to_s != ''
-        existing_files[category] = process_folder(type: category, folder: existing_path, no_prompt: no_prompt)
-      else
-        existing_files[category] = {}
-      end
+      existing_files[category] = existing_media_from_db(category, source.dig('existing_folder', category))
     when 'search'
       keywords = source['keywords']
       keywords = [keywords] if keywords.is_a?(String)
@@ -533,6 +530,12 @@ class Library
     app.speaker.tell_error(e, Utils.arguments_dump(binding))
     media_list.delete(cache_name)
     {}
+  end
+
+  def self.existing_media_from_db(category, folder)
+    return {} if folder.to_s.empty?
+
+    LocalMediaRepository.new(app: app).library_index(type: category, folder: folder) || {}
   end
 
   def self.rename_media_file(original, destination, type, item_name = '', item = nil, no_prompt = 0, hard_link = 0, replaced_outdated = 0, folder_hierarchy = {}, ensure_qualities = '', base_folder = Dir.home)

--- a/app/local_media_repository.rb
+++ b/app/local_media_repository.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+class LocalMediaRepository
+  include MediaLibrarian::AppContainerSupport
+
+  def initialize(app: self.class.app)
+    self.class.configure(app: app)
+  end
+
+  def library_index(type:, folder: nil)
+    rows = fetch_rows(type, folder)
+    rows.each_with_object({}) do |row, memo|
+      identifiers = build_identifiers(row)
+      next if identifiers.empty?
+
+      file = { type: 'file', name: row[:local_path], f_type: type, parts: [row[:local_path]] }
+      attrs = { obj_title: row[:title], obj_year: row[:year], f_type: type }
+      Metadata.media_add(row[:title], type, row[:title], identifiers, attrs, { f_type: type }, file, memo)
+    end
+  end
+
+  private
+
+  def build_identifiers(row)
+    id = (row[:external_id] || row['external_id']).to_s
+    return [] if id.empty?
+
+    source = (row[:external_source] || row['external_source']).to_s
+    [id, (source.empty? ? nil : "#{source}#{id}")].compact.uniq
+  end
+
+  def fetch_rows(type, folder)
+    return [] unless app&.respond_to?(:db)
+
+    additionals = {}
+    if folder.to_s != ''
+      normalized = File.expand_path(folder.to_s)
+      additionals['local_path like'] = "#{normalized}%"
+    end
+
+    app.db.get_rows(:local_media, { media_type: type.to_s }, additionals)
+  rescue StandardError => e
+    app&.speaker&.tell_error(e, Utils.arguments_dump(binding)) if app&.respond_to?(:speaker)
+    []
+  end
+end

--- a/test/services/list_management_service_test.rb
+++ b/test/services/list_management_service_test.rb
@@ -14,6 +14,20 @@ require_relative '../../lib/watchlist_store'
 require_relative '../../lib/storage/db'
 
 class ListManagementServiceTest < Minitest::Test
+  class StubLocalMediaRepository
+    attr_reader :calls
+
+    def initialize(response)
+      @response = response
+      @calls = []
+    end
+
+    def library_index(type:, folder:)
+      @calls << { type: type, folder: folder }
+      @response
+    end
+  end
+
   def setup
     @speaker = TestSupport::Fakes::Speaker.new
     @service = MediaLibrarian::Services::ListManagementService.new(
@@ -85,18 +99,46 @@ class ListManagementServiceTest < Minitest::Test
 
       parsed_media = { 'tt0042' => { already_followed: 1 } }
       Library.stub(:parse_media, parsed_media) do
-        existing = { 'tmdb-42' => { identifier: 'tmdb-42' } }
-        Library.stub(:process_folder, existing) do
-          files, search_list = @service.get_search_list(request)
+        repo_data = { 'tmdb-42' => { identifier: 'tmdb-42' }, 'tt0042' => { identifier: 'tt0042' } }
+        repo = StubLocalMediaRepository.new(repo_data)
+        LocalMediaRepository.stub(:new, repo) do
+          Library.stub(:process_folder, ->(**_) { flunk 'process_folder should not be called' }) do
+            files, search_list = @service.get_search_list(request)
 
-          assert_equal existing, files['movies']
-          assert_equal parsed_media['tt0042'], search_list['tt0042']
-          assert_equal true, search_list[:calendar_entries].first[:downloaded]
-          assert_equal 'tt0042', search_list[:calendar_entries].first[:external_id]
+            assert_equal repo_data, files['movies']
+            assert_equal parsed_media['tt0042'], search_list['tt0042']
+            assert_equal true, search_list[:calendar_entries].first[:downloaded]
+            assert_equal 'tt0042', search_list[:calendar_entries].first[:external_id]
+            assert_equal [{ type: 'movies', folder: '/media/movies' }], repo.calls.map { |call| { type: call[:type], folder: call[:folder] } }.uniq
+          end
         end
       end
     ensure
       MediaLibrarian.instance_variable_set(:@application, previous_app)
+    end
+  end
+
+  def test_filesystem_source_reads_existing_media_from_db_only
+    request = MediaLibrarian::Services::SearchListRequest.new(
+      source_type: 'filesystem',
+      category: 'movies',
+      source: {
+        'existing_folder' => { 'movies' => '/media/movies' },
+        'list_name' => 'library'
+      }
+    )
+
+    repo_data = { 'tt0001' => { identifier: 'tt0001', files: [{ name: '/media/movies/sample.mkv' }] } }
+    repo = StubLocalMediaRepository.new(repo_data)
+
+    LocalMediaRepository.stub(:new, repo) do
+      Library.stub(:process_folder, ->(**_) { flunk 'process_folder should not be invoked' }) do
+        files, search_list = @service.get_search_list(request)
+
+        assert_equal repo_data, files['movies']
+        assert_equal repo_data, search_list
+        assert_equal [{ type: 'movies', folder: '/media/movies' }], repo.calls.map { |call| { type: call[:type], folder: call[:folder] } }.uniq
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary
- add a LocalMediaRepository to read persisted local media into the structures used by search and calendar annotations
- update Library and ListManagementService to use database-backed existing media instead of scanning folders for existing_folder sources
- expand list management service tests to cover database lookups and calendar annotations without filesystem traversal

## Testing
- bundle exec ruby -Itest test/services/list_management_service_test.rb


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693aee3e071483279dccee15eefdaaeb)