### PR TITLE
Add placeholder migration for version 13

### DIFF
--- a/lib/db/migrations/013_enrich_calendar_entries_metadata.rb
+++ b/lib/db/migrations/013_enrich_calendar_entries_metadata.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    # Version 13 previously performed calendar entry enrichment as a data-only migration.
+    # Keep this placeholder so databases already at version 13 remain in sync.
+  end
+
+  down do
+    # No schema changes were introduced in version 13.
+  end
+end


### PR DESCRIPTION
## Summary
- restore migration version 13 to align with previous calendar enrichment release
- provide no-op up/down blocks matching current schema state so Sequel can traverse versions

## Testing
- bundle exec rake test *(fails due to existing suite issues and Zeitwerk conflicts in current branch)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e88641e9c8327bc663c02fe4fe930)