### PR TITLE
Use Daemon.kill for job cancellation endpoint

### DIFF
--- a/app/client.rb
+++ b/app/client.rb
@@ -37,6 +37,10 @@ class Client
     perform(:get, "/jobs/#{job_id}")
   end
 
+  def kill_job(job_id)
+    perform(:delete, "/jobs/#{job_id}")
+  end
+
   def stop
     perform(:post, '/stop')
   end

--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -1146,8 +1146,16 @@ class Daemon
         return handle_job_not_found(res) unless req.path.start_with?('/jobs/')
 
         handle_job_lookup(req, res)
+      when 'DELETE'
+        return handle_job_not_found(res) unless req.path.start_with?('/jobs/')
+
+        jid = req.path.sub('/jobs/', '')
+        cancelled = Daemon.kill(jid: jid)
+        return handle_job_not_found(res) unless cancelled
+
+        json_response(res, body: { 'status' => 'cancelled', 'id' => jid })
       else
-        method_not_allowed(res, 'GET, POST')
+        method_not_allowed(res, 'GET, POST, DELETE')
       end
     rescue Concurrent::RejectedExecutionError
       error_response(res, status: 429, message: 'queue_full')

--- a/app/web/app.css
+++ b/app/web/app.css
@@ -413,10 +413,22 @@ button.danger:hover {
 .job-item header {
   display: flex;
   justify-content: space-between;
-  align-items: baseline;
+  align-items: center;
   font-size: 0.95rem;
   margin-bottom: 0.5rem;
   padding: 0;
+}
+
+.job-header-main {
+  display: flex;
+  gap: 0.75rem;
+  align-items: baseline;
+}
+
+.job-actions {
+  display: flex;
+  gap: 0.35rem;
+  align-items: center;
 }
 
 .job-meta {

--- a/test/daemon_integration_test.rb
+++ b/test/daemon_integration_test.rb
@@ -115,6 +115,19 @@ class DaemonIntegrationTest < Minitest::Test
     assert_equal 200, status['status_code']
   end
 
+  def test_running_job_can_be_cancelled_via_http
+    boot_daemon_environment
+
+    killed = []
+    Daemon.stub(:kill, ->(jid:) { killed << jid }) do
+      response = control_delete('/jobs/demo')
+      assert_equal 200, response[:status_code]
+      assert_equal 'cancelled', response.dig(:body, 'status')
+    end
+
+    assert_equal ['demo'], killed
+  end
+
   def test_reload_refreshes_configuration_and_scheduler
     scheduler_name = 'reload_scheduler'
 


### PR DESCRIPTION
## Summary
- delegate the DELETE /jobs/:id handler to the existing Daemon.kill helper

## Testing
- bundle exec ruby -Itest test/daemon_integration_test.rb

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b0642967083278820c826234abefd)