### PR TITLE
Keep calendar watchlist button disabled after success

### DIFF
--- a/app/web/app.js
+++ b/app/web/app.js
@@ -1453,6 +1453,7 @@ async function addToWatchlist(entry, button) {
     showNotification("Impossible d'ajouter cet élément.", 'error');
     return;
   }
+  const originalLabel = button?.textContent;
   if (button) {
     button.disabled = true;
   }
@@ -1473,6 +1474,9 @@ async function addToWatchlist(entry, button) {
     entry.in_watchlist = true;
     entry.watchlist = true;
     entry.in_interest_list = true;
+    if (button) {
+      button.textContent = 'Ajouté à la liste d’intérêt';
+    }
     if (Array.isArray(state.calendar.entries)) {
       state.calendar.entries = state.calendar.entries.map((item) => (item === entry ? entry : item));
     }
@@ -1483,9 +1487,9 @@ async function addToWatchlist(entry, button) {
       Object.assign(entry, previousStatus);
     }
     showNotification(error.message, 'error');
-  } finally {
     if (button) {
       button.disabled = false;
+      button.textContent = originalLabel || button.textContent;
     }
   }
 }


### PR DESCRIPTION
## Summary
- keep calendar add-to-watchlist buttons disabled after successful additions and update their labels
- only re-enable the button when the watchlist request fails

## Testing
- bundle exec rake test *(fails: repository dependencies not installed; bundle install required)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c5a439aa8832797ff2bf002afc9f3)