### PR TITLE
Ensure watchlist uses IMDb IDs exclusively

### DIFF
--- a/app/media_librarian/services/list_management_service.rb
+++ b/app/media_librarian/services/list_management_service.rb
@@ -69,7 +69,7 @@ module MediaLibrarian
             next if imdb_id.to_s.empty?
             ids = ids.transform_keys { |k| k.is_a?(String) ? k : k.to_s }
             ids['imdb'] = imdb_id if imdb_id
-            attrs = { already_followed: 1, watchlist: 1, external_id: imdb_id, imdb_id: imdb_id }
+            attrs = { already_followed: 1, watchlist: 1, imdb_id: imdb_id }
             attrs[:metadata] = meta unless meta.empty?
             title = build_watchlist_title(row[:title], meta[:year])
             search_list[cache_name] = Library.parse_media({ type: 'lists', name: title }, request.category, request.no_prompt, search_list[cache_name] || {}, {}, {}, attrs, '', ids)
@@ -108,11 +108,13 @@ module MediaLibrarian
       def build_calendar_entries(raw_entries, ids, imdb_id, type)
         return [] unless raw_entries.is_a?(Array)
 
+        ids = ids.is_a?(Hash) ? ids : {}
+
         raw_entries.filter_map do |entry|
           next unless entry
 
           base = entry.is_a?(Hash) ? entry.transform_keys(&:to_sym) : { title: entry }
-          base.merge(ids: ids, external_id: imdb_id, imdb_id: imdb_id, type: type)
+          base.merge(ids: ids, imdb_id: imdb_id, type: type)
         end
       end
 
@@ -128,14 +130,12 @@ module MediaLibrarian
 
       def imdb_identifier(source, ids = nil)
         ids ||= source[:ids] || source['ids'] if source.is_a?(Hash)
-        ids = ids.transform_keys(&:to_s) if ids.is_a?(Hash)
+        ids = ids.is_a?(Hash) ? ids.transform_keys(&:to_s) : {}
 
         [
           (source[:imdb_id] if source.is_a?(Hash)),
           (source['imdb_id'] if source.is_a?(Hash)),
           ids['imdb'],
-          (source[:external_id] if source.is_a?(Hash)),
-          (source['external_id'] if source.is_a?(Hash))
         ].compact.map(&:to_s).map(&:strip).find { |value| !value.empty? }
       end
 

--- a/lib/watchlist_store.rb
+++ b/lib/watchlist_store.rb
@@ -21,9 +21,8 @@ module WatchlistStore
     []
   end
 
-  def delete(external_id: nil, imdb_id: nil, type: nil)
-    identifier = imdb_id.to_s
-    identifier = external_id.to_s if identifier.empty? && external_id
+  def delete(imdb_id: nil, type: nil)
+    identifier = imdb_id.to_s.strip
     return 0 if identifier.empty?
 
     conditions = { imdb_id: identifier }
@@ -40,18 +39,17 @@ module WatchlistStore
 
       metadata = normalize_metadata(entry[:metadata] || entry['metadata'])
       imdb_id = imdb_id_for(entry, metadata)
-      imdb_id = (entry[:external_id] || entry['external_id']).to_s if imdb_id.to_s.empty?
+      imdb_id = (entry[:external_id] || entry['external_id']).to_s.strip if imdb_id.to_s.empty?
 
       title = entry[:title] || entry['title']
       type = entry[:type] || entry['type'] || 'movies'
       next if imdb_id.to_s.empty? || title.to_s.empty?
 
       ids = metadata[:ids]
-      if ids.is_a?(Hash)
-        ids = ids.transform_keys(&:to_s)
-        ids['imdb'] ||= imdb_id
-        metadata[:ids] = ids
-      end
+      ids = {} unless ids.is_a?(Hash)
+      ids = ids.transform_keys(&:to_s)
+      ids['imdb'] ||= imdb_id
+      metadata[:ids] = ids
 
       {
         external_id: imdb_id,

--- a/test/lib/watchlist_store_test.rb
+++ b/test/lib/watchlist_store_test.rb
@@ -32,10 +32,19 @@ class WatchlistStoreTest < Minitest::Test
     assert_equal 1, rows.size
     row = rows.first
     assert_equal 'tt1234567', row[:imdb_id]
-    assert_equal 'tt1234567', row[:external_id]
     assert_equal 'tt1234567', row[:metadata][:ids][:imdb]
 
     assert_equal 1, WatchlistStore.delete(imdb_id: 'tt1234567')
     assert_empty WatchlistStore.fetch
+  end
+
+  def test_normalize_legacy_external_id_only
+    WatchlistStore.upsert([
+      { external_id: 'tt4242', type: 'movies', title: 'Legacy title' }
+    ])
+
+    row = WatchlistStore.fetch.first
+    assert_equal 'tt4242', row[:imdb_id]
+    assert_equal 'tt4242', row[:metadata][:ids][:imdb]
   end
 end

--- a/test/services/list_management_service_test.rb
+++ b/test/services/list_management_service_test.rb
@@ -107,7 +107,7 @@ class ListManagementServiceTest < Minitest::Test
             assert_equal repo_data, files['movies']
             assert_equal parsed_media['tt0042'], search_list['tt0042']
             assert_equal true, search_list[:calendar_entries].first[:downloaded]
-            assert_equal 'tt0042', search_list[:calendar_entries].first[:external_id]
+            assert_equal 'tt0042', search_list[:calendar_entries].first[:imdb_id]
             assert_equal [{ type: 'movies', folder: '/media/movies' }], repo.calls.map { |call| { type: call[:type], folder: call[:folder] } }.uniq
           end
         end


### PR DESCRIPTION
## Summary
- enforce IMDb IDs as the required identifier for watchlist API CRUD operations and normalize metadata accordingly
- simplify watchlist storage and list management logic to propagate only IMDb IDs
- update tests to reflect IMDb-only workflows and legacy external-id normalization

## Testing
- bundle exec ruby -Itest test/daemon_watchlist_api_test.rb test/lib/watchlist_store_test.rb test/services/list_management_service_test.rb

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c4e42bbe483278395fb2aa7d415cd)