### PR TITLE
Handle retryable metadata lookups

### DIFF
--- a/app/movie.rb
+++ b/app/movie.rb
@@ -229,7 +229,7 @@ class Movie
     nil
   end
 
-  def self.movie_search(title, no_prompt = 0, original_filename = '', ids = {}, app: self.app)
+  def self.movie_search(title, no_prompt = 0, original_filename = '', ids = {}, app: self.app, force_refresh: 0)
     Metadata.media_lookup(
       'movies',
       title,
@@ -239,7 +239,8 @@ class Movie
       [[Tmdb::Movie, :find], [TraktAgent, :search__movies]],
       no_prompt,
       original_filename,
-      ids
+      ids,
+      force_refresh: force_refresh
     )
   end
 end

--- a/app/tv_series.rb
+++ b/app/tv_series.rb
@@ -207,9 +207,9 @@ class TvSeries
     return '', nil
   end
 
-  def self.tv_show_search(title, no_prompt = 0, original_filename = '', ids = {}, app: self.app)
+  def self.tv_show_search(title, no_prompt = 0, original_filename = '', ids = {}, app: self.app, force_refresh: 0)
     Metadata.media_lookup('shows', title, 'tv_show_search', {'name' => 'name', 'url' => 'url', 'year' => 'year'},
                           ->(search_ids) { tv_show_get(search_ids, app: app) },
-                          [[TVMaze::Show, 'search'], [app.tvdb, 'search']], no_prompt, original_filename, TvSeries.formate_ids(ids))
+                          [[TVMaze::Show, 'search'], [app.tvdb, 'search']], no_prompt, original_filename, TvSeries.formate_ids(ids), force_refresh: force_refresh)
   end
 end

--- a/test/lib/metadata_test.rb
+++ b/test/lib/metadata_test.rb
@@ -23,4 +23,56 @@ class MetadataTest < Minitest::Test
     refute_same attrs[:metadata][:tags], stored[:metadata][:tags]
     refute_same attrs[:metadata][:tags].last, stored[:metadata][:tags].last
   end
+
+  def test_media_lookup_retries_after_initial_failure
+    unless Cache.respond_to?(:cache_get)
+      Cache.singleton_class.class_eval do
+        def cache_get(*) = nil
+        def cache_add(*) = nil
+      end
+    end
+    provider = Class.new do
+      attr_reader :calls
+
+      def initialize(responses)
+        @responses = responses
+        @calls = 0
+      end
+
+      def find(_title)
+        @calls += 1
+        @responses.shift
+      end
+    end.new([[], { 'name' => 'Found', 'ids' => { 'tmdb' => 1 }, 'year' => 2020 }])
+    fetcher = ->(search_ids) { ['Found', search_ids.merge('name' => 'Found')] }
+
+    second_item = nil
+    Metadata.stub(:detect_real_title, ->(*) { 'Retry Movie' }) do
+      Metadata.stub(:media_chose, ->(_title, items, *_rest) { [items.first['name'], items.first] }) do
+        _, first_item = Metadata.media_lookup(
+          'movies',
+          'Retry Movie',
+          'movie_lookup',
+          { 'name' => 'name', 'url' => 'url', 'year' => 'year' },
+          fetcher,
+          [[provider, :find]],
+          1
+        )
+        assert_nil first_item
+
+        _, second_item = Metadata.media_lookup(
+          'movies',
+          'Retry Movie',
+          'movie_lookup',
+          { 'name' => 'name', 'url' => 'url', 'year' => 'year' },
+          fetcher,
+          [[provider, :find]],
+          1
+        )
+      end
+    end
+    assert_equal 2, provider.calls
+    refute_nil second_item
+    assert_equal 'Found', second_item['name']
+  end
 end


### PR DESCRIPTION
## Summary
- avoid caching failed metadata lookups and allow bypassing cached results via a force_refresh flag
- propagate cache bypass support through movie and TV search helpers
- add a regression test ensuring a retry queries providers after an initial failure

## Testing
- bundle exec ruby -Itest test/lib/metadata_test.rb


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694196da815c8327b030fd63de0b8577)