### PR TITLE
Handle unscheduled template command detection

### DIFF
--- a/app/web/index.html
+++ b/app/web/index.html
@@ -186,6 +186,15 @@
             </div>
           </section>
 
+          <section class="panel" id="unscheduled-templates-panel">
+            <div class="panel-header">
+              <h2>Commandes de template non planifiées</h2>
+            </div>
+            <div id="unscheduled-template-list" class="scheduler-tasks">
+              <p class="hint">Aucune commande de template détectée.</p>
+            </div>
+          </section>
+
           <section class="panel" id="available-commands-panel">
             <div class="panel-header">
               <h2>Commandes disponibles</h2>


### PR DESCRIPTION
## Summary
- add shared YAML parsing helper and fetch template file contents to derive commands
- ignore templates without a `command` entry and render only unscheduled template commands
- keep available commands limited to items not scheduled or covered by templates

## Testing
- node --test test/web/*.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c7c4981e08327a366be21df8af815)