### PR TITLE
Add tracker error logging context

### DIFF
--- a/lib/media_librarian/container.rb
+++ b/lib/media_librarian/container.rb
@@ -164,7 +164,18 @@ module MediaLibrarian
 
         memo[tracker_name] = TorznabTracker.new(opts, tracker_name)
       rescue StandardError => e
-        speaker.tell_error(e, Utils.arguments_dump(binding)) if speaker.respond_to?(:tell_error)
+        if speaker.respond_to?(:speak_up)
+          api_key_present = !api_key.to_s.empty?
+          speaker.speak_up("Tracker config error: name=#{tracker_name} file=trackers/#{tracker_name}.yml api_url=#{api_url.inspect} url_template=#{url_template.inspect} api_key_present=#{api_key_present}")
+        end
+        if speaker.respond_to?(:tell_error)
+          args = begin
+            Utils.arguments_dump(binding)
+          rescue StandardError
+            nil
+          end
+          speaker.tell_error(e, args)
+        end
       end
     end
 


### PR DESCRIPTION
### Motivation
- Make it easier to identify which tracker config caused an error during `build_trackers` by emitting a concise, explicit log line.
- Avoid leaking secrets: indicate whether an `api_key` is present without logging its value.
- Ensure operators get at least one informative line even if `Utils.arguments_dump` itself raises.

### Description
- In `build_trackers` rescue block, emit a single, lean log line via `speaker.speak_up` with: `name`, config file path (`trackers/<name>.yml`), `api_url`, `url_template`, and `api_key_present=true/false`.
- Wrap `Utils.arguments_dump(binding)` in a `begin/rescue` so a failure there doesn't prevent the log or the subsequent `speaker.tell_error` call.
- Keep the existing `speaker.tell_error(e, args)` behavior; `args` will be `nil` if argument dumping fails.

### Testing
- Ran `git status` and committed the change locally.
- Attempted to run the test suite with `bundle exec rake test` but it failed early due to missing dependencies (`bundle install` required to fetch `archive-zip`).
- No automated tests were modified. Manual inspection and local commit verify the change applied to `lib/media_librarian/container.rb`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69454cd7c48483279e177ccf3f6ae118)