### PR TITLE
Remove duplicate mpg video extension

### DIFF
--- a/init/global.rb
+++ b/init/global.rb
@@ -46,7 +46,7 @@ VALID_MEDIA_TYPES = {
     :video => ['movies', 'shows']
 }
 EXTENSIONS_TYPE= {
-    :video => %w(mkv avi mp4 mpg m4v mpg divx iso ts m2ts)
+    :video => %w[mkv avi mp4 mpg m4v divx iso ts m2ts].uniq.freeze
 }
 VALID_VIDEO_EXT="(.*)\\.(#{EXTENSIONS_TYPE[:video].join('|')})$"
 SEP_CHARS='[\/ \.\(\)\-]'


### PR DESCRIPTION
## Summary
- remove the duplicate `mpg` entry from the default video extension whitelist
- freeze the unique list to prevent future duplicates

## Testing
- bundle exec rake test *(fails: archive-zip dependency not checked out; run `bundle install` first)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694407c854c083278476d4c61e06b983)