### PR TITLE
Use IMDb ID as watchlist key

### DIFF
--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -15,6 +15,7 @@ require 'fileutils'
 require 'base64'
 require 'get_process_mem'
 
+require_relative '../lib/utils'
 require_relative '../lib/logger'
 require_relative '../lib/list_store'
 require_relative '../lib/watchlist_store'
@@ -1572,9 +1573,7 @@ class Daemon
         json_response(res, body: { 'entries' => entries })
       when 'POST'
         payload = parse_payload(req)
-        external_id = (payload['id'] || payload['external_id']).to_s.strip
         title = payload['title'].to_s.strip
-        return error_response(res, status: 422, message: 'missing_id') if external_id.empty?
         return error_response(res, status: 422, message: 'missing_title') if title.empty?
 
         metadata = payload['metadata']
@@ -1582,10 +1581,12 @@ class Daemon
         ids = metadata['ids'] || metadata[:ids] || {}
         ids = {} unless ids.is_a?(Hash)
 
-        imdb_id = (payload['imdb_id'] || ids['imdb'] || ids[:imdb] || external_id).to_s.strip
+        imdb_id = (payload['imdb_id'] || ids['imdb'] || ids[:imdb]).to_s.strip
+        return error_response(res, status: 422, message: 'missing_id') if imdb_id.empty?
+
+        ids['imdb'] = imdb_id unless ids['imdb'] || ids[:imdb]
         metadata['ids'] = ids if ids.any?
         entry = {
-          external_id: external_id,
           imdb_id: imdb_id,
           title: title,
           type: Utils.regularise_media_type((payload['type'] || 'movies').to_s),
@@ -1597,14 +1598,9 @@ class Daemon
       when 'DELETE'
         payload = parse_payload(req)
         imdb_id = (payload['imdb_id'] || req.query['imdb_id']).to_s.strip
-        external_id = (payload['id'] || payload['external_id'] || req.query['id']).to_s.strip
-        return error_response(res, status: 422, message: 'missing_id') if imdb_id.empty? && external_id.empty?
+        return error_response(res, status: 422, message: 'missing_id') if imdb_id.empty?
 
-        removed = WatchlistStore.delete(
-          imdb_id: imdb_id,
-          external_id: external_id,
-          type: payload['type'] || req.query['type']
-        )
+        removed = WatchlistStore.delete(imdb_id: imdb_id, type: payload['type'] || req.query['type'])
         json_response(res, body: { 'removed' => removed.to_i })
       else
         method_not_allowed(res, 'GET, POST, DELETE')

--- a/app/web/app.js
+++ b/app/web/app.js
@@ -1435,9 +1435,7 @@ async function addToWatchlist(entry, button) {
     metadata.release_date = releaseDate.toISOString();
   }
   const imdbId = ids.imdb || ids.imdb_id;
-  if (imdbId) {
-    payload.imdb_id = imdbId;
-  }
+  payload.imdb_id = imdbId;
   const cleanIds = Object.fromEntries(Object.entries(ids).filter(([, value]) => value));
   if (Object.keys(cleanIds).length) {
     metadata.ids = cleanIds;
@@ -1449,8 +1447,8 @@ async function addToWatchlist(entry, button) {
   if (Object.keys(metadata).length) {
     payload.metadata = metadata;
   }
-  if (!payload.id && !payload.title) {
-    showNotification("Impossible d'ajouter cet élément.", 'error');
+  if (!payload.imdb_id) {
+    showNotification("Identifiant IMDb manquant.", 'error');
     return;
   }
   if (button) {
@@ -2050,8 +2048,8 @@ function renderWatchlist(entries = [], { message } = {}) {
     const year = metadata.year
       || metadata.release_year
       || (Number.isFinite(releaseDateYear) ? releaseDateYear : '');
-    const imdb = ids.imdb || metadata.imdb || '';
-    const externalId = entry.external_id || entry.id || ids.slug || '';
+    const imdb = entry.imdb_id || ids.imdb || metadata.imdb || '';
+    const externalId = imdb || entry.external_id || entry.id || ids.slug || '';
     const url = metadata.url || '';
 
     const cells = [
@@ -2083,7 +2081,7 @@ function renderWatchlist(entries = [], { message } = {}) {
     if (!hasTrackers) {
       trackerCell.textContent = 'Aucun tracker configuré';
     } else {
-      const selectionKey = externalId || imdb || title;
+      const selectionKey = externalId || title;
       const select = document.createElement('select');
       trackers.forEach(({ name }) => {
         const option = document.createElement('option');
@@ -2157,11 +2155,11 @@ async function loadWatchlist() {
   }
 }
 
-async function removeWatchlistEntry(externalId, type) {
-  if (!externalId) {
+async function removeWatchlistEntry(imdbId, type) {
+  if (!imdbId) {
     return;
   }
-  const payload = { id: externalId };
+  const payload = { imdb_id: imdbId };
   if (type) {
     payload.type = type;
   }

--- a/test/app/watchlist_api_test.rb
+++ b/test/app/watchlist_api_test.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'json'
+require 'ostruct'
+require_relative '../../app/daemon'
+require_relative '../../lib/watchlist_store'
+require_relative '../../lib/storage/db'
+
+class WatchlistApiTest < Minitest::Test
+  def setup
+    @environment = build_stubbed_environment
+    MediaLibrarian.application = @environment.application
+    attach_db(Storage::Db.new(File.join(@environment.root_path, 'librarian.db')))
+    Daemon.configure(app: @environment.application)
+  end
+
+  def teardown
+    MediaLibrarian.application = nil
+    @environment.cleanup if @environment
+  end
+
+  def test_post_requires_imdb_id
+    response = FakeResponse.new
+    request = OpenStruct.new(request_method: 'POST', body: { title: 'Missing id' }.to_json)
+
+    Daemon.send(:handle_watchlist_request, request, response)
+
+    assert_equal 422, response.status
+    assert_equal({ 'error' => 'missing_id' }, JSON.parse(response.body))
+  end
+
+  def test_crud_operates_on_imdb_id_only
+    response = FakeResponse.new
+    request = OpenStruct.new(
+      request_method: 'POST',
+      body: { title: 'With id', imdb_id: 'tt0123', metadata: { ids: { tmdb: '42' } } }.to_json
+    )
+
+    Daemon.send(:handle_watchlist_request, request, response)
+    assert_equal 200, response.status, response.body
+
+    rows = WatchlistStore.fetch
+    refute_empty rows
+    row = rows.first
+    assert_equal 'tt0123', row[:imdb_id]
+    assert_equal 'tt0123', row[:external_id]
+    ids = row[:metadata][:ids] || row[:metadata]['ids']
+    assert_equal 'tt0123', ids[:imdb] || ids['imdb']
+
+    delete_response = FakeResponse.new
+    delete_request = OpenStruct.new(request_method: 'DELETE', body: { imdb_id: 'tt0123' }.to_json, query: {})
+    Daemon.send(:handle_watchlist_request, delete_request, delete_response)
+
+    assert_equal 200, delete_response.status
+    assert_equal 0, WatchlistStore.fetch.length
+  end
+
+  private
+
+  def attach_db(db)
+    app = @environment.application
+    app.singleton_class.class_eval { attr_accessor :db }
+    app.db = db
+  end
+
+  class FakeResponse
+    attr_accessor :status, :body
+
+    def initialize
+      @headers = {}
+      @status = nil
+      @body = nil
+    end
+
+    def []=(key, value)
+      @headers[key] = value
+    end
+  end
+end

--- a/test/services/list_management_service_test.rb
+++ b/test/services/list_management_service_test.rb
@@ -83,11 +83,10 @@ class ListManagementServiceTest < Minitest::Test
 
       WatchlistStore.upsert([
         {
-          external_id: 'tmdb-42',
           imdb_id: 'tt0042',
           type: 'movies',
           title: 'Sample',
-          metadata: { year: 2024, ids: { 'tmdb' => '42', 'imdb' => 'tt0042' }, calendar_entries: [{ external_id: 'tmdb-42' }] }
+          metadata: { year: 2024, ids: { 'tmdb' => '42', 'imdb' => 'tt0042' }, calendar_entries: [{}] }
         }
       ])
 
@@ -109,6 +108,7 @@ class ListManagementServiceTest < Minitest::Test
             assert_equal parsed_media['tt0042'], search_list['tt0042']
             assert_equal true, search_list[:calendar_entries].first[:downloaded]
             assert_equal 'tt0042', search_list[:calendar_entries].first[:external_id]
+            assert_equal 'tt0042', search_list[:calendar_entries].first[:imdb_id]
             assert_equal [{ type: 'movies', folder: '/media/movies' }], repo.calls.map { |call| { type: call[:type], folder: call[:folder] } }.uniq
           end
         end


### PR DESCRIPTION
## Summary
- require IMDb identifiers for watchlist CRUD and persist them as the single watchlist key
- update WatchlistStore and list management to normalize, annotate, and build calendar data with IMDb IDs only
- adjust the web client and add tests to cover IMDb-only watchlist operations

## Testing
- bundle exec ruby -Itest test/app/watchlist_api_test.rb test/services/list_management_service_test.rb

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c4585475c83278a60d4a088adad39)