### PR TITLE
Fetch template commands from dedicated endpoint

### DIFF
--- a/app/web/app.js
+++ b/app/web/app.js
@@ -2551,8 +2551,8 @@ async function loadSchedulerTasks() {
   }
 
   try {
-    const templateData = await fetchJson('/templates');
-    templateCommands = normalizeCommandEntries(extractEntries(templateData));
+    const templateData = await fetchJson('/template_commands');
+    templateCommands = normalizeCommandEntries(templateData?.commands);
     renderUnscheduledTemplateCommands(templateCommands, scheduledKeys);
   } catch (error) {
     renderUnscheduledTemplateCommands([], scheduledKeys);


### PR DESCRIPTION
## Summary
- load template command metadata from the dedicated /template_commands endpoint
- keep unscheduled template commands separate from regular commands

## Testing
- node --test test/web/*.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d59ea391483279f59899ddcdd754c)