### PR TITLE
Use TLS when fetching tracker diagnostics

### DIFF
--- a/lib/media_librarian/container.rb
+++ b/lib/media_librarian/container.rb
@@ -327,7 +327,9 @@ module MediaLibrarian
 
     def fetch_caps_diagnostic(api_url)
       uri = URI.parse(api_url.to_s)
-      response = Net::HTTP.get_response(uri)
+      response = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') do |http|
+        http.get(uri)
+      end
       body = response.body
       body_str = body.to_s
       prefix = body_str.length > 400 ? "#{body_str[0, 400]}...[truncated]" : body_str


### PR DESCRIPTION
### Motivation
- Ensure HTTPS `api_url` uses TLS when fetching tracker capabilities diagnostics to avoid insecure requests.
- Preserve existing diagnostic behavior and keep the change minimal without adding extra SSL options.
- Ensure `response.body` continues to be retrieved for logging and XML parsing.

### Description
- Replace `Net::HTTP.get_response(uri)` with `Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') { |http| http.get(uri) }` in `fetch_caps_diagnostic`.
- Keep the existing handling of `response.body` and the `prefix` truncation logic unchanged.
- Do not introduce additional SSL configuration options to keep the code lean.

### Testing
- Ran `bundle exec rake test` which failed due to a missing dependency checkout (`archive-zip`), so tests could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946d222cca88327bfa598166a43c672)