### PR TITLE
Remove downloaded items from watchlist during file scan

### DIFF
--- a/test/services/file_system_scan_service_test.rb
+++ b/test/services/file_system_scan_service_test.rb
@@ -12,10 +12,11 @@ require_relative '../../app/media_librarian/services/file_system_scan_service'
 
 class FileSystemScanServiceTest < Minitest::Test
   class RecordingDb
-    attr_reader :rows
+    attr_reader :rows, :deleted_rows
 
     def initialize
       @rows = []
+      @deleted_rows = []
     end
 
     def insert_row(table, values, or_replace = 0)
@@ -26,8 +27,13 @@ class FileSystemScanServiceTest < Minitest::Test
       @rows.select { |row| row[:table] == table.to_sym }
     end
 
+    def delete_rows(table, conditions, *_)
+      @deleted_rows << conditions.merge(table: table.to_sym)
+      1
+    end
+
     def table_exists?(table)
-      %i[calendar_entries local_media].include?(table.to_sym)
+      %i[calendar_entries local_media watchlist].include?(table.to_sym)
     end
   end
 
@@ -86,5 +92,30 @@ class FileSystemScanServiceTest < Minitest::Test
     assert_equal 'tt1234567', local_media[:imdb_id]
     assert_equal @file_path, local_media[:local_path]
     assert_equal 1, local_media[:replace]
+  end
+
+  def test_removes_watchlist_entry_for_detected_media
+    movie = Struct.new(:ids, :year).new({ 'imdb' => 'tt1234567' }, 2021)
+    request = MediaLibrarian::Services::FileSystemScanRequest.new(
+      root_path: @tmp_dir,
+      type: 'movies'
+    )
+
+    library = {
+      'movieExample2021' => {
+        type: 'movies',
+        name: 'Example',
+        full_name: 'Example (2021)',
+        movie: movie,
+        files: [{ name: @file_path }]
+      }
+    }
+
+    MediaLibrarian::Services::CalendarFeedService.stub(:enrich_entries, ->(entries, **) { entries }) do
+      Library.stub(:process_folder, library) { @service.scan(request) }
+    end
+
+    deletion = @db.deleted_rows.find { |row| row[:table] == :watchlist }
+    assert_equal({ table: :watchlist, imdb_id: 'tt1234567', type: 'movies' }, deletion)
   end
 end


### PR DESCRIPTION
## Summary
- remove watchlist entries when the filesystem scan finds downloaded media
- avoid redundant deletions and guard against missing watchlist tables
- extend filesystem scan tests to cover watchlist cleanup

## Testing
- bundle exec ruby -Itest test/services/file_system_scan_service_test.rb


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d87501300832797fb2fec03c72bfb)