### PR TITLE
Use folder type parameter for file system scan

### DIFF
--- a/app/file_system_scan.rb
+++ b/app/file_system_scan.rb
@@ -3,10 +3,10 @@
 class FileSystemScan
   include MediaLibrarian::AppContainerSupport
 
-  def self.scan(root_path:, folder_types: {})
+  def self.scan(root_path:, type: 'movies')
     request = MediaLibrarian::Services::FileSystemScanRequest.new(
       root_path: root_path,
-      folder_types: folder_types
+      type: type
     )
     MediaLibrarian::Services::FileSystemScanService.new(app: app).scan(request)
   end

--- a/app/media_librarian/services/file_system_scan_service.rb
+++ b/app/media_librarian/services/file_system_scan_service.rb
@@ -12,15 +12,9 @@ module MediaLibrarian
           return []
         end
 
-        mapped_folders = request.folder_types
-        mapped_folders[root] ||= 'movies'
-
-        mapped_folders.flat_map do |folder, type|
-          next [] unless file_system.directory?(folder)
-
-          library = Library.process_folder(type: type, folder: folder, no_prompt: 1, cache_expiration: 1)
-          persist_media_entries(library, type)
-        end.flatten
+        folder_type = request.type.empty? ? 'movies' : request.type
+        library = Library.process_folder(type: folder_type, folder: root, no_prompt: 1, cache_expiration: 1)
+        persist_media_entries(library, folder_type)
       rescue StandardError => e
         speaker.tell_error(e, Utils.arguments_dump(binding))
         []

--- a/lib/media_librarian/services/file_system_scan_request.rb
+++ b/lib/media_librarian/services/file_system_scan_request.rb
@@ -3,21 +3,17 @@
 module MediaLibrarian
   module Services
     class FileSystemScanRequest
-      attr_reader :root_path, :folder_types
+      attr_reader :root_path, :type
 
-      def initialize(root_path:, folder_types: {})
+      def initialize(root_path:, type: nil)
         @root_path = root_path
-        @folder_types = normalize(folder_types)
+        @type = normalize(type)
       end
 
       private
 
-      def normalize(folder_types)
-        (folder_types || {}).each_with_object({}) do |(path, type), memo|
-          next if path.to_s.empty?
-
-          memo[File.expand_path(path)] = type.to_s
-        end
+      def normalize(type)
+        type.to_s
       end
     end
   end

--- a/test/services/file_system_scan_service_test.rb
+++ b/test/services/file_system_scan_service_test.rb
@@ -49,7 +49,7 @@ class FileSystemScanServiceTest < Minitest::Test
     movie = Struct.new(:ids, :year).new({ 'imdb' => 'tt1234567' }, 2021)
     request = MediaLibrarian::Services::FileSystemScanRequest.new(
       root_path: @tmp_dir,
-      folder_types: { @tmp_dir => 'movies' }
+      type: 'movies'
     )
 
     library = {


### PR DESCRIPTION
## Summary
- switch file system scan to accept a single folder type argument
- simplify scan request and service processing logic
- update tests for the new scan signature

## Testing
- bundle exec ruby -Itest test/services/file_system_scan_service_test.rb

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b0335380c832788e9fdadd10d1e0f)