### PR TITLE
Skip tracker placeholders

### DIFF
--- a/config/trackers/tracker.yml
+++ b/config/trackers/tracker.yml
@@ -1,6 +1,6 @@
-api_url: "https://torznab.example/api" # ignored if left as the torznab_api_url placeholder
-api_key: "replace-with-api-key" # ignored if left as the torznab_api_key placeholder
-url_template: "https://tracker.example/search?title=%title%&year=%year%&imdb=%imdbid%"
+api_url: "https://torznab.example/api" # ignored if left as https://torznab.example/api
+api_key: "replace-with-api-key" # ignored if left as replace-with-api-key
+url_template: "https://tracker.example/search?title=%title%&year=%year%&imdb=%imdbid%" # ignored if left pointing to tracker.example
 assume_quality: "vf" #Takes precedence on search qualities
 seed_time: 24
 site_specific_kw:

--- a/lib/media_librarian/container.rb
+++ b/lib/media_librarian/container.rb
@@ -156,8 +156,9 @@ module MediaLibrarian
       tracker_configs.each_with_object({}) do |(tracker_name, opts), memo|
         api_url = opts['api_url']
         api_key = opts['api_key']
-        if [api_url, api_key].any? { |value| value.to_s.strip.empty? || value.to_s.match?(/torznab_api_(url|key)/) }
-          speaker.speak_up("Skipping tracker '#{tracker_name}': set a real api_url/api_key in trackers/#{tracker_name}.yml.") if speaker.respond_to?(:speak_up)
+        url_template = opts['url_template']
+        if [api_url, api_key, url_template].any? { |value| placeholder_value?(value) }
+          speaker.speak_up("Skipping tracker '#{tracker_name}': update trackers/#{tracker_name}.yml placeholders.") if speaker.respond_to?(:speak_up)
           next
         end
 
@@ -260,6 +261,14 @@ module MediaLibrarian
       else
         value
       end
+    end
+
+    def placeholder_value?(value)
+      return true if value.to_s.strip.empty?
+
+      value.to_s.match?(/torznab_api_(url|key)/) ||
+        %w[https://torznab.example/api replace-with-api-key].include?(value) ||
+        value.to_s.include?('tracker.example')
     end
 
     def deep_dup(value)


### PR DESCRIPTION
## Summary
- skip initializing trackers that still use placeholder tracker URLs or keys
- keep tracker warnings concise while naming the tracker to update
- note placeholder values directly in the sample tracker configuration comments

## Testing
- ruby -c lib/media_librarian/container.rb


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69443ecd09588327900aa000c72f60ec)