### PR TITLE
Add HTTParty debug logging wrapper for TMDb and Trakt

### DIFF
--- a/lib/media_librarian/application.rb
+++ b/lib/media_librarian/application.rb
@@ -131,6 +131,7 @@ module MediaLibrarian
       require 'mechanize' unless defined?(Mechanize)
       require 'deluge/rpc' unless defined?(Deluge::Rpc::Client)
       require 'mediainfo' unless defined?(MediaInfo)
+      require_relative '../http_debug_logger'
       Numeric.class_eval do
         time_units = {
           second: 1,


### PR DESCRIPTION
### Motivation

- Ensure all TMDb and Trakt HTTP calls are captured with a minimal, centralized wrapper to aid debugging and diagnostics.
- Log provider name, HTTP method, full URL, and payload before requests and status + truncated body after requests while avoiding noisy production output by gating on `Env.debug?`.
- Reuse `HttpDebugLogger.log_request` to keep the implementation small and consistent with existing logging.
- Apply the wrapper early in startup so third-party client calls (TMDb/Trakt) are routed through it.

### Description

- Added helper methods in `lib/http_debug_logger.rb`: `provider_for`, `payload_for`, and `full_url` to identify provider and construct a full request URL.
- Implemented `HttpDebugLogger::HTTPartyWrapper` that defines `get`, `post`, `put`, and `delete` wrappers which log before the request, after the response, and on exceptions using `HttpDebugLogger.log_request`.
- Prepend the wrapper to `HTTParty::ClassMethods` when available so existing `HTTParty` calls are intercepted transparently.
- Require the debug logger during app setup by adding `require_relative '../http_debug_logger'` to `lib/media_librarian/application.rb` so hooks are applied early.

### Testing

- Ran `ruby -c lib/http_debug_logger.rb` and it reported `Syntax OK`.
- Ran `ruby -c lib/media_librarian/application.rb` and it reported `Syntax OK`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946e15a277883278532d809b9827130)