### PR TITLE
Guard Hash.from_xml against empty XML roots

### DIFF
--- a/lib/hash.rb
+++ b/lib/hash.rb
@@ -54,6 +54,7 @@ class Hash
     def from_xml(xml_io)
       begin
         result = Nokogiri::XML(xml_io)
+        return {} if result.root.nil?
         return {result.root.name.to_sym => xml_node_to_hash(result.root)}
       rescue Exception => e
         if MediaLibrarian.instance_variable_defined?(:@application)


### PR DESCRIPTION
### Motivation
- Prevent `NoMethodError` when Nokogiri parses XML that has no root node so callers don't blow up on empty responses.
- Make `Hash.from_xml` return a consistent, minimal value for empty/invalid XML so calling code like `lib/media_librarian/container.rb#build_trackers` can handle it safely.
- Preserve the existing error handling for malformed XML while adding a lightweight guard for empty documents.

### Description
- Added a guard in `Hash.from_xml` (file `lib/hash.rb`) to `return {}` if `result.root.nil?` right after parsing with `Nokogiri::XML`.
- Left the existing `rescue` block intact so malformed XML is still handled and reported the same way.
- Change is intentionally minimal to keep the code lean and reduce surface area for regressions.

### Testing
- Ran `bundle exec rake test`, which failed due to missing dependencies (`archive-zip` not checked out); tests could not run until `bundle install` is executed.
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946ad2d681c832780a75cc9d5f84e19)