### PR TITLE
Refine calendar entry interest detection

### DIFF
--- a/test/app/calendar_entries_repository_test.rb
+++ b/test/app/calendar_entries_repository_test.rb
@@ -31,6 +31,20 @@ class CalendarEntriesRepositoryTest < Minitest::Test
     @app = Struct.new(:db).new(nil)
   end
 
+  def test_marks_entries_in_interest_list_when_watchlist_matches
+    calendar_rows = [
+      { media_type: 'movie', title: 'Alpha', imdb_id: 'tt1234' }
+    ]
+
+    WatchlistStore.stub(:fetch, [{ imdb_id: 'tt1234' }]) do
+      @app.db = FakeDb.new(calendar_rows: calendar_rows, local_rows: [])
+
+      entries = CalendarEntriesRepository.new(app: @app).load_entries
+
+      assert entries.first[:in_interest_list]
+    end
+  end
+
   def test_marks_entries_downloaded_when_inventory_matches_imdb
     calendar_rows = [
       { media_type: 'movie', title: 'Alpha', ids: { 'imdb' => 'tt1234' } }


### PR DESCRIPTION
## Summary
- rely on calendar entry data directly for calendar builds and remove watchlist-derived metadata merging
- annotate calendar entries with watchlist interest flags and updated downloaded detection using the new local_media schema
- cover interest flagging and calendar flows with updated tests

## Testing
- bundle exec ruby -Itest test/app/calendar_entries_repository_test.rb
- bundle exec ruby -Itest test/app/calendar_test.rb

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d559b242483278463e464ef61dbee)