### PR TITLE
Use database dataset for calendar enrichment

### DIFF
--- a/scripts/enrich_calendar_entries.rb
+++ b/scripts/enrich_calendar_entries.rb
@@ -144,7 +144,7 @@ module CalendarEntriesEnrichment
   module_function
 
   def run(db, out: $stdout)
-    dataset = db[:calendar_entries]
+    dataset = db.database[:calendar_entries]
     entries = dataset.map { |row| Helpers.normalize(row) }.compact
     candidates = entries.select { |entry| Helpers.needs_enrichment?(entry) }
     return out.puts('No calendar entries need enrichment.') if candidates.empty?


### PR DESCRIPTION
## Summary
- update calendar entries enrichment to query dataset through the underlying database connection
- keep existing enrichment flow unchanged while avoiding errors when db does not implement dataset accessors

## Testing
- bundle exec ruby -c scripts/enrich_calendar_entries.rb

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693dc83af17c832788fb5b478c0d7f72)