### PR TITLE
Add calendar search support

### DIFF
--- a/app/web/index.html
+++ b/app/web/index.html
@@ -233,6 +233,29 @@
             </div>
 
             <div class="calendar-filters" aria-label="Filtres calendrier">
+              <form id="calendar-search-form" class="calendar-search" role="search" autocomplete="off">
+                <label for="calendar-search-query">Recherche</label>
+                <input
+                  id="calendar-search-query"
+                  name="query"
+                  type="search"
+                  placeholder="Titre ou mots-clés"
+                  required
+                />
+
+                <label for="calendar-search-year">Année</label>
+                <input
+                  id="calendar-search-year"
+                  name="year"
+                  type="number"
+                  inputmode="numeric"
+                  min="1900"
+                  max="2100"
+                />
+
+                <button type="submit">Chercher</button>
+              </form>
+
               <label for="calendar-type">Type</label>
               <select id="calendar-type" name="type">
                 <option value="">Tous</option>
@@ -278,6 +301,11 @@
 
               <label for="calendar-country">Pays</label>
               <input id="calendar-country" name="country" type="text" />
+            </div>
+
+            <div id="calendar-search-results" class="calendar-content" hidden>
+              <h3>Résultats de recherche</h3>
+              <p class="hint">Aucun résultat pour le moment.</p>
             </div>
 
             <div id="calendar-content" class="calendar-content">


### PR DESCRIPTION
## Summary
- add a calendar search form with title and optional year inputs
- build client-side calendar search handling and results rendering that reuse existing cards
- keep add-to-watchlist actions available on search results

## Testing
- bundle exec rake test *(fails: archive-zip dependency not checked out without bundle install)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e9243f8288327bda33642cd8b639b)