### PR TITLE
Refine local media schema to use IMDb IDs

### DIFF
--- a/app/calendar_entries_repository.rb
+++ b/app/calendar_entries_repository.rb
@@ -207,11 +207,19 @@ class CalendarEntriesRepository
     rows = Array(database.get_rows(:local_media))
     rows.each_with_object(Hash.new { |hash, key| hash[key] = {} }) do |row, memo|
       type = normalize_type(row[:media_type] || row['media_type'])
-      source = (row[:external_source] || row['external_source']).to_s.strip.downcase
-      external_id = (row[:external_id] || row['external_id']).to_s.strip
-      next if type.nil? || source.empty? || external_id.empty?
+      next if type.nil?
 
-      memo[[type, source]][external_id] = true
+      imdb_id = (row[:imdb_id] || row['imdb_id']).to_s.strip
+      if !imdb_id.empty?
+        memo[[type, 'imdb']][imdb_id] = true
+        next
+      end
+
+      fallback_id = (row[:external_id] || row['external_id']).to_s.strip
+      fallback_source = (row[:external_source] || row['external_source']).to_s.strip.downcase
+      next if fallback_id.empty? || fallback_source.empty?
+
+      memo[[type, fallback_source]][fallback_id] = true
     end
   rescue StandardError
     {}

--- a/app/local_media_repository.rb
+++ b/app/local_media_repository.rb
@@ -14,19 +14,18 @@ class LocalMediaRepository
       next if identifiers.empty?
 
       file = { type: 'file', name: row[:local_path], f_type: type, parts: [row[:local_path]] }
-      attrs = { obj_title: row[:title], obj_year: row[:year], f_type: type }
-      Metadata.media_add(row[:title], type, row[:title], identifiers, attrs, { f_type: type }, file, memo)
+      attrs = { obj_title: inferred_title(row), f_type: type }
+      Metadata.media_add(identifiers.first, type, identifiers.first, identifiers, attrs, { f_type: type }, file, memo)
     end
   end
 
   private
 
   def build_identifiers(row)
-    id = (row[:external_id] || row['external_id']).to_s
+    id = (row[:imdb_id] || row['imdb_id'] || row[:external_id] || row['external_id']).to_s
     return [] if id.empty?
 
-    source = (row[:external_source] || row['external_source']).to_s
-    [id, (source.empty? ? nil : "#{source}#{id}")].compact.uniq
+    [id]
   end
 
   def fetch_rows(type, folder)
@@ -42,5 +41,9 @@ class LocalMediaRepository
   rescue StandardError => e
     app&.speaker&.tell_error(e, Utils.arguments_dump(binding)) if app&.respond_to?(:speaker)
     []
+  end
+
+  def inferred_title(row)
+    File.basename(row[:local_path].to_s)
   end
 end

--- a/lib/db/migrations/011_update_local_media_to_imdb_ids.rb
+++ b/lib/db/migrations/011_update_local_media_to_imdb_ids.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require 'json'
+
+Sequel.migration do
+  up do
+    break unless table_exists?(:local_media)
+
+    alter_table(:local_media) do
+      add_column :imdb_id, String, text: true, null: false, default: ''
+    end
+
+    parse_ids = lambda do |value|
+      parsed = value
+      parsed = JSON.parse(value) if value.is_a?(String) && value.strip.start_with?('{', '[')
+      parsed.is_a?(Hash) ? parsed : {}
+    rescue StandardError
+      {}
+    end
+
+    extract_sources = lambda do |row, ids|
+      sources = []
+      source = (row[:source] || row['source']).to_s.downcase
+      external_id = (row[:external_id] || row['external_id']).to_s.strip
+      sources << [source, external_id] unless source.empty? || external_id.empty?
+
+      ids.each do |key, value|
+        key_name = key.to_s.downcase
+        value_str = value.to_s.strip
+        sources << [key_name, value_str] unless key_name.empty? || value_str.empty?
+      end
+
+      sources
+    end
+
+    extract_imdb_id = lambda do |row, ids|
+      [ids['imdb'], ids[:imdb], row[:imdb_id], row['imdb_id'], row[:external_id], row['external_id']].each do |candidate|
+        candidate = candidate.to_s.strip
+        return candidate unless candidate.empty?
+      end
+      ''
+    end
+
+    build_imdb_lookup = lambda do
+      lookup = Hash.new { |hash, key| hash[key] = {} }
+      next lookup unless table_exists?(:calendar_entries)
+
+      self[:calendar_entries].each do |row|
+        ids = parse_ids.call(row[:ids])
+        imdb_id = extract_imdb_id.call(row, ids)
+        next if imdb_id.empty?
+
+        extract_sources.call(row, ids).each do |source, identifier|
+          lookup[source][identifier] = imdb_id unless identifier.empty?
+        end
+      end
+
+      lookup
+    end
+
+    resolve_imdb_id = lambda do |row, imdb_lookup|
+      source = (row[:external_source] || row['external_source']).to_s.downcase
+      identifier = (row[:external_id] || row['external_id']).to_s.strip
+
+      imdb_id = if source == 'imdb' || identifier.match?(/^tt\d+/i)
+                  identifier
+                else
+                  imdb_lookup[source][identifier]
+                end
+
+      imdb_id = identifier if imdb_id.to_s.empty? && !identifier.empty?
+      imdb_id = File.basename(row[:local_path].to_s) if imdb_id.to_s.empty?
+      imdb_id.to_s.strip
+    end
+
+    columns = schema(:local_media).map(&:first)
+    unless columns.include?(:imdb_id)
+      alter_table(:local_media) do
+        add_column :imdb_id, String, text: true, null: false, default: ''
+      end
+    end
+
+    columns = schema(:local_media).map(&:first)
+    imdb_lookup = build_imdb_lookup.call
+
+    self[:local_media].each do |row|
+      imdb_id = resolve_imdb_id.call(row, imdb_lookup)
+      next if imdb_id.empty?
+
+      self[:local_media].where(id: row[:id]).update(imdb_id: imdb_id)
+    end
+
+    alter_table(:local_media) do
+      drop_column :title if columns.include?(:title)
+      drop_column :year if columns.include?(:year)
+      drop_column :external_id if columns.include?(:external_id)
+      drop_column :external_source if columns.include?(:external_source)
+      set_column_default :imdb_id, nil
+      add_index [:media_type, :imdb_id], unique: true, name: :idx_local_media_type_imdb_id
+    end
+  end
+
+  down do
+    break unless table_exists?(:local_media)
+
+    alter_table(:local_media) do
+      drop_index [:media_type, :imdb_id], name: :idx_local_media_type_imdb_id
+      add_column :title, Text, null: false, default: ''
+      add_column :year, Integer
+      add_column :external_id, Text, null: false, default: ''
+      add_column :external_source, Text
+      drop_column :imdb_id
+    end
+
+    alter_table(:local_media) do
+      set_column_default :title, nil
+      set_column_default :external_id, nil
+      add_index [:media_type, :external_id], unique: true, name: :idx_local_media_type_external_id
+    end
+  end
+
+end

--- a/test/app/calendar_entries_repository_test.rb
+++ b/test/app/calendar_entries_repository_test.rb
@@ -36,7 +36,7 @@ class CalendarEntriesRepositoryTest < Minitest::Test
       { media_type: 'movie', title: 'Alpha', ids: { 'imdb' => 'tt1234' } }
     ]
     local_rows = [
-      { media_type: 'movies', external_id: 'tt1234', external_source: 'imdb', title: 'Alpha', local_path: '/tmp/a' }
+      { media_type: 'movies', imdb_id: 'tt1234', local_path: '/tmp/a' }
     ]
     @app.db = FakeDb.new(calendar_rows: calendar_rows, local_rows: local_rows)
 

--- a/test/services/file_system_scan_service_test.rb
+++ b/test/services/file_system_scan_service_test.rb
@@ -68,9 +68,7 @@ class FileSystemScanServiceTest < Minitest::Test
     row = @db.rows.first
     assert_equal 'local_media', row[:table]
     assert_equal 'movies', row[:media_type]
-    assert_equal 'Example (2021)', row[:title]
-    assert_equal 2021, row[:year]
-    assert_equal 'tt1234567', row[:external_id]
+    assert_equal 'tt1234567', row[:imdb_id]
     assert_equal @file_path, row[:local_path]
     assert_equal 1, row[:replace]
   end


### PR DESCRIPTION
## Summary
- add a migration that backfills an imdb_id for local media using stored identifiers and drops obsolete metadata columns
- update ingestion and repository logic to track local media by imdb_id plus path, including collection queries and library indexing
- refresh downloaded index handling and tests to reflect the imdb-focused schema

## Testing
- bundle exec ruby -Itest test/app/collection_repository_test.rb
- bundle exec ruby -Itest test/app/calendar_entries_repository_test.rb
- bundle exec ruby -Itest test/services/file_system_scan_service_test.rb

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d422bdb788327bd4c7f5eb700b12c)