### PR TITLE
Correct existing TV media types during scan

### DIFF
--- a/test/services/file_system_scan_service_test.rb
+++ b/test/services/file_system_scan_service_test.rb
@@ -12,11 +12,12 @@ require_relative '../../app/media_librarian/services/file_system_scan_service'
 
 class FileSystemScanServiceTest < Minitest::Test
   class RecordingDb
-    attr_reader :rows, :deleted_rows
+    attr_reader :rows, :deleted_rows, :updated_rows
 
     def initialize
       @rows = []
       @deleted_rows = []
+      @updated_rows = []
     end
 
     def insert_row(table, values, or_replace = 0)
@@ -29,6 +30,11 @@ class FileSystemScanServiceTest < Minitest::Test
 
     def delete_rows(table, conditions, *_)
       @deleted_rows << conditions.merge(table: table.to_sym)
+      1
+    end
+
+    def update_rows(table, values, conditions)
+      @updated_rows << { table: table.to_sym, values: values, conditions: conditions }
       1
     end
 
@@ -88,10 +94,67 @@ class FileSystemScanServiceTest < Minitest::Test
     assert_equal 'movie', calendar[:media_type]
 
     local_media = @db.rows.find { |row| row[:table] == :local_media }
-    assert_equal 'movies', local_media[:media_type]
+    assert_equal 'movie', local_media[:media_type]
     assert_equal 'tt1234567', local_media[:imdb_id]
     assert_equal @file_path, local_media[:local_path]
     assert_equal 1, local_media[:replace]
+  end
+
+  def test_maps_tv_folder_to_show_media_type
+    show = Struct.new(:ids, :title).new({ 'imdb' => 'tt7654321' }, 'Example Show')
+    request = MediaLibrarian::Services::FileSystemScanRequest.new(
+      root_path: @tmp_dir,
+      type: 'TV Shows'
+    )
+
+    library = {
+      'showExample' => {
+        type: 'tv shows',
+        name: 'Example Show',
+        full_name: 'Example Show',
+        show: show,
+        files: [{ name: @file_path }]
+      }
+    }
+
+    MediaLibrarian::Services::CalendarFeedService.stub(:enrich_entries, ->(entries, **) { entries }) do
+      Library.stub(:process_folder, library) { @service.scan(request) }
+    end
+
+    calendar = @db.rows.find { |row| row[:table] == :calendar_entries }
+    assert_equal 'show', calendar[:media_type]
+
+    local_media = @db.rows.find { |row| row[:table] == :local_media }
+    assert_equal 'show', local_media[:media_type]
+  end
+
+  def test_corrects_existing_tv_records_to_show
+    imdb_id = 'tt7654321'
+    @db.rows << { table: :calendar_entries, imdb_id: imdb_id, media_type: 'tv' }
+    @db.rows << { table: :local_media, imdb_id: imdb_id, media_type: 'tv', local_path: @file_path }
+
+    show = Struct.new(:ids, :title).new({ 'imdb' => imdb_id }, 'Example Show')
+    request = MediaLibrarian::Services::FileSystemScanRequest.new(
+      root_path: @tmp_dir,
+      type: 'series'
+    )
+
+    library = {
+      'showExample' => {
+        type: 'series',
+        name: 'Example Show',
+        full_name: 'Example Show',
+        show: show,
+        files: [{ name: @file_path }]
+      }
+    }
+
+    MediaLibrarian::Services::CalendarFeedService.stub(:enrich_entries, ->(entries, **) { entries }) do
+      Library.stub(:process_folder, library) { @service.scan(request) }
+    end
+
+    assert_includes @db.updated_rows, { table: :calendar_entries, values: { media_type: 'show' }, conditions: { imdb_id: imdb_id } }
+    assert_includes @db.updated_rows, { table: :local_media, values: { media_type: 'show' }, conditions: { imdb_id: imdb_id } }
   end
 
   def test_removes_watchlist_entry_for_detected_media


### PR DESCRIPTION
## Summary
- update file system scan persistence to correct existing calendar and local media records to the canonical `show` type for TV scans
- extend the recording test DB to capture updates and cover the correction path for existing TV records

## Testing
- bundle exec ruby -Itest test/services/file_system_scan_service_test.rb *(fails: sqlite3 gem missing in environment)*
- bundle install *(interrupted due to long runtime in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694064033fbc8327bb838cb387f919fe)