### PR TITLE
Add debug logging for TraktAgent.method_missing responses

### DIFF
--- a/lib/trakt_agent.rb
+++ b/lib/trakt_agent.rb
@@ -11,13 +11,24 @@ class TraktAgent
     segments = name.to_s.split('__')
     return unless segments[0] && segments[1]
 
-    MediaLibrarian.app.speaker.speak_up(
-      "Running TraktAgent.#{segments[0]}__#{segments[1]}(#{DataUtils.format_string(args).join(', ')})",
-      0
-    ) if Env.debug?
-
+    args_formatted = DataUtils.format_string(args).join(', ')
     target = MediaLibrarian.app.trakt.public_send(segments[0])
-    target.public_send(segments[1], *args)
+    response = target.public_send(segments[1], *args)
+
+    if Env.debug?
+      response_summary = case response
+                         when nil then 'nil'
+                         when Array then "Array(size=#{response.size})"
+                         when Hash then "Hash(keys=#{response.keys.size})"
+                         else response.class.to_s
+                         end
+      MediaLibrarian.app.speaker.speak_up(
+        "TraktAgent.#{segments[0]}__#{segments[1]} target=#{target.class} args=#{args_formatted} => #{response_summary}",
+        0
+      )
+    end
+
+    response
   rescue StandardError => e
     MediaLibrarian.app.speaker.tell_error(e, "TraktAgent.#{name}")
   end


### PR DESCRIPTION
### Motivation

- Improve observability when dynamic TraktAgent calls are invoked via `method_missing` so callers can see what target, method and args were used and what concise response was returned.
- Only emit the extra output in debug mode to avoid noisy logs during normal operation.
- Ensure `nil` responses are explicitly reported.
- Keep changes minimal and lean (small localized change inside `method_missing`).

### Description

- Capture formatted args in `args_formatted = DataUtils.format_string(args).join(', ')`.
- Invoke the target method and store its result in `response` instead of returning directly.
- When `Env.debug?` is true, compute a concise `response_summary` using a `case` for `nil`, `Array`, `Hash`, and fallback to the response class, and call `MediaLibrarian.app.speaker.speak_up` with: target class, method name, `args_formatted`, and `response_summary`.
- Return the original `response` and preserve existing error handling via `rescue StandardError => e`.

### Testing

- Ran syntax check: `ruby -c lib/trakt_agent.rb` — Syntax OK (passed).
- No additional automated tests were available/modified in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945863912648327abd0c4d36ae03b77)