### PR TITLE
Enforce IMDb identifiers for watchlists

### DIFF
--- a/app/media_librarian/services/list_management_service.rb
+++ b/app/media_librarian/services/list_management_service.rb
@@ -65,10 +65,11 @@ module MediaLibrarian
             meta = normalize_metadata(row[:metadata])
             ids = meta[:ids] || {}
             ids = {} unless ids.is_a?(Hash)
-            imdb_id = row[:imdb_id] || ids[:imdb] || ids['imdb'] || row[:external_id]
+            imdb_id = imdb_identifier(row, meta)
+            next if imdb_id.to_s.empty?
             ids = ids.transform_keys { |k| k.is_a?(String) ? k : k.to_s }
-            ids['imdb'] ||= imdb_id
-            attrs = { already_followed: 1, watchlist: 1, external_id: imdb_id }
+            ids['imdb'] = imdb_id if imdb_id
+            attrs = { already_followed: 1, watchlist: 1, external_id: imdb_id, imdb_id: imdb_id }
             attrs[:metadata] = meta unless meta.empty?
             title = build_watchlist_title(row[:title], meta[:year])
             search_list[cache_name] = Library.parse_media({ type: 'lists', name: title }, request.category, request.no_prompt, search_list[cache_name] || {}, {}, {}, attrs, '', ids)
@@ -99,21 +100,19 @@ module MediaLibrarian
 
         library = existing_files[category] || {}
         entries.each do |entry|
-          identifiers = [entry[:external_id], entry['external_id']].compact
-          ids = entry[:ids] || entry['ids']
-          identifiers.concat(ids.values.compact) if ids.is_a?(Hash)
-          entry[:downloaded] = identifiers.any? { |id| Metadata.media_exist?(library, id) }
+          identifier = imdb_identifier(entry, entry[:ids] || entry['ids'])
+          entry[:downloaded] = Metadata.media_exist?(library, identifier)
         end
       end
 
-      def build_calendar_entries(raw_entries, ids, external_id, type)
+      def build_calendar_entries(raw_entries, ids, imdb_id, type)
         return [] unless raw_entries.is_a?(Array)
 
         raw_entries.filter_map do |entry|
           next unless entry
 
           base = entry.is_a?(Hash) ? entry.transform_keys(&:to_sym) : { title: entry }
-          base.merge(ids: ids, external_id: external_id, type: type)
+          base.merge(ids: ids, external_id: imdb_id, imdb_id: imdb_id, type: type)
         end
       end
 
@@ -125,6 +124,19 @@ module MediaLibrarian
 
       def normalize_metadata(metadata)
         metadata.is_a?(Hash) ? metadata : {}
+      end
+
+      def imdb_identifier(source, ids = nil)
+        ids ||= source[:ids] || source['ids'] if source.is_a?(Hash)
+        ids = ids.transform_keys(&:to_s) if ids.is_a?(Hash)
+
+        [
+          (source[:imdb_id] if source.is_a?(Hash)),
+          (source['imdb_id'] if source.is_a?(Hash)),
+          ids['imdb'],
+          (source[:external_id] if source.is_a?(Hash)),
+          (source['external_id'] if source.is_a?(Hash))
+        ].compact.map(&:to_s).map(&:strip).find { |value| !value.empty? }
       end
 
       def media_repository

--- a/test/daemon_watchlist_api_test.rb
+++ b/test/daemon_watchlist_api_test.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'ostruct'
+require 'fileutils'
+require 'tmpdir'
+
+require_relative 'test_helper'
+require_relative '../app/daemon'
+require_relative '../lib/watchlist_store'
+require_relative '../lib/storage/db'
+
+class DaemonWatchlistApiTest < Minitest::Test
+  def setup
+    @environment = build_stubbed_environment
+    ensure_db_accessor(@environment.application)
+    @environment.application.db = Storage::Db.new(File.join(@environment.root_path, 'librarian.db'))
+    MediaLibrarian.application = @environment.application
+    Daemon.configure(app: @environment.application)
+  end
+
+  def teardown
+    MediaLibrarian.application = nil
+    @environment.cleanup if @environment
+  end
+
+  def test_post_requires_imdb_id
+    response = FakeResponse.new
+    request = OpenStruct.new(request_method: 'POST', body: { title: 'Missing id' }.to_json, query: {}, path: '/watchlist')
+
+    Daemon.send(:handle_watchlist_request, request, response)
+
+    assert_equal 422, response.status
+  end
+
+  def test_crud_relies_on_imdb_id
+    post_response = FakeResponse.new
+    post_request = OpenStruct.new(
+      request_method: 'POST',
+      body: { imdb_id: 'tt7777', title: 'Example', metadata: { ids: { tmdb: '777' } } }.to_json,
+      query: {},
+      path: '/watchlist'
+    )
+
+    Daemon.send(:handle_watchlist_request, post_request, post_response)
+
+    assert_equal 200, post_response.status
+    entries = WatchlistStore.fetch
+    assert_equal ['tt7777'], entries.map { |row| row[:imdb_id] }
+    assert_equal ['tt7777'], entries.map { |row| row[:external_id] }
+    assert_equal 'tt7777', entries.first[:metadata][:ids][:imdb]
+
+    delete_response = FakeResponse.new
+    delete_request = OpenStruct.new(request_method: 'DELETE', body: { imdb_id: 'tt7777' }.to_json, query: {}, path: '/watchlist')
+    Daemon.send(:handle_watchlist_request, delete_request, delete_response)
+
+    assert_empty WatchlistStore.fetch
+  end
+
+  private
+
+  def ensure_db_accessor(application)
+    return if application.respond_to?(:db)
+
+    application.singleton_class.class_eval { attr_accessor :db }
+  end
+
+  class FakeResponse
+    attr_accessor :status, :body
+
+    def initialize
+      @headers = {}
+      @status = nil
+      @body = nil
+    end
+
+    def []=(key, value)
+      @headers[key] = value
+    end
+  end
+end

--- a/test/lib/watchlist_store_test.rb
+++ b/test/lib/watchlist_store_test.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'ostruct'
+require 'fileutils'
+require 'tmpdir'
+require_relative '../test_helper'
+require_relative '../../lib/watchlist_store'
+require_relative '../../lib/storage/db'
+require_relative '../../lib/media_librarian/application'
+
+class WatchlistStoreTest < Minitest::Test
+  def setup
+    @root = Dir.mktmpdir('watchlist-store-test')
+    db_path = File.join(@root, 'db.sqlite3')
+    db = Storage::Db.new(db_path)
+    speaker = TestSupport::Fakes::Speaker.new
+    @app = OpenStruct.new(db: db, speaker: speaker)
+    MediaLibrarian.instance_variable_set(:@application, @app)
+  end
+
+  def teardown
+    MediaLibrarian.instance_variable_set(:@application, nil)
+    FileUtils.remove_entry(@root) if @root && Dir.exist?(@root)
+  end
+
+  def test_normalize_and_delete_use_imdb_id
+    WatchlistStore.upsert([
+      { imdb_id: 'tt1234567', type: 'movies', title: 'Example', metadata: { ids: { tmdb: '99' } } }
+    ])
+
+    rows = WatchlistStore.fetch
+    assert_equal 1, rows.size
+    row = rows.first
+    assert_equal 'tt1234567', row[:imdb_id]
+    assert_equal 'tt1234567', row[:external_id]
+    assert_equal 'tt1234567', row[:metadata][:ids][:imdb]
+
+    assert_equal 1, WatchlistStore.delete(imdb_id: 'tt1234567')
+    assert_empty WatchlistStore.fetch
+  end
+end

--- a/test/services/list_management_service_test.rb
+++ b/test/services/list_management_service_test.rb
@@ -83,7 +83,6 @@ class ListManagementServiceTest < Minitest::Test
 
       WatchlistStore.upsert([
         {
-          external_id: 'tmdb-42',
           imdb_id: 'tt0042',
           type: 'movies',
           title: 'Sample',
@@ -99,7 +98,7 @@ class ListManagementServiceTest < Minitest::Test
 
       parsed_media = { 'tt0042' => { already_followed: 1 } }
       Library.stub(:parse_media, parsed_media) do
-        repo_data = { 'tmdb-42' => { identifier: 'tmdb-42' }, 'tt0042' => { identifier: 'tt0042' } }
+        repo_data = { 'tt0042' => { identifier: 'tt0042' } }
         repo = StubLocalMediaRepository.new(repo_data)
         LocalMediaRepository.stub(:new, repo) do
           Library.stub(:process_folder, ->(**_) { flunk 'process_folder should not be called' }) do


### PR DESCRIPTION
## Summary
- enforce imdb_id as the required identifier when creating or deleting watchlist entries and normalize stored metadata accordingly
- propagate IMDb identifiers through watchlist search/list management flows and calendar annotations
- add watchlist API and store regression tests to cover imdb-only CRUD behavior

## Testing
- bundle exec ruby -Itest test/lib/watchlist_store_test.rb
- bundle exec ruby -Itest test/daemon_watchlist_api_test.rb
- bundle exec ruby -Itest test/services/list_management_service_test.rb


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c497dae4c8327ba35c40cc642b440)