### PR TITLE
Log TMDb detail lookup nil with id/source

### DIFF
--- a/app/movie.rb
+++ b/app/movie.rb
@@ -182,7 +182,7 @@ class Movie
           movie = Cache.object_pack(tmdb_movie, 1)
           src = 'tmdb'
         elsif Env.debug?
-          app.speaker.speak_up("TMDb lookup returned nil (id #{ids['tmdb'] || ids['imdb']}, source tmdb)")
+          app.speaker.speak_up("tmdb detail lookup returned nil for id=#{ids['tmdb'] || ids['imdb']}, source=tmdb")
         end
       end
       if (movie.nil? || movie['title'].nil?) && (ids['trakt'].to_s != '' || ids['imdb'].to_s != '' || ids['slug'].to_s != '')


### PR DESCRIPTION
### Motivation
- Add a concise, debug-only log when a TMDb detail lookup returns nil so the missing-data case is easier to spot.
- Include the TMDb id and source in the message to distinguish which identifier produced the nil result.
- Keep debug messages terse and gated behind `Env.debug?` to avoid noisy logs in normal runs.

### Description
- Replace the previous TMDb-nil message with `tmdb detail lookup returned nil for id=..., source=tmdb` in `Movie.movie_get`.
- The message is emitted via `app.speaker.speak_up` only when `Env.debug?` is true, and no other logic was changed.
- Existing lookup timeout and exception handling in `Movie.lookup_with_timeout` remains in place and already logs exception class/message in debug mode.

### Testing
- Ran `bundle exec rake test`, which failed because `bundle install` is required to fetch `archive-zip` and other gems.
- No automated test suite changes were made and no other automated tests were executed due to missing dependencies.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946b57415088327b545f29af1f911d1)