### PR TITLE
Add low-level HTTP debug logging for TMDb and Trakt

### DIFF
--- a/init/tmdb.rb
+++ b/init/tmdb.rb
@@ -1,5 +1,34 @@
 require 'themoviedb'
 require_relative '../boot/librarian'
+require_relative '../lib/http_debug_logger'
 
 app = MediaLibrarian::Boot.application
 Tmdb::Api.key(app.config['tmdb']['api_key']) if app.config['tmdb'] && app.config['tmdb']['api_key']
+
+if defined?(Tmdb::Api)
+  class << Tmdb::Api
+    unless instance_variable_defined?(:@http_debug_wrapped)
+      @http_debug_wrapped = true
+      alias_method :http_debug_original_get, :get
+
+      def get(path, options = {}, &block)
+        url = HttpDebugLogger.build_url(base_uri, path)
+        payload = options[:body] || options[:query] || options[:payload]
+        HttpDebugLogger.log(provider: 'TMDb', method: :get, url: url, payload: payload)
+
+        response = http_debug_original_get(path, options, &block)
+        HttpDebugLogger.log_request(provider: 'TMDb', response: response, method: :get, url: url, payload: payload)
+        response
+      rescue StandardError => e
+        HttpDebugLogger.log(
+          provider: 'TMDb',
+          method: :get,
+          url: url,
+          payload: payload,
+          response: "exception #{e.class}: #{e.message}"
+        )
+        raise
+      end
+    end
+  end
+end

--- a/lib/http_debug_logger.rb
+++ b/lib/http_debug_logger.rb
@@ -10,7 +10,9 @@ class HttpDebugLogger
 
     speaker ||= MediaLibrarian.app.speaker if defined?(MediaLibrarian)
     payload_text = payload.nil? ? 'nil' : payload.inspect
-    speaker&.speak_up("#{provider} #{method} #{url} payload=#{payload_text} response=#{response_summary(response)}", 0)
+    message = "#{provider} #{method} #{url} payload=#{payload_text}"
+    message += " response=#{response_summary(response)}" if response
+    speaker&.speak_up(message, 0)
   end
 
   def self.log_request(provider:, response:, method: nil, url: nil, payload: nil, speaker: nil)
@@ -70,5 +72,12 @@ class HttpDebugLogger
     return request.method if request.respond_to?(:method)
 
     nil
+  end
+
+  def self.build_url(base_uri, path)
+    base = base_uri.to_s
+    return path.to_s if base.empty?
+
+    "#{base.chomp('/')}/#{path.to_s.sub(%r{\A/}, '')}"
   end
 end


### PR DESCRIPTION
### Motivation
- Ensure every HTTP call to TMDb and Trakt is logged at the lowest request layer so requests, responses and exceptions are always captured.
- Reuse the existing `HttpDebugLogger` to keep logging consistent and avoid duplication.
- Guard logging behind `Env.debug?` to prevent noisy production output.

### Description
- Updated `lib/http_debug_logger.rb` to allow request-only messages and added `HttpDebugLogger.build_url` for consistent base URI + path assembly.
- Wrapped `Tmdb::Api.get` to call `HttpDebugLogger.log` before the request, `HttpDebugLogger.log_request` after, and log exceptions with request context before re-raising. 
- Wrapped `Trakt::Request.get` and `Trakt::Request.post` with the same before/after/exception logging behavior and protection against multiple wrapping.

### Testing
- Ran `ruby -c lib/http_debug_logger.rb` and received `Syntax OK`.
- Ran `ruby -c init/tmdb.rb` and received `Syntax OK`.
- Ran `ruby -c init/trakt.rb` and received `Syntax OK`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946da36321883279c936156c70c6472)