### PR TITLE
Add operation labels to OMDb requests

### DIFF
--- a/test/services/calendar_feed_service_test.rb
+++ b/test/services/calendar_feed_service_test.rb
@@ -327,7 +327,7 @@ class CalendarFeedServiceTest < Minitest::Test
     api = OmdbApi.allocate
     api.send(:initialize, api_key: 'omdb-key', http_client: fake_client, speaker: @speaker)
 
-    assert_nil api.send(:parse_json, invalid_body, 200)
+    assert_nil api.send(:parse_json, invalid_body, 200, :calendar)
 
     entry = base_entry.merge(source: 'tmdb', ids: { 'imdb' => 'tt7654321' }, rating: nil, imdb_votes: nil, poster_url: nil)
     provider = FakeProvider.new([entry])


### PR DESCRIPTION
## Summary
- pass operation labels through OMDb requests to JSON parsing for clearer error context
- include operation names in OMDb JSON error and empty response messages
- update calendar feed test to exercise the new parse_json signature

## Testing
- bundle exec rake test *(fails: existing failures in DaemonQueueConcurrencyTest#test_enqueue_retries_until_executor_accepts_job and TrackerQueryServiceTest#test_get_torrent_file_reauthenticates_when_redirected_to_login due to Zeitwerk loader conflict)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b203193608327858dfce8c4857ca5)