### PR TITLE
Rescue Torznab XMLError and log concise caps diagnostic

### DIFF
--- a/lib/media_librarian/container.rb
+++ b/lib/media_librarian/container.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'yaml'
+require 'net/http'
 
 require 'io/console'
 
@@ -163,6 +164,12 @@ module MediaLibrarian
         end
 
         memo[tracker_name] = TorznabTracker.new(opts, tracker_name)
+      rescue Torznab::Errors::XmlError
+        if speaker.respond_to?(:speak_up)
+          api_key_present = !api_key.to_s.empty?
+          caps_url, status, content_type, body_prefix = fetch_caps_diagnostic(api_url)
+          speaker.speak_up("Tracker caps XML error: name=#{tracker_name} api_url=#{caps_url} status=#{status} content_type=#{content_type.inspect} body_prefix=#{body_prefix.inspect} api_key_present=#{api_key_present}")
+        end
       rescue StandardError => e
         if speaker.respond_to?(:speak_up)
           api_key_present = !api_key.to_s.empty?
@@ -306,6 +313,18 @@ module MediaLibrarian
       else
         value
       end
+    end
+
+    def fetch_caps_diagnostic(api_url)
+      uri = URI.parse(api_url.to_s)
+      redacted = uri.dup
+      redacted.query = nil
+      response = Net::HTTP.get_response(uri)
+      body_prefix = response.body.to_s.gsub(/\s+/, ' ')[0, 200]
+      [redacted.to_s, response.code, response['content-type'], body_prefix]
+    rescue StandardError
+      redacted = api_url.to_s.sub(/\?.*/, '')
+      [redacted, 'n/a', nil, '']
     end
   end
 end


### PR DESCRIPTION
### Motivation
- Improve diagnostics when a tracker returns invalid/malformed caps XML so operators can quickly see what the tracker returned.
- Avoid leaking API keys while still providing useful info: caps URL (redacted), HTTP status, content-type, and a short sanitized response prefix.

### Description
- Added a `Torznab::Errors::XmlError` rescue around `TorznabTracker.new` in `lib/media_librarian/container.rb` that emits a single concise log line with: tracker name, redacted caps URL, HTTP status, response `Content-Type`, a whitespace-collapsed body prefix (first 200 chars), and `api_key_present=true/false`.
- Implemented a small helper `fetch_caps_diagnostic(api_url)` in the same file that uses `Net::HTTP.get_response` to fetch the caps URL, redacts query params from the logged URL, collapses newlines/whitespace and truncates the body to 200 chars, and returns `[caps_url, status, content_type, body_prefix]`.
- Added `require 'net/http'` and kept the log output intentionally lean (one extra `speak_up` line) and avoids logging query params or actual API keys.

### Testing
- Ran `bundle exec rake test` in the environment; test run failed to start due to missing dependencies (`bundle install` required).
- No automated tests were modified or added for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69457f5d47648327875b4edef8e2cc9d)