### PR TITLE
Handle invalid OMDb JSON gracefully

### DIFF
--- a/lib/omdb_api.rb
+++ b/lib/omdb_api.rb
@@ -122,7 +122,8 @@ class OmdbApi
       retry
     end
 
-    raise StandardError, "OMDb calendar response was invalid JSON (status #{status || 'unknown'}): #{e.message}"
+    report_error(e, "OMDb calendar response was invalid JSON (status #{status || 'unknown'}): #{e.message}")
+    nil
   end
 
   def verify_response!(status)


### PR DESCRIPTION
## Summary
- log and return nil when OMDb responses contain invalid JSON so callers treat them as missing data
- ensure calendar enrichment skips entries when OMDb parsing fails instead of propagating errors
- add a regression test covering malformed OMDb JSON during enrichment

## Testing
- bundle exec ruby test/lib/omdb_api_test.rb
- bundle exec ruby test/services/calendar_feed_service_test.rb

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b1e5aa8788327acb5b8f2ab7eaea7)