### PR TITLE
Require tvmaze during application setup

### DIFF
--- a/lib/media_librarian/application.rb
+++ b/lib/media_librarian/application.rb
@@ -122,6 +122,7 @@ module MediaLibrarian
 
     def setup_dependencies
       Bundler.require(:default)
+      require 'tvmaze' unless defined?(TVMaze::Show)
       require 'fuzzystringmatch' unless defined?(FuzzyStringMatch)
       require 'mechanize' unless defined?(Mechanize)
       require 'deluge/rpc' unless defined?(Deluge::Rpc::Client)


### PR DESCRIPTION
## Summary
- ensure the tvmaze gem is explicitly required during application dependency setup so TVMaze::Show is available before use

## Testing
- bundle exec rake test *(fails: existing suite errors including Zeitwerk loader conflict and other test failures)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b12b7a9b08327a1da5df91947d10c)