### PR TITLE
Disable watchlist action for downloaded calendar entries

### DIFF
--- a/app/web/app.js
+++ b/app/web/app.js
@@ -1629,7 +1629,7 @@ function renderCalendar(data = null) {
           body.appendChild(meta);
         }
 
-        if (!inWatchlist) {
+        if (!inWatchlist && !downloaded) {
           const actions = document.createElement('div');
           actions.className = 'calendar-actions-row';
           const button = document.createElement('button');


### PR DESCRIPTION
## Summary
- hide the calendar add-to-interest action for entries that are already downloaded to avoid redundant watchlist additions

## Testing
- node --test test/web/*.test.js


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c580f0dac83279fd0220d3a2e9376)