### PR TITLE
Align collection rendering with calendar grid

### DIFF
--- a/app/web/app.js
+++ b/app/web/app.js
@@ -1727,7 +1727,7 @@ function resolveCollectionSortOption(sort) {
 
 function renderCollectionCard(entry) {
   const item = document.createElement('li');
-  item.className = 'calendar-entry';
+  item.className = 'calendar-item';
 
   const media = document.createElement('div');
   media.className = 'calendar-media';
@@ -1842,7 +1842,7 @@ function renderCollection(data = null) {
   }
 
   const list = document.createElement('ol');
-  list.className = 'calendar-list collection-list';
+  list.className = 'calendar-items collection-list';
   entries.forEach((entry) => list.appendChild(renderCollectionCard(entry)));
   container.replaceChildren(list);
   renderCollectionPagination();


### PR DESCRIPTION
## Summary
- ensure collection cards use the calendar grid item class
- render the collection list with the shared calendar grid container

## Testing
- bundle exec rake test *(fails: existing suite errors in LibraryTest, DaemonCliStopTest, and tracker login service)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b28d800208327a3c1027e7670433f)