### PR TITLE
Capture watchlist metadata for release info

### DIFF
--- a/app/web/app.js
+++ b/app/web/app.js
@@ -1376,6 +1376,39 @@ async function addToWatchlist(entry, button) {
     type: pickEntryValue(entry, ['type', 'kind', 'category']) || '',
     title: pickEntryValue(entry, ['title', 'name']) || '',
   };
+
+  const metadata = {};
+  const releaseDate = resolveCalendarDate(entry);
+  const releaseYear = pickEntryValue(entry, ['year', 'release_year']) || releaseDate?.getFullYear();
+  const ids = { ...(entry?.ids || {}) };
+  ['imdb', 'imdb_id', 'tmdb', 'tmdb_id', 'tvdb', 'tvdb_id', 'trakt', 'trakt_id'].forEach((key) => {
+    const value = pickEntryValue(entry, [key]);
+    if (value) {
+      ids[key] = value;
+    }
+  });
+
+  if (releaseYear) {
+    metadata.year = releaseYear;
+  }
+  if (releaseDate instanceof Date && !Number.isNaN(releaseDate.getTime())) {
+    metadata.release_date = releaseDate.toISOString();
+  }
+  const imdbId = ids.imdb || ids.imdb_id;
+  if (imdbId) {
+    payload.imdb_id = imdbId;
+  }
+  const cleanIds = Object.fromEntries(Object.entries(ids).filter(([, value]) => value));
+  if (Object.keys(cleanIds).length) {
+    metadata.ids = cleanIds;
+  }
+  const url = resolveExternalUrl(entry);
+  if (url) {
+    metadata.url = url;
+  }
+  if (Object.keys(metadata).length) {
+    payload.metadata = metadata;
+  }
   if (!payload.id && !payload.title) {
     showNotification("Impossible d'ajouter cet élément.", 'error');
     return;


### PR DESCRIPTION
## Summary
- include release year, IDs, and external URL metadata when adding items to the watchlist
- preserve IMDb ID in the payload to support tracker links
- ensure watchlist rows can show release years and linked resources

## Testing
- bundle exec rake test TEST=test/services/list_management_service_test.rb


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b12b36b8c83279aab5802ba3ab9c1)