### PR TITLE
Handle malformed provider payloads in media lookup

### DIFF
--- a/lib/metadata.rb
+++ b/lib/metadata.rb
@@ -322,7 +322,12 @@ class Metadata
                 end
             v = case type
                 when 'movies'
-                  detail_ids = v['ids'] || { 'tmdb' => v['id'] }
+                  v = v.is_a?(Hash) ? v : { 'name' => v.to_s }
+                  detail_ids = v['ids'] || (v['id'] ? { 'tmdb' => v['id'] } : nil)
+                  unless detail_ids
+                    MediaLibrarian.app.speaker.tell_error(StandardError.new("[#{provider_call}] unexpected payload #{v.inspect}"), title_norm)
+                    next nil
+                  end
                   detail_item = item_fetch_method.call(detail_ids)
                   detail_item = detail_item && detail_item[1]
                   if detail_item.nil?


### PR DESCRIPTION
## Summary
- guard movie search provider items that are not hashes before invoking detail lookups
- log unexpected payloads and skip them instead of raising during media lookup

## Testing
- bundle exec rake test *(fails: Bundler::GitError – git dependency not checked out; bundle install not run)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69418aa06b6083278c168946b210c123)