### PR TITLE
Skip placeholder tracker configs

### DIFF
--- a/config/trackers/tracker.yml
+++ b/config/trackers/tracker.yml
@@ -1,5 +1,5 @@
-api_url: torznab_api_url (not set if not a torznab tracker)
-api_key: torznab_api_key
+api_url: "https://torznab.example/api" # ignored if left as the torznab_api_url placeholder
+api_key: "replace-with-api-key" # ignored if left as the torznab_api_key placeholder
 url_template: "https://tracker.example/search?title=%title%&year=%year%&imdb=%imdbid%"
 assume_quality: "vf" #Takes precedence on search qualities
 seed_time: 24

--- a/lib/media_librarian/container.rb
+++ b/lib/media_librarian/container.rb
@@ -154,7 +154,12 @@ module MediaLibrarian
 
     def build_trackers
       tracker_configs.each_with_object({}) do |(tracker_name, opts), memo|
-        next unless opts['api_url'] && opts['api_key']
+        api_url = opts['api_url']
+        api_key = opts['api_key']
+        if [api_url, api_key].any? { |value| value.to_s.strip.empty? || value.to_s.match?(/torznab_api_(url|key)/) }
+          speaker.speak_up("Skipping tracker '#{tracker_name}': set a real api_url/api_key in trackers/#{tracker_name}.yml.") if speaker.respond_to?(:speak_up)
+          next
+        end
 
         memo[tracker_name] = TorznabTracker.new(opts, tracker_name)
       rescue StandardError => e

--- a/test/lib/container_build_trackers_test.rb
+++ b/test/lib/container_build_trackers_test.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'fileutils'
+require 'tmpdir'
+require 'yaml'
+
+module MediaLibrarian
+  class ContainerBuildTrackersTest < Minitest::Test
+    FakeApplication = Struct.new(:config_dir, :config_file, :config_example, :api_config_file, :env_flags, :tracker_dir, keyword_init: true)
+
+    def setup
+      @tmpdir = Dir.mktmpdir('container-trackers')
+      @config_dir = File.join(@tmpdir, 'config')
+      @tracker_dir = File.join(@tmpdir, 'trackers')
+      FileUtils.mkdir_p(@config_dir)
+      FileUtils.mkdir_p(@tracker_dir)
+      @config_file = File.join(@config_dir, 'conf.yml')
+      @config_example = File.join(@config_dir, 'conf.yml.example')
+      File.write(@config_file, {}.to_yaml)
+      File.write(@config_example, {}.to_yaml)
+    end
+
+    def teardown
+      FileUtils.remove_entry(@tmpdir) if @tmpdir && Dir.exist?(@tmpdir)
+    end
+
+    def test_skips_placeholder_tracker_configs
+      File.write(File.join(@tracker_dir, 'demo.yml'), { 'api_url' => 'torznab_api_url', 'api_key' => 'torznab_api_key' }.to_yaml)
+
+      app = FakeApplication.new(config_dir: @config_dir,
+                                config_file: @config_file,
+                                config_example: @config_example,
+                                api_config_file: File.join(@config_dir, 'api.yml'),
+                                tracker_dir: @tracker_dir,
+                                env_flags: {})
+
+      speaker = TestSupport::Fakes::Speaker.new
+
+      SimpleSpeaker::Speaker.stub(:new, speaker) do
+        Storage::Db.stub(:new, Object.new) do
+          container = Container.new(app)
+          assert_empty container.trackers
+        end
+      end
+
+      joined_messages = speaker.messages.join(' ')
+      assert_includes joined_messages, 'demo'
+      assert_includes joined_messages, 'api_url/api_key'
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- skip tracker initialization when api_url/api_key are blank or left as torznab placeholders and emit a warning with the tracker name
- update the sample tracker config to clarify placeholders are ignored
- add coverage ensuring placeholder tracker configs are skipped and warn

## Testing
- bundle exec rake test *(fails: existing suite reports 9 failures and 20 errors unrelated to this change)*
- bundle exec ruby -Itest test/lib/container_build_trackers_test.rb


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694407dbfdd0832799d1bf4ce55f8aab)