### PR TITLE
Sanitize tracker titles in search URLs

### DIFF
--- a/app/web/tracker_links.js
+++ b/app/web/tracker_links.js
@@ -26,6 +26,7 @@
     }
 
     const normalizedTitle = (metadata.title || '').toString().trim();
+    const sanitizedTitle = normalizedTitle.replace(/[^\p{L}\p{N}\s]/gu, '');
     const normalizedYear = metadata.year == null ? '' : metadata.year.toString().trim();
     const normalizedImdb = (metadata.imdb || metadata.imdbid || '').toString().trim();
 
@@ -36,7 +37,7 @@
 
     let url = normalizedTemplate;
     const replacements = {
-      '%title%': normalizedTitle,
+      '%title%': sanitizedTitle,
       '%year%': normalizedYear,
       '%imdbid%': normalizedImdb,
     };

--- a/test/web/tracker_links.test.js
+++ b/test/web/tracker_links.test.js
@@ -32,3 +32,11 @@ test('buildTrackerSearchUrl encodes placeholders and validates required fields',
   assert.equal(buildTrackerSearchUrl(template, { title: 'Film' }), '');
   assert.equal(buildTrackerSearchUrl('https://tracker/%title%', { title: 'Film' }), 'https://tracker/Film');
 });
+
+test('buildTrackerSearchUrl strips punctuation from titles before encoding', () => {
+  const url = buildTrackerSearchUrl('https://tracker/%title%', {
+    title: 'Blade: Runner, 2049.',
+  });
+
+  assert.equal(url, 'https://tracker/Blade%20Runner%202049');
+});


### PR DESCRIPTION
## Summary
- sanitize tracker title placeholders by removing punctuation before encoding
- ensure tracker search URLs omit punctuation in title replacements
- add tests covering titles with punctuation in tracker search URLs

## Testing
- node --test test/web/tracker_links.test.js


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b0652fc1c83278f98043f8c0bcfff)