### PR TITLE
Avoid bootstrapping app on XML parse errors in `Hash.from_xml`

### DIFF
--- a/lib/hash.rb
+++ b/lib/hash.rb
@@ -56,7 +56,13 @@ class Hash
         result = Nokogiri::XML(xml_io)
         return {result.root.name.to_sym => xml_node_to_hash(result.root)}
       rescue Exception => e
-        MediaLibrarian.app.speaker.tell_error(e, Utils.arguments_dump(binding))
+        if MediaLibrarian.instance_variable_defined?(:@application)
+          app = MediaLibrarian.instance_variable_get(:@application)
+          app.speaker.tell_error(e, Utils.arguments_dump(binding)) if app&.respond_to?(:speaker)
+        else
+          Kernel.warn(e.full_message)
+        end
+        nil
       end
     end
 


### PR DESCRIPTION
### Motivation

- Prevent creating a second `Application` instance during XML parse error handling which can trigger loader/configuration conflicts.
- Avoid calling `MediaLibrarian.app` during rescue time so we don't bootstrap the app during early boot.

### Description

- Update `Hash.from_xml` to check `MediaLibrarian.instance_variable_defined?(:@application)` before touching the application.
- If an application instance exists, call `app.speaker.tell_error(e, Utils.arguments_dump(binding))` only when `speaker` is present; otherwise fall back to `Kernel.warn(e.full_message)`.
- Return `nil` on parse failure to avoid returning a partially constructed value.

### Testing

- Attempted `bundle exec rake test`, but it failed due to missing gems prior to installing dependencies.
- Ran `bundle install` / `bundle install --jobs 4 --retry 3` attempts to install dependencies but the process was interrupted and tests could not be completed.
- No automated test failures introduced by the change were observed locally because full test suite did not run to completion.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946aa4c66a88327b820f7131f929ab6)