### PR TITLE
Refresh calendar entry enrichment metadata

### DIFF
--- a/lib/db/migrations/support/calendar_entry_enricher.rb
+++ b/lib/db/migrations/support/calendar_entry_enricher.rb
@@ -26,15 +26,33 @@ module CalendarEntryEnricher
       ids = normalized_ids(entry)
       ids['imdb'] ||= details.dig(:ids, 'imdb') || details.dig('ids', 'imdb')
       entry[:ids] = ids unless ids.empty?
-      entry[:rating] ||= details[:rating] || details['rating']
-      entry[:imdb_votes] ||= details[:imdb_votes] || details['imdb_votes']
-      entry[:poster_url] ||= details[:poster_url] || details['poster_url']
-      entry[:backdrop_url] ||= details[:backdrop_url] || details['backdrop_url']
-      entry[:release_date] ||= coerce_date(details[:release_date] || details['release_date'])
 
-      entry[:genres] = details[:genres] if Array(entry[:genres]).empty? && array_present?(details[:genres])
-      entry[:languages] = details[:languages] if Array(entry[:languages]).empty? && array_present?(details[:languages])
-      entry[:countries] = details[:countries] if Array(entry[:countries]).empty? && array_present?(details[:countries])
+      rating = details[:rating] || details['rating']
+      entry[:rating] = rating unless rating.nil?
+
+      votes = details[:imdb_votes] || details['imdb_votes']
+      entry[:imdb_votes] = votes unless votes.nil?
+
+      poster = details[:poster_url] || details['poster_url']
+      entry[:poster_url] = poster unless poster.to_s.strip.empty?
+
+      backdrop = details[:backdrop_url] || details['backdrop_url']
+      entry[:backdrop_url] = backdrop unless backdrop.to_s.strip.empty?
+
+      synopsis = details[:synopsis] || details['synopsis'] || details[:plot] || details['plot']
+      entry[:synopsis] = synopsis unless synopsis.to_s.strip.empty?
+
+      release_date = coerce_date(details[:release_date] || details['release_date'])
+      entry[:release_date] = release_date if release_date
+
+      genres = details[:genres]
+      entry[:genres] = genres if array_present?(genres)
+
+      languages = details[:languages]
+      entry[:languages] = languages if array_present?(languages)
+
+      countries = details[:countries]
+      entry[:countries] = countries if array_present?(countries)
 
       entry
     end

--- a/lib/omdb_api.rb
+++ b/lib/omdb_api.rb
@@ -158,6 +158,7 @@ class OmdbApi
       genres: list_from(record, :genres, :Genre),
       languages: list_from(record, :languages, :Language),
       countries: list_from(record, :countries, :Country),
+      synopsis: value_from(record, :synopsis, :plot, :Plot),
       rating: float_value(value_from(record, :rating, :imdbRating)),
       imdb_votes: votes_value(value_from(record, :imdb_votes, :imdbVotes)),
       poster_url: url_value(value_from(record, :poster_url, :Poster)),

--- a/scripts/enrich_calendar_entries.rb
+++ b/scripts/enrich_calendar_entries.rb
@@ -42,23 +42,34 @@ module CalendarEntriesEnrichment
 
     def updates_for(original, enriched)
       updates = {}
-      updates[:title] = enriched[:title] if blank?(original[:title]) && present?(enriched[:title])
-      updates[:synopsis] = enriched[:synopsis] if blank?(original[:synopsis]) && present?(enriched[:synopsis])
-      updates[:poster_url] = enriched[:poster_url] if blank?(original[:poster_url]) && present?(enriched[:poster_url])
-      updates[:backdrop_url] = enriched[:backdrop_url] if blank?(original[:backdrop_url]) && present?(enriched[:backdrop_url])
+      updates[:title] = enriched[:title] if present?(enriched[:title]) && enriched[:title] != original[:title]
+
+      synopsis = text(enriched[:synopsis])
+      updates[:synopsis] = synopsis if present?(synopsis) && synopsis != original[:synopsis]
+
+      poster_url = text(enriched[:poster_url])
+      updates[:poster_url] = poster_url if present?(poster_url) && poster_url != original[:poster_url]
+
+      backdrop_url = text(enriched[:backdrop_url])
+      updates[:backdrop_url] = backdrop_url if present?(backdrop_url) && backdrop_url != original[:backdrop_url]
 
       release_date = parse_date(enriched[:release_date])
-      updates[:release_date] = release_date if original[:release_date].nil? && release_date
+      updates[:release_date] = release_date if release_date && release_date != original[:release_date]
 
-      updates[:genres] = json_array(enriched[:genres]) if original[:genres].empty? && enriched[:genres].any?
-      updates[:languages] = json_array(enriched[:languages]) if original[:languages].empty? && enriched[:languages].any?
-      updates[:countries] = json_array(enriched[:countries]) if original[:countries].empty? && enriched[:countries].any?
+      genres = Array(enriched[:genres])
+      updates[:genres] = json_array(genres) if genres.any? && genres != Array(original[:genres])
 
-      updates[:rating] = enriched[:rating].to_f if original[:rating].nil? && !enriched[:rating].nil?
-      updates[:imdb_votes] = enriched[:imdb_votes].to_i if original[:imdb_votes].nil? && !enriched[:imdb_votes].nil?
+      languages = Array(enriched[:languages])
+      updates[:languages] = json_array(languages) if languages.any? && languages != Array(original[:languages])
+
+      countries = Array(enriched[:countries])
+      updates[:countries] = json_array(countries) if countries.any? && countries != Array(original[:countries])
+
+      updates[:rating] = enriched[:rating].to_f if !enriched[:rating].nil? && enriched[:rating].to_f != original[:rating]
+      updates[:imdb_votes] = enriched[:imdb_votes].to_i if !enriched[:imdb_votes].nil? && enriched[:imdb_votes].to_i != original[:imdb_votes]
 
       ids = normalize_ids(enriched[:ids])
-      updates[:ids] = JSON.generate(ids) if original[:ids].empty? && ids.any?
+      updates[:ids] = JSON.generate(ids) if ids.any? && ids != normalize_ids(original[:ids])
 
       imdb_id = text(enriched[:imdb_id])
       updates[:imdb_id] = imdb_id if blank?(original[:imdb_id]) && present?(imdb_id)


### PR DESCRIPTION
## Summary
- update calendar entry enrichment to replace stale OMDb metadata while preserving IMDb identifiers
- propagate refreshed OMDb fields to database updates instead of only filling blanks
- cover overwriting poster, rating, and synopsis values with new tests

## Testing
- bundle exec ruby -Itest test/lib/calendar_entry_enricher_test.rb test/scripts/enrich_calendar_entries_test.rb

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ef686e1b483279e5dc0b1020cf2a6)