### PR TITLE
Add scheduled runs panel to scheduler tab

### DIFF
--- a/app/web/index.html
+++ b/app/web/index.html
@@ -176,6 +176,16 @@
             </div>
           </section>
 
+          <section class="panel" id="scheduler-runs-panel">
+            <div class="panel-header">
+              <h2>Exécutions planifiées</h2>
+            </div>
+            <div id="scheduler-runs-container" class="scheduler-tasks">
+              <ul id="scheduler-runs-list"></ul>
+              <p class="hint">Aucune exécution planifiée.</p>
+            </div>
+          </section>
+
           <section class="panel" id="available-commands-panel">
             <div class="panel-header">
               <h2>Commandes disponibles</h2>


### PR DESCRIPTION
## Summary
- add a new scheduled runs panel between scheduler and available commands sections
- provide dedicated container and list identifiers while reusing existing panel styling

## Testing
- bundle exec rake test *(fails: existing suite reports 2 failures and 12 errors in tracker_query_service_test and loader conflicts)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c7904b5a88327a43a1aaa45d5624f)