### PR TITLE
Add verbose logging to calendar enrichment script

### DIFF
--- a/test/lib/calendar_entry_enricher_test.rb
+++ b/test/lib/calendar_entry_enricher_test.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require 'date'
+require_relative '../../lib/db/migrations/support/calendar_entry_enricher'
+
+class CalendarEntryEnricherTest < Minitest::Test
+  def setup
+    CalendarEntryEnricher.instance_variable_set(:@omdb_api, nil)
+  end
+
+  def test_fails_fast_without_api_configuration
+    CalendarEntryEnricher.stub(:omdb_api, nil) do
+      assert_raises(StandardError) { CalendarEntryEnricher.enrich([{}]) }
+    end
+  end
+
+  def test_enriches_show_entries_via_title_search
+    api = FakeApi.new
+    entry = {
+      title: 'Sample Show',
+      media_type: 'show',
+      release_date: Date.new(2024, 1, 1),
+      ids: {},
+      genres: [],
+      languages: [],
+      countries: [],
+      poster_url: nil,
+      backdrop_url: nil,
+      rating: nil,
+      imdb_votes: nil
+    }
+
+    enriched = CalendarEntryEnricher.stub(:omdb_api, api) { CalendarEntryEnricher.enrich([entry]).first }
+
+    assert_equal 'series', api.calls.first[:type]
+    assert_equal 'tt1234567', enriched[:ids]['imdb']
+    assert_in_delta 8.1, enriched[:rating]
+    assert_equal ['Drama'], enriched[:genres]
+    assert_equal Date.new(2024, 1, 1), enriched[:release_date]
+  end
+
+  class FakeApi
+    attr_reader :calls
+
+    def initialize
+      @calls = []
+    end
+
+    def title(*)
+      nil
+    end
+
+    def find_by_title(title:, year:, type:)
+      @calls << { title: title, year: year, type: type }
+      {
+        title: title,
+        ids: { 'imdb' => 'tt1234567' },
+        rating: 8.1,
+        imdb_votes: 1234,
+        genres: ['Drama'],
+        languages: ['en'],
+        countries: ['US'],
+        release_date: Date.new(year || 2024, 1, 1),
+        poster_url: 'https://example.test/poster.jpg'
+      }
+    end
+  end
+end

--- a/test/scripts/enrich_calendar_entries_test.rb
+++ b/test/scripts/enrich_calendar_entries_test.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require 'stringio'
+require 'date'
+require_relative '../../scripts/enrich_calendar_entries'
+
+class EnrichCalendarEntriesTest < Minitest::Test
+  def setup
+    @entries = [
+      {
+        id: 1,
+        title: 'Verbose Film',
+        synopsis: '',
+        poster_url: '',
+        backdrop_url: '',
+        release_date: nil,
+        genres: '[]',
+        languages: '[]',
+        countries: '[]',
+        rating: nil,
+        imdb_votes: nil,
+        ids: '{}',
+        media_type: 'movie',
+        external_id: nil,
+        source: nil
+      }
+    ]
+    @dataset = FakeDataset.new(@entries)
+    @db = FakeDB.new(@dataset)
+  end
+
+  def test_logs_progress_and_updates
+    enriched_entry = @entries.first.merge(
+      poster_url: 'poster.jpg',
+      synopsis: 'A story.',
+      release_date: Date.new(2024, 2, 2),
+      genres: ['Drama'],
+      languages: ['en'],
+      countries: ['US'],
+      rating: 8.0,
+      imdb_votes: 123,
+      ids: { imdb: 'tt123' }
+    )
+
+    out = StringIO.new
+    CalendarEntryEnricher.stub(:enrich, [enriched_entry]) do
+      CalendarEntriesEnrichment.run(@db, out: out)
+    end
+
+    output = out.string
+    assert_includes output, 'Scanning 1 calendar entries'
+    assert_includes output, 'Found 1 entries needing enrichment'
+    assert_includes output, 'Enriching 1 entries via OMDb'
+    assert_includes output, 'Updated entry 1 (Verbose Film) with '
+    assert_equal 'poster.jpg', @dataset.updates[1][:poster_url]
+  end
+
+  class FakeDB
+    attr_reader :database
+
+    def initialize(dataset)
+      @database = FakeDatabase.new(dataset)
+    end
+  end
+
+  class FakeDatabase
+    def initialize(dataset)
+      @dataset = dataset
+    end
+
+    def [](key)
+      key == :calendar_entries ? @dataset : nil
+    end
+  end
+
+  class FakeDataset
+    attr_reader :updates
+
+    def initialize(entries)
+      @entries = entries
+      @updates = {}
+    end
+
+    def map(&block)
+      @entries.map(&block)
+    end
+
+    def where(id:)
+      FakeWhere.new(self, id)
+    end
+
+    class FakeWhere
+      def initialize(dataset, id)
+        @dataset = dataset
+        @id = id
+      end
+
+      def update(values)
+        @dataset.updates[@id] = values
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add progress logging to the calendar enrichment script so operators can see scan, enrichment, and update steps
- emit per-entry messages when no updates are applied and when updates occur
- add a unit test covering the new verbose output and update behavior

## Testing
- bundle exec ruby -Itest test/lib/calendar_entry_enricher_test.rb test/scripts/enrich_calendar_entries_test.rb

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e78b4b44c83278b61bed6b59f1bd6)