### PR TITLE
Add collection endpoint for indexed media

### DIFF
--- a/app/collection_repository.rb
+++ b/app/collection_repository.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require 'time'
+require 'sequel'
+
+class CollectionRepository
+  include MediaLibrarian::AppContainerSupport
+
+  DEFAULT_PER_PAGE = 50
+  MAX_PER_PAGE = 200
+
+  def initialize(app: self.class.app)
+    self.class.configure(app: app)
+  end
+
+  def paginated_entries(sort:, page:, per_page: DEFAULT_PER_PAGE)
+    dataset = collection_dataset
+    return empty_response(page, per_page) unless dataset
+
+    per_page = clamp_per_page(per_page)
+    page = normalize_page(page)
+    ordered = apply_sort(dataset, sort)
+    total = ordered.unlimited.count
+    entries = ordered.limit(per_page, offset(page, per_page)).all
+
+    { entries: entries.map { |row| serialize_row(row) }, total: total }
+  rescue StandardError
+    empty_response(page, per_page)
+  end
+
+  private
+
+  def apply_sort(dataset, sort)
+    case sort
+    when 'title'
+      dataset.order(Sequel.asc(:title))
+    when 'released_at', 'year'
+      dataset.order(Sequel.desc(:year), Sequel.asc(:title))
+    else
+      dataset
+    end
+  end
+
+  def clamp_per_page(per_page)
+    value = per_page.to_i
+    value = DEFAULT_PER_PAGE if value <= 0
+    [value, MAX_PER_PAGE].min
+  end
+
+  def collection_dataset
+    return unless app.respond_to?(:db) && app.db.respond_to?(:database)
+    return if app.db.respond_to?(:table_exists?) && !app.db.table_exists?(:local_media)
+
+    app.db.database[:local_media]
+  end
+
+  def empty_response(page, per_page)
+    { entries: [], total: 0, page: normalize_page(page), per_page: clamp_per_page(per_page) }
+  end
+
+  def normalize_page(page)
+    value = page.to_i
+    value = 1 if value <= 0
+    value
+  end
+
+  def offset(page, per_page)
+    (page - 1) * per_page
+  end
+
+  def serialize_row(row)
+    year = parse_year(row)
+    {
+      id: fetch(row, :id),
+      media_type: fetch(row, :media_type),
+      title: fetch(row, :title),
+      year: year,
+      released_at: build_released_at(year),
+      external_id: fetch(row, :external_id),
+      external_source: fetch(row, :external_source),
+      local_path: fetch(row, :local_path),
+      created_at: fetch(row, :created_at)
+    }.compact
+  end
+
+  def fetch(row, key)
+    row[key] || row[key.to_s]
+  end
+
+  def parse_year(row)
+    value = fetch(row, :year)
+    return nil if value.nil?
+
+    int_value = value.to_i
+    int_value.positive? ? int_value : nil
+  end
+
+  def build_released_at(year)
+    return nil unless year
+
+    Time.utc(year, 1, 1).iso8601
+  rescue RangeError
+    nil
+  end
+end

--- a/test/app/collection_repository_test.rb
+++ b/test/app/collection_repository_test.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'ostruct'
+require 'securerandom'
+require_relative '../test_helper'
+require_relative '../../app/collection_repository'
+require_relative '../../lib/storage/db'
+require_relative '../../app/daemon'
+
+class CollectionRepositoryTest < Minitest::Test
+  def setup
+    @environment = build_stubbed_environment
+    db_path = File.join(@environment.root_path, 'db.sqlite3')
+    attach_db(Storage::Db.new(db_path))
+    CollectionRepository.configure(app: @environment.application)
+    @repository = CollectionRepository.new(app: @environment.application)
+  end
+
+  def teardown
+    @environment.cleanup
+  end
+
+  def test_paginated_entries_returns_sorted_results
+    insert_media([
+      { title: 'Future', year: 2024, external_id: 'tmdb-1' },
+      { title: 'Recent', year: 2023, external_id: 'tmdb-2' },
+      { title: 'Classic', year: 1999, external_id: 'tmdb-3' }
+    ])
+
+    result = @repository.paginated_entries(sort: 'released_at', page: 1, per_page: 2)
+
+    assert_equal 3, result[:total]
+    assert_equal %w[Future Recent], result[:entries].map { |entry| entry[:title] }
+    assert result[:entries].first[:released_at].start_with?('2024-01-01')
+  end
+
+  def test_paginated_entries_clamps_page_and_per_page
+    insert_media([{ title: 'Single', year: 2020, external_id: 'tmdb-10' }])
+
+    result = @repository.paginated_entries(sort: 'title', page: -5, per_page: 1_000)
+
+    assert_equal 1, result[:entries].size
+    assert_equal 'Single', result[:entries].first[:title]
+  end
+
+  private
+
+  def attach_db(db)
+    singleton = @environment.application.singleton_class
+    unless @environment.application.respond_to?(:db)
+      singleton.class_eval do
+        attr_accessor :db
+      end
+    end
+    @environment.application.db = db
+  end
+
+  def insert_media(rows)
+    rows.each do |row|
+      @environment.application.db.insert_row(:local_media, base_row.merge(row), 1)
+    end
+  end
+
+  def base_row
+    {
+      media_type: 'movie',
+      title: 'Placeholder',
+      year: 2000,
+      external_id: SecureRandom.uuid,
+      external_source: 'tmdb',
+      local_path: '/tmp/media/file.mkv'
+    }
+  end
+end
+
+class CollectionRequestTest < Minitest::Test
+  def setup
+    @environment = build_stubbed_environment
+    Daemon.configure(app: @environment.application)
+  end
+
+  def teardown
+    @environment.cleanup
+  end
+
+  def test_handle_collection_request_clamps_numeric_params
+    response = FakeResponse.new
+    captured = nil
+    fake_result = { entries: [], total: 42 }
+
+    CollectionRepository.stub(:new, ->(app:) { FakeRepository.new(app: app, on_query: ->(**params) { captured = params; fake_result }) }) do
+      request = OpenStruct.new(
+        request_method: 'GET',
+        query: { 'page' => '0', 'per_page' => '9999', 'sort' => 'invalid' },
+        path: '/collection'
+      )
+
+      Daemon.send(:handle_collection_request, request, response)
+    end
+
+    assert_equal({ sort: 'released_at', page: 1, per_page: CollectionRepository::MAX_PER_PAGE }, captured)
+    parsed = JSON.parse(response.body)
+    assert_equal({ 'page' => 1, 'per_page' => CollectionRepository::MAX_PER_PAGE, 'total' => 42 }, parsed['pagination'])
+  end
+
+  class FakeRepository
+    def initialize(app:, on_query:)
+      @app = app
+      @on_query = on_query
+    end
+
+    def paginated_entries(**params)
+      @on_query.call(**params)
+    end
+  end
+
+  class FakeResponse
+    attr_accessor :status, :body
+
+    def initialize
+      @headers = {}
+      @status = nil
+      @body = nil
+    end
+
+    def []=(key, value)
+      @headers[key] = value
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add a CollectionRepository to paginate and sort indexed local media
- expose a GET /collection endpoint that validates sort and pagination parameters and returns normalized pagination metadata
- cover repository and handler behaviour with tests, including numeric bounds

## Testing
- bundle exec ruby -Itest test/app/collection_repository_test.rb

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b1618ac4483279686fc5212801aed)