### PR TITLE
Refine auto refresh behavior

### DIFF
--- a/app/web/app.js
+++ b/app/web/app.js
@@ -150,11 +150,11 @@ function stopAutoRefresh() {
 function startAutoRefresh() {
   stopAutoRefresh();
   state.autoRefresh = window.setInterval(() => {
-    if (!state.authenticated) {
+    if (!state.authenticated || document.visibilityState === 'hidden') {
       return;
     }
-    refreshAll();
-  }, 10000);
+    refreshActiveTab();
+  }, 15000);
 }
 
 function setTrackerTemplates(trackers = []) {


### PR DESCRIPTION
## Summary
- adjust automatic refresh to skip hidden pages and only reload the active tab
- increase the auto-refresh interval to reduce background network load while keeping full refreshes manual

## Testing
- `bundle exec rake test` *(fails: existing test failures in SpeakerAdapterTest, TrackerQueryServiceTest, and Zeitwerk loader conflicts; see log)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b12bd076c8327b05a0826b1f440ab)