### PR TITLE
Normalize whitelisted extension handling in download criteria

### DIFF
--- a/app/media_librarian/services/tracker_query_service.rb
+++ b/app/media_librarian/services/tracker_query_service.rb
@@ -220,6 +220,7 @@ module MediaLibrarian
           nil
         end
         download_criteria[:whitelisted_extensions] = FileUtils.get_valid_extensions(category) unless download_criteria[:whitelisted_extensions].is_a?(Array)
+        download_criteria[:whitelisted_extensions] = Array(download_criteria[:whitelisted_extensions]).flatten.compact.map(&:to_s).uniq
         download_criteria.merge(post_actions)
       end
 


### PR DESCRIPTION
## Summary
- normalize whitelisted extensions when preparing download criteria to flatten, string-coerce, and deduplicate values
- keep fallback extension selection intact while ensuring cleaner queue state before post-action merge

## Testing
- bundle exec rake test *(fails: missing bundle install dependency)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694402c295fc83278839d367d862ba18)