### PR TITLE
Add search form to collection tab

### DIFF
--- a/app/collection_repository.rb
+++ b/app/collection_repository.rb
@@ -13,8 +13,8 @@ class CollectionRepository
     self.class.configure(app: app)
   end
 
-  def paginated_entries(sort:, page:, per_page: DEFAULT_PER_PAGE)
-    dataset = collection_dataset
+  def paginated_entries(sort:, page:, per_page: DEFAULT_PER_PAGE, search: '')
+    dataset = apply_search(collection_dataset, search)
     return empty_response(page, per_page) unless dataset
 
     per_page = clamp_per_page(per_page)
@@ -39,6 +39,12 @@ class CollectionRepository
     else
       dataset
     end
+  end
+
+  def apply_search(dataset, search)
+    return dataset unless dataset && search.to_s.strip != ''
+
+    dataset.where(Sequel.ilike(:title, "%#{search.strip}%"))
   end
 
   def clamp_per_page(per_page)

--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -1544,13 +1544,18 @@ class Daemon
       {
         sort: normalize_collection_sort(query['sort']),
         page: page,
-        per_page: per_page
+        per_page: per_page,
+        search: normalize_collection_search(query['search'])
       }
     end
 
     def normalize_collection_sort(value)
       sort = value.to_s.strip
       %w[released_at year title].include?(sort) ? sort : 'released_at'
+    end
+
+    def normalize_collection_search(value)
+      value.to_s.strip[0, 200]
     end
 
     def clamp_positive_integer(value, default:, max:)

--- a/app/web/app.css
+++ b/app/web/app.css
@@ -199,6 +199,21 @@ main {
   font-weight: 600;
 }
 
+.collection-search {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.collection-search input {
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(17, 24, 39, 0.6);
+  color: inherit;
+}
+
 .download-list-form {
   display: grid;
   gap: 1rem;

--- a/app/web/app.js
+++ b/app/web/app.js
@@ -33,6 +33,7 @@ const state = {
     perPage: 50,
     total: 0,
     loading: false,
+    search: '',
   },
   trackers: {
     entries: [],
@@ -1866,6 +1867,9 @@ async function loadCollection(options = {}) {
   const sort = resolveCollectionSort(sortInput);
   const page = Math.max(1, options.page ?? state.collection.page ?? 1);
   const perPage = Math.max(1, options.perPage ?? state.collection.perPage ?? 50);
+  const searchInput = document.getElementById('collection-search');
+  const rawSearch = options.search ?? searchInput?.value ?? state.collection.search ?? '';
+  const searchTerm = rawSearch.toString().trim();
 
   const sortSelect = document.getElementById('collection-sort');
   if (sortSelect) {
@@ -1875,12 +1879,20 @@ async function loadCollection(options = {}) {
     }
   }
 
+  if (searchInput && searchInput.value !== searchTerm) {
+    searchInput.value = searchTerm;
+  }
+
   const search = new URLSearchParams({ sort, page, per_page: perPage });
+  if (searchTerm) {
+    search.set('search', searchTerm);
+  }
   const path = `/collection${search.toString() ? `?${search.toString()}` : ''}`;
   state.collection.loading = true;
   state.collection.sort = sort;
   state.collection.page = page;
   state.collection.perPage = perPage;
+  state.collection.search = searchTerm;
   renderCollection();
 
   try {
@@ -2818,6 +2830,15 @@ function setupCalendarEvents() {
 }
 
 function setupCollectionEvents() {
+  const searchForm = document.getElementById('collection-search-form');
+  const searchInput = document.getElementById('collection-search');
+  if (searchForm && searchInput) {
+    searchForm.addEventListener('submit', (event) => {
+      event.preventDefault();
+      loadCollection({ search: searchInput.value, page: 1 });
+    });
+  }
+
   const sort = document.getElementById('collection-sort');
   if (sort) {
     sort.addEventListener('change', () => loadCollection({ sort: sort.value, page: 1 }));

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -297,6 +297,11 @@
             <div class="panel-header">
               <h2>Collection</h2>
               <div class="panel-tools">
+                <form id="collection-search-form" class="collection-search" role="search" autocomplete="off">
+                  <label for="collection-search">Rechercher un film</label>
+                  <input id="collection-search" name="search" type="search" placeholder="Titre" />
+                  <button type="submit">Chercher</button>
+                </form>
                 <label for="collection-sort">Tri</label>
                 <select id="collection-sort" name="sort">
                   <option value="year">Année</option>


### PR DESCRIPTION
## Summary
- add a search form to the Collection tab to look up movies by title
- pass the search query through the API and repository to filter collection entries
- style the search controls alongside existing collection tools

## Testing
- bundle exec ruby -c app/collection_repository.rb
- bundle exec rake test *(fails: requires bundle install to complete; installation hung on git-based dependencies in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d279f85ec83279054d6b29edc0eaf)