### PR TITLE
Add daemon refresh for Trakt authentication

### DIFF
--- a/test/daemon_trakt_refresh_test.rb
+++ b/test/daemon_trakt_refresh_test.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require_relative '../app/daemon'
+
+class DaemonTraktRefreshTest < Minitest::Test
+  def setup
+    reset_librarian_state!
+    @environment = build_stubbed_environment
+    MediaLibrarian.application = @environment.application
+    Daemon.configure(app: @environment.application)
+  end
+
+  def teardown
+    MediaLibrarian.application = nil
+    @environment&.cleanup
+  end
+
+  def test_refreshes_expiring_trakt_token_and_persists
+    token = build_token('old', expires_in: 120, created_at: Time.now.to_i - 4_000)
+    refreshed = build_token('new', expires_in: 3_600, created_at: Time.now.to_i)
+    trakt = build_trakt_stub(token, refreshed)
+
+    app = @environment.application
+    app.trakt_account = 'account'
+    app.trakt = trakt
+    app.db = CaptureDb.new
+
+    Daemon.send(:refresh_trakt_token)
+
+    assert_equal({ 'account' => 'account' }.merge(refreshed), app.db.last_insert)
+    assert_equal 1, trakt.account.refresh_calls
+  end
+
+  def test_skips_refresh_when_token_not_due
+    token = build_token('valid', expires_in: 10_000, created_at: Time.now.to_i)
+    trakt = build_trakt_stub(token, token)
+
+    app = @environment.application
+    app.trakt_account = 'account'
+    app.trakt = trakt
+    app.db = CaptureDb.new
+
+    Daemon.send(:refresh_trakt_token)
+
+    assert_nil app.db.last_insert
+    assert_equal 0, trakt.account.refresh_calls
+  end
+
+  private
+
+  def build_token(access_token, expires_in:, created_at: Time.now.to_i)
+    {
+      'access_token' => access_token,
+      'refresh_token' => 'refresh',
+      'created_at' => created_at,
+      'expires_in' => expires_in
+    }
+  end
+
+  def build_trakt_stub(initial_token, refreshed_token)
+    account = Struct.new(:trakt, :refreshed_token, :refresh_calls) do
+      def access_token
+        self.refresh_calls += 1
+        trakt.token = refreshed_token
+        refreshed_token['access_token']
+      end
+    end.new(nil, refreshed_token, 0)
+
+    trakt = Struct.new(:token, :account).new(initial_token.dup, account)
+    account.trakt = trakt
+    trakt
+  end
+
+  class CaptureDb
+    attr_reader :last_insert
+
+    def insert_row(_table, values, _replace)
+      @last_insert = values
+    end
+  end
+end

--- a/test/support/container_helpers.rb
+++ b/test/support/container_helpers.rb
@@ -32,12 +32,10 @@ module TestSupport
     class StubApplication
       attr_accessor :librarian, :speaker, :args_dispatch,
                     :workers_pool_size, :queue_slots, :finished_jobs_per_queue, :container,
-                    :email, :email_templates
+                    :email, :email_templates, :db, :trakt, :trakt_account
       attr_reader :root, :loader, :template_dir, :pidfile,
                   :env_flags, :config_dir, :config_file, :config_example,
                   :tracker_dir, :api_config_file
-
-      attr_accessor :trakt
 
       def initialize(root:, speaker:, args_dispatch:)
         @root = root


### PR DESCRIPTION
## Summary
- start a daemon timer that refreshes expiring Trakt tokens and persists them
- guard refresh logic with normalized token checks and account-aware persistence
- extend the test stubs and add coverage for the refresh behavior

## Testing
- bundle exec ruby -Itest test/daemon_trakt_refresh_test.rb *(fails: bundle install required for dependencies)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ef749b5f08327a5571e5c5d1c8cff)