### PR TITLE
Simplify watchlist storage and reuse calendar details

### DIFF
--- a/app/web/app.js
+++ b/app/web/app.js
@@ -2056,19 +2056,15 @@ function renderWatchlist(entries = [], { message } = {}) {
 
   normalized.forEach((entry) => {
     const row = document.createElement('tr');
-    const metadata = entry && typeof entry.metadata === 'object' && !Array.isArray(entry.metadata)
-      ? entry.metadata
-      : {};
-    const ids = metadata.ids && typeof metadata.ids === 'object' ? metadata.ids : {};
-    const title = entry.title || metadata.title || '';
-    const type = entry.type || metadata.type || '';
-    const releaseDateYear = metadata.release_date ? new Date(metadata.release_date).getFullYear() : '';
-    const year = metadata.year
-      || metadata.release_year
-      || (Number.isFinite(releaseDateYear) ? releaseDateYear : '');
-    const imdb = ids.imdb || metadata.imdb || '';
-    const externalId = entry.external_id || entry.id || ids.slug || '';
-    const url = metadata.url || '';
+    const ids = entry && typeof entry.ids === 'object' ? entry.ids : {};
+    const title = entry.title || '';
+    const type = entry.type || '';
+    const releaseDateYear = entry.release_date ? new Date(entry.release_date).getFullYear() : '';
+    const year = entry.year || entry.release_year || (Number.isFinite(releaseDateYear) ? releaseDateYear : '');
+    const imdb = entry.imdb_id || ids.imdb || '';
+    const externalId = imdb || entry.id || ids.slug || '';
+    const url = entry.url || '';
+    const metadata = { ids, title, type, year, release_date: entry.release_date, imdb, url };
 
     const cells = [
       { text: title || '—' },
@@ -2173,11 +2169,11 @@ async function loadWatchlist() {
   }
 }
 
-async function removeWatchlistEntry(externalId, type) {
-  if (!externalId) {
+async function removeWatchlistEntry(imdbId, type) {
+  if (!imdbId) {
     return;
   }
-  const payload = { id: externalId };
+  const payload = { imdb_id: imdbId };
   if (type) {
     payload.type = type;
   }

--- a/lib/db/migrations/012_cleanup_watchlist_table.rb
+++ b/lib/db/migrations/012_cleanup_watchlist_table.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    table_columns = schema(:watchlist).map(&:first)
+    existing_indexes = indexes(:watchlist)
+
+    alter_table(:watchlist) do
+      drop_index :imdb_id, name: :idx_watchlist_imdb_id if existing_indexes[:idx_watchlist_imdb_id]
+      drop_column :external_id if table_columns.include?(:external_id)
+      drop_column :title if table_columns.include?(:title)
+      drop_column :metadata if table_columns.include?(:metadata)
+      add_index %i[imdb_id type], unique: true, name: :idx_watchlist_imdb_type
+    end
+  end
+
+  down do
+    table_columns = schema(:watchlist).map(&:first)
+    existing_indexes = indexes(:watchlist)
+
+    alter_table(:watchlist) do
+      drop_index %i[imdb_id type], name: :idx_watchlist_imdb_type if existing_indexes[:idx_watchlist_imdb_type]
+      add_column :external_id, :text, null: false, default: '' unless table_columns.include?(:external_id)
+      add_column :title, :text, null: false, default: '' unless table_columns.include?(:title)
+      add_column :metadata, :text unless table_columns.include?(:metadata)
+      add_index :imdb_id, unique: true, name: :idx_watchlist_imdb_id unless existing_indexes[:idx_watchlist_imdb_id]
+    end
+
+    run <<~SQL
+      UPDATE watchlist
+      SET external_id = COALESCE(imdb_id, ''), title = COALESCE(title, imdb_id)
+      WHERE external_id IS NULL OR title IS NULL OR external_id = '' OR title = '';
+    SQL
+  end
+end

--- a/lib/watchlist_store.rb
+++ b/lib/watchlist_store.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'date'
+
 module WatchlistStore
   module_function
 
@@ -21,6 +23,25 @@ module WatchlistStore
     []
   end
 
+  def fetch_with_details(type: nil)
+    rows = fetch(type: type)
+    return rows if rows.empty?
+
+    imdb_ids = rows.filter_map { |row| normalize_imdb(row[:imdb_id] || row['imdb_id']) }.uniq
+    return rows if imdb_ids.empty?
+
+    calendar_rows = MediaLibrarian.app.db.get_rows('calendar_entries', imdb_id: imdb_ids)
+    calendar_index = build_calendar_index(calendar_rows)
+
+    rows.map do |row|
+      imdb_id = normalize_imdb(row[:imdb_id] || row['imdb_id'])
+      merge_calendar_data(row, calendar_index[imdb_id])
+    end
+  rescue StandardError => e
+    MediaLibrarian.app.speaker.tell_error(e, 'WatchlistStore.fetch_with_details') rescue nil
+    rows
+  end
+
   def delete(imdb_id: nil, type: nil)
     identifier = imdb_id.to_s.strip
     return 0 if identifier.empty?
@@ -35,28 +56,19 @@ module WatchlistStore
 
   def normalize_entries(entries)
     Array(entries).filter_map do |entry|
-      next unless entry
+      next unless entry.is_a?(Hash)
 
       metadata = normalize_metadata(entry[:metadata] || entry['metadata'])
       imdb_id = imdb_id_for(entry, metadata)
-      imdb_id = (entry[:external_id] || entry['external_id']).to_s.strip if imdb_id.to_s.empty?
+      imdb_id = (entry[:external_id] || entry['external_id']).to_s.strip if imdb_id.empty?
 
-      title = entry[:title] || entry['title']
-      type = entry[:type] || entry['type'] || 'movies'
-      next if imdb_id.to_s.empty? || title.to_s.empty?
-
-      ids = metadata[:ids]
-      ids = {} unless ids.is_a?(Hash)
-      ids = ids.transform_keys(&:to_s)
-      ids['imdb'] ||= imdb_id
-      metadata[:ids] = ids
+      title = (entry[:title] || entry['title']).to_s.strip
+      type = normalize_type(entry[:type] || entry['type'] || 'movies')
+      next if imdb_id.empty? || title.empty? || type.empty?
 
       {
-        external_id: imdb_id,
         imdb_id: imdb_id,
-        type: type.to_s,
-        title: title.to_s,
-        metadata: metadata,
+        type: type,
         updated_at: Time.now.utc
       }
     end
@@ -70,12 +82,73 @@ module WatchlistStore
 
   def imdb_id_for(entry, metadata)
     explicit_imdb = entry[:imdb_id] || entry['imdb_id']
-    return explicit_imdb.to_s if explicit_imdb
+    return explicit_imdb.to_s.strip if explicit_imdb
 
     ids = metadata[:ids] || metadata['ids'] || {}
     return '' unless ids.is_a?(Hash)
 
-    (ids[:imdb] || ids['imdb']).to_s
+    (ids[:imdb] || ids['imdb']).to_s.strip
   end
-  private_class_method :normalize_entries, :normalize_metadata, :imdb_id_for
+
+  def normalize_type(type)
+    type.to_s.strip
+  end
+
+  def normalize_imdb(value)
+    value.to_s.strip
+  end
+
+  def build_calendar_index(rows)
+    Array(rows).each_with_object({}) do |row, memo|
+      imdb = normalize_imdb(row[:imdb_id] || row['imdb_id'])
+      memo[imdb] = row unless imdb.empty?
+    end
+  end
+
+  def merge_calendar_data(row, calendar_row)
+    base = {
+      imdb_id: normalize_imdb(row[:imdb_id] || row['imdb_id']),
+      type: normalize_type(row[:type] || row['type']),
+      created_at: row[:created_at] || row['created_at'],
+      updated_at: row[:updated_at] || row['updated_at']
+    }
+
+    return base unless calendar_row
+
+    ids = normalize_ids(calendar_row[:ids] || calendar_row['ids'])
+    ids['imdb'] ||= base[:imdb_id]
+    release_date = calendar_row[:release_date] || calendar_row['release_date']
+
+    base.merge(
+      title: (calendar_row[:title] || calendar_row['title']).to_s,
+      ids: ids,
+      year: extract_year(release_date),
+      release_date: release_date,
+      type: normalize_type(base[:type].empty? ? (calendar_row[:media_type] || calendar_row['media_type']) : base[:type]),
+      source: calendar_row[:source] || calendar_row['source'],
+      url: calendar_row[:url] || calendar_row['url']
+    )
+  end
+
+  def normalize_ids(ids)
+    return {} unless ids.is_a?(Hash)
+
+    ids.each_with_object({}) do |(key, value), memo|
+      memo[key.to_s] = value unless key.to_s.strip.empty?
+    end
+  end
+
+  def extract_year(release_date)
+    return release_date.year if release_date.respond_to?(:year)
+    return nil unless release_date.respond_to?(:to_s)
+
+    date = release_date.to_s[0, 10]
+    Date.parse(date).year
+  rescue StandardError
+    nil
+  end
+
+  private_class_method :normalize_entries, :normalize_metadata, :imdb_id_for,
+                       :normalize_type, :normalize_imdb, :build_calendar_index,
+                       :merge_calendar_data, :normalize_ids, :extract_year
 end

--- a/test/app/calendar_test.rb
+++ b/test/app/calendar_test.rb
@@ -47,7 +47,7 @@ class CalendarTest < Minitest::Test
       }
     ])
 
-    WatchlistStore.stub(:fetch, [{ imdb_id: 'ttalpha', type: 'movies', metadata: { ids: { imdb: 'ttalpha' } } }]) do
+    WatchlistStore.stub(:fetch, [{ imdb_id: 'ttalpha', type: 'movies' }]) do
       calendar = Calendar.new(app: @environment.application)
       result = calendar.entries(type: 'movie', genres: ['Drama'], interest: 'true')
 
@@ -67,7 +67,7 @@ class CalendarTest < Minitest::Test
       {
         source: 'tmdb',
         external_id: '999',
-        imdb_id: '',
+        imdb_id: 'tt1234567',
         title: 'Delta',
         media_type: 'movie',
         ids: { tmdb: '999', imdb: 'tt1234567' },
@@ -76,11 +76,7 @@ class CalendarTest < Minitest::Test
     ])
 
     watchlist = [
-      {
-        imdb_id: 'tt1234567',
-        type: 'movies',
-        metadata: { ids: { tmdb: '999' } }
-      }
+      { imdb_id: 'tt1234567', type: 'movies' }
     ]
 
     WatchlistStore.stub(:fetch, watchlist) do

--- a/test/daemon_watchlist_api_test.rb
+++ b/test/daemon_watchlist_api_test.rb
@@ -47,7 +47,6 @@ class DaemonWatchlistApiTest < Minitest::Test
     assert_equal 200, post_response.status
     entries = WatchlistStore.fetch
     assert_equal ['tt7777'], entries.map { |row| row[:imdb_id] }
-    assert_equal 'tt7777', entries.first[:metadata][:ids][:imdb]
 
     delete_response = FakeResponse.new
     delete_request = OpenStruct.new(request_method: 'DELETE', body: { imdb_id: 'tt7777' }.to_json, query: {}, path: '/watchlist')

--- a/test/services/list_management_service_test.rb
+++ b/test/services/list_management_service_test.rb
@@ -81,12 +81,21 @@ class ListManagementServiceTest < Minitest::Test
       previous_app = MediaLibrarian.instance_variable_get(:@application)
       MediaLibrarian.instance_variable_set(:@application, app)
 
+      db.insert_row(
+        'calendar_entries',
+        source: 'tmdb',
+        external_id: 'tmdb-42',
+        title: 'Sample',
+        media_type: 'movie',
+        imdb_id: 'tt0042',
+        ids: { imdb: 'tt0042', tmdb: '42' }
+      )
+
       WatchlistStore.upsert([
         {
           imdb_id: 'tt0042',
           type: 'movies',
-          title: 'Sample',
-          metadata: { year: 2024, ids: { 'tmdb' => '42', 'imdb' => 'tt0042' }, calendar_entries: [{ external_id: 'tmdb-42' }] }
+          title: 'Sample'
         }
       ])
 


### PR DESCRIPTION
## Summary
- drop legacy watchlist columns and enforce a unique imdb/type index
- stop persisting watchlist metadata blobs while enriching watchlist responses from calendar entries
- update watchlist API, UI, and library/list services to rely on calendar details for display and downloads

## Testing
- bundle exec ruby -I test test/lib/watchlist_store_test.rb
- bundle exec ruby -I test test/daemon_watchlist_api_test.rb
- bundle exec ruby -I test test/app/calendar_test.rb
- bundle exec ruby -I test test/services/list_management_service_test.rb

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d4924345483279707be213de8aa6e)