### PR TITLE
Add debug HTTP logging for TMDb and Trakt

### DIFF
--- a/app/movie.rb
+++ b/app/movie.rb
@@ -1,5 +1,7 @@
 require 'timeout'
 require 'socket'
+require 'uri'
+require_relative '../lib/http_debug_logger'
 
 class Movie
   include MediaLibrarian::AppContainerSupport
@@ -177,7 +179,10 @@ class Movie
     case type
     when 'movie_get'
       if movie.nil? && (ids['tmdb'].to_s != '' || ids['imdb'].to_s != '')
-        tmdb_movie = lookup_with_timeout(app, 'tmdb') { Tmdb::Movie.detail(ids['tmdb'] || ids['imdb']) }
+        tmdb_id = ids['tmdb'] || ids['imdb']
+        tmdb_movie = lookup_with_timeout(app, 'tmdb') do
+          log_tmdb_request("/movie/#{tmdb_id}", tmdb_id, Tmdb::Movie.detail(tmdb_id), app)
+        end
         if tmdb_movie
           movie = Cache.object_pack(tmdb_movie, 1)
           src = 'tmdb'
@@ -204,7 +209,7 @@ class Movie
       end
       _, m = movie_get({ 'tmdb' => ids['tmdb'] }, app: app)
       if m&.set.to_s != ''
-        collection_detail = Tmdb::Collection.detail(m.set.id)
+        collection_detail = log_tmdb_request("/collection/#{m.set.id}", m.set.id, Tmdb::Collection.detail(m.set.id), app)
         movie = collection_detail.is_a?(Hash) ? MoviesSet.new(Cache.object_pack(collection_detail, 1), app: app) : collection_detail
       end
       title = movie.name if movie&.name.to_s != ''
@@ -217,6 +222,22 @@ class Movie
     app.speaker.tell_error(e, Utils.arguments_dump(binding))
     Cache.cache_add(type, cache_name, ['', nil], nil)
     return '', nil
+  end
+
+  def self.log_tmdb_request(path, payload, response, app)
+    url = "https://api.themoviedb.org/3#{path}"
+    if payload.is_a?(Hash) && !payload.empty?
+      url = "#{url}?#{URI.encode_www_form(payload)}"
+    end
+    HttpDebugLogger.log(
+      provider: 'TMDb',
+      method: 'GET',
+      url: url,
+      payload: payload,
+      response: response,
+      speaker: app.speaker
+    )
+    response
   end
 
   def self.lookup_with_timeout(app, source, &block)
@@ -240,11 +261,15 @@ class Movie
       'movie_lookup',
       { 'name' => 'name', 'titles' => 'alt_titles', 'url' => 'url', 'year' => 'year' },
       ->(search_ids) { movie_get(search_ids, app: app) },
-      [[Tmdb::Movie, :find], [TraktAgent, :search__movies]],
+      [[self, :tmdb_search], [TraktAgent, :search__movies]],
       no_prompt,
       original_filename,
       ids,
       force_refresh: force_refresh
     )
+  end
+
+  def self.tmdb_search(title)
+    log_tmdb_request('/search/movie', { query: title }, Tmdb::Movie.find(title), app)
   end
 end

--- a/lib/http_debug_logger.rb
+++ b/lib/http_debug_logger.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require_relative 'env'
+
+class HttpDebugLogger
+  MAX_BODY = 250
+
+  def self.log(provider:, method:, url:, payload: nil, response: nil, speaker: nil)
+    return unless Env.debug?
+
+    speaker ||= MediaLibrarian.app.speaker if defined?(MediaLibrarian)
+    payload_text = payload.nil? ? 'nil' : payload.inspect
+    speaker&.speak_up("#{provider} #{method} #{url} payload=#{payload_text} response=#{response_summary(response)}", 0)
+  end
+
+  def self.response_summary(response)
+    status = if response.respond_to?(:code)
+               response.code
+             elsif response.is_a?(Hash)
+               response[:status] || response['status']
+             end
+    body = response.respond_to?(:body) ? response.body : response
+    "status #{status || 'unknown'} body #{truncate_body(body)}"
+  end
+
+  def self.truncate_body(body)
+    text = body.to_s.strip
+    return text if text.length <= MAX_BODY
+
+    "#{text[0, MAX_BODY]}..."
+  end
+end


### PR DESCRIPTION
### Motivation
- Provide consistent, minimal-overhead debug logging for external API calls to aid troubleshooting while keeping normal output lean.
- Capture provider name, HTTP method, full URL, request payload, and a concise response summary for TMDb and Trakt interactions.
- Reuse a single helper to avoid duplication and keep the implementation small and maintainable.

### Description
- Add `lib/http_debug_logger.rb` which implements `HttpDebugLogger.log` gated by `Env.debug?` and truncates long response bodies.
- Instrument TMDb flows in `app/media_librarian/services/calendar_feed_service.rb` to call a `log_tmdb_request` wrapper that builds the full URL and logs requests/responses.
- Wire TMDb detail/collection/search call sites in `app/movie.rb` to use the shared `log_tmdb_request` helper and add `tmdb_search` for discovery.
- Update `lib/trakt_agent.rb` to emit debug logs via `HttpDebugLogger.log`, deriving the request URL from available client/response metadata when possible.

### Testing
- Ran `ruby -c lib/http_debug_logger.rb` which returned no syntax errors (OK).
- Ran `ruby -c lib/trakt_agent.rb` which returned no syntax errors (OK).
- Ran `ruby -c app/media_librarian/services/calendar_feed_service.rb` which returned no syntax errors (OK).
- Ran `ruby -c app/movie.rb` which returned no syntax errors (OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946c415dcf483278c78237f051ea6fd)