### PR TITLE
Add unscheduled template command listing

### DIFF
--- a/app/web/index.html
+++ b/app/web/index.html
@@ -186,6 +186,15 @@
             </div>
           </section>
 
+          <section class="panel" id="unscheduled-templates-panel">
+            <div class="panel-header">
+              <h2>Commandes de template non planifiées</h2>
+            </div>
+            <div id="unscheduled-template-list" class="scheduler-tasks">
+              <p class="hint">Aucune commande de template détectée.</p>
+            </div>
+          </section>
+
           <section class="panel" id="available-commands-panel">
             <div class="panel-header">
               <h2>Commandes disponibles</h2>


### PR DESCRIPTION
## Summary
- fetch scheduler, template, and command data to separate scheduled, unscheduled template, and remaining commands
- add reusable command rendering helper and normalize command metadata for consistent comparisons
- expose a new panel showing template commands that are not yet scheduled

## Testing
- node --test test/web/*.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c7c4981e08327a366be21df8af815)