### PR TITLE
Normalize IMDb lookups for calendar enrichment

### DIFF
--- a/app/media_librarian/services/calendar_feed_service.rb
+++ b/app/media_librarian/services/calendar_feed_service.rb
@@ -481,7 +481,7 @@ module MediaLibrarian
           candidates.concat(ids.values) if ids.is_a?(Hash)
           candidates << entry[:imdb_id]
           candidates << entry[:external_id]
-          candidates.map { |id| normalize_identifier(id) }.find { |id| !id.empty? }
+          candidates.map { |id| normalize_identifier(id) }.find { |id| id && !id.empty? }
         end
       end
 
@@ -503,7 +503,13 @@ module MediaLibrarian
       end
 
       def normalize_identifier(value)
-        value.to_s.strip
+        token = value.to_s.strip
+        return '' if token.empty?
+
+        digits = token.sub(/\A(?:imdb|tt)/i, '')
+        return token unless digits.match?(/\A\d+\z/)
+
+        "tt#{digits}"
       end
 
       def omdb_titles_match?(entry, details)

--- a/lib/db/migrations/support/calendar_entry_enricher.rb
+++ b/lib/db/migrations/support/calendar_entry_enricher.rb
@@ -66,9 +66,9 @@ module CalendarEntryEnricher
 
     def imdb_identifier(entry)
       ids = normalized_ids(entry)
-      [entry[:imdb_id], ids['imdb'], ids[:imdb], entry[:external_id]].map { |id| normalize_identifier(id) }.find do |candidate|
-        candidate && candidate.match?(/\Aimdb\d+/i)
-      end
+      [entry[:imdb_id], ids['imdb'], ids[:imdb], entry[:external_id]]
+        .map { |id| normalize_identifier(id) }
+        .find { |candidate| imdb_identifier?(candidate) }
     end
 
     def normalized_ids(entry)
@@ -82,7 +82,14 @@ module CalendarEntryEnricher
       token = value.to_s.strip
       return nil if token.empty?
 
-      token.start_with?('tt') ? "imdb#{token.delete_prefix('tt')}" : token
+      digits = token.sub(/\A(?:imdb|tt)/i, '')
+      return nil unless digits.match?(/\A\d+\z/)
+
+      "tt#{digits}"
+    end
+
+    def imdb_identifier?(value)
+      value.to_s.match?(/\Att\d+/i)
     end
 
     def matches_title?(entry, details)

--- a/scripts/enrich_calendar_entries.rb
+++ b/scripts/enrich_calendar_entries.rb
@@ -59,8 +59,14 @@ def missing_release_date?(value)
   date.nil? || !date.respond_to?(:year)
 end
 
+def title_matches_imdb_id?(row)
+  title = row[:title].to_s.strip
+  imdb = row[:imdb_id].to_s.strip
+  !title.empty? && !imdb.empty? && title.casecmp?(imdb)
+end
+
 selected = rows.select do |row|
-  row[:title].to_s.strip.empty? || missing_release_date?(row[:release_date])
+  row[:title].to_s.strip.empty? || missing_release_date?(row[:release_date]) || title_matches_imdb_id?(row)
 end
 selected = selected.first(options[:limit]) if options[:limit]&.positive?
 
@@ -91,21 +97,20 @@ begin
     end
 
     updates = {}
-    updates[:title] = enriched[:title] if missing_value?(row[:title]) && enriched[:title]
-    updates[:release_date] = coerce_date(enriched[:release_date]) if missing_release_date?(row[:release_date]) && enriched[:release_date]
+    updates[:title] = enriched[:title] if enriched[:title]
+    updates[:release_date] = coerce_date(enriched[:release_date]) if enriched[:release_date]
 
     existing_ids = row[:ids].is_a?(Hash) ? row[:ids] : {}
     enriched_ids = enriched[:ids].is_a?(Hash) ? enriched[:ids] : {}
     merged_ids = existing_ids.each_with_object({}) { |(k, v), memo| memo[k.to_s] = v }
-    enriched_ids.each { |k, v| merged_ids[k.to_s] ||= v }
+    enriched_ids.each { |k, v| merged_ids[k.to_s] = v }
     imdb_value = merged_ids['imdb'] || merged_ids[:imdb] || enriched[:imdb_id]
     merged_ids['imdb'] ||= imdb_value if imdb_value
     updates[:ids] = merged_ids if merged_ids.any? && merged_ids != row[:ids]
-    updates[:imdb_id] = imdb_value if missing_value?(row[:imdb_id]) && imdb_value
 
     %i[rating imdb_votes poster_url backdrop_url synopsis genres languages countries].each do |key|
       value = enriched[key]
-      updates[key] = value if missing_value?(row[key]) && !missing_value?(value)
+      updates[key] = value if !missing_value?(value)
     end
 
     if updates.empty?


### PR DESCRIPTION
## Summary
- normalize IMDb identifiers so OMDb lookups use the explicit imdb_id when present
- reuse the normalized identifiers during calendar feed enrichment to prefer ID-based queries
- ensure manual calendar enrichment applies all available OMDb metadata except imdb_id

## Testing
- bundle exec ruby -c scripts/enrich_calendar_entries.rb
- OMDB_API_KEY=1e964bc4 bundle exec ruby scripts/enrich_calendar_entries.rb --limit 1 --verbose *(fails: archive-zip dependency not installed)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694034363604832788816cb8dd52fc7c)