### PR TITLE
Use helper module in calendar entry enrichment migration

### DIFF
--- a/lib/db/migrations/013_enrich_calendar_entries_metadata.rb
+++ b/lib/db/migrations/013_enrich_calendar_entries_metadata.rb
@@ -4,32 +4,8 @@ require 'json'
 require 'date'
 require_relative 'support/calendar_entry_enricher'
 
-Sequel.migration do
-  up do
-    dataset = self[:calendar_entries]
-    entries = dataset.map { |row| normalize_entry(row) }.compact
-    candidates = entries.select { |entry| needs_enrichment?(entry) }
-    return if candidates.empty?
-
-    payload = deep_dup_entries(candidates)
-    enriched = CalendarEntryEnricher.enrich(payload) || []
-    original_by_id = candidates.each_with_object({}) { |entry, memo| memo[entry[:id]] = entry }
-    return if enriched.all? { |entry| original_by_id[entry[:id]] == entry }
-
-    enriched.each do |entry|
-      original = original_by_id[entry[:id]]
-      next unless original
-
-      updates = build_updates(original, entry)
-      next if updates.empty?
-
-      dataset.where(id: entry[:id]).update(updates)
-    end
-  end
-
-  down do
-    # no-op; enrichment is additive
-  end
+module CalendarEntryEnrichmentHelpers
+  module_function
 
   def normalize_entry(row)
     {
@@ -177,4 +153,34 @@ Sequel.migration do
       value
     end
   end
+end
+
+Sequel.migration do
+  up do
+    helpers = CalendarEntryEnrichmentHelpers
+    dataset = self[:calendar_entries]
+    entries = dataset.map { |row| helpers.normalize_entry(row) }.compact
+    candidates = entries.select { |entry| helpers.needs_enrichment?(entry) }
+    return if candidates.empty?
+
+    payload = helpers.deep_dup_entries(candidates)
+    enriched = CalendarEntryEnricher.enrich(payload) || []
+    original_by_id = candidates.each_with_object({}) { |entry, memo| memo[entry[:id]] = entry }
+    return if enriched.all? { |entry| original_by_id[entry[:id]] == entry }
+
+    enriched.each do |entry|
+      original = original_by_id[entry[:id]]
+      next unless original
+
+      updates = helpers.build_updates(original, entry)
+      next if updates.empty?
+
+      dataset.where(id: entry[:id]).update(updates)
+    end
+  end
+
+  down do
+    # no-op; enrichment is additive
+  end
+
 end


### PR DESCRIPTION
## Summary
- move the migration helper methods into a reusable `CalendarEntryEnrichmentHelpers` module
- update the migration to call the helpers through the module to avoid missing-method errors while keeping behavior the same

## Testing
- `bundle exec ruby <<'RUBY'
require 'sequel'
Sequel.extension :migration
DB = Sequel.sqlite
DB.create_table(:calendar_entries) do
  primary_key :id
  String :imdb_id
  String :title
  String :synopsis
  String :poster_url
  String :backdrop_url
  Date :release_date
  String :genres
  String :languages
  String :countries
  Float :rating
  Integer :imdb_votes
  String :ids
  String :media_type
  String :external_id
  String :source
end
require_relative 'lib/db/migrations/support/calendar_entry_enricher'
module CalendarEntryEnricher
  class << self
    def enrich(entries)
      entries.map do |entry|
        entry.merge(
          title: 'Updated',
          synopsis: 'Synopsis',
          poster_url: 'http://example.com/poster.jpg',
          backdrop_url: 'http://example.com/backdrop.jpg',
          release_date: '2024-01-01',
          genres: ['Drama'],
          languages: ['en'],
          countries: ['US'],
          rating: 7.0,
          imdb_votes: 1000,
          ids: { imdb: 'tt123' }
        )
      end
    end
  end
end
require_relative 'lib/db/migrations/013_enrich_calendar_entries_metadata'
DB[:calendar_entries].insert(title: nil, poster_url: nil, synopsis: nil, release_date: nil, genres: nil, languages: nil, countries: nil, rating: nil, imdb_votes: nil, ids: nil, media_type: 'movie')
migration = Sequel::Migration.descendants.last
migration.apply(DB, :up)
puts DB[:calendar_entries].all.inspect
RUBY`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693dbab52e5c8327a5e5495bcbb26ac1)