### PR TITLE
Centralize TMDb and Trakt HTTP logging

### DIFF
--- a/app/media_librarian/services/calendar_feed_service.rb
+++ b/app/media_librarian/services/calendar_feed_service.rb
@@ -5,9 +5,7 @@ require 'time'
 require 'themoviedb'
 require 'json'
 require 'httparty'
-require 'uri'
 require_relative '../../../init/global'
-require_relative '../../../lib/http_debug_logger'
 require_relative '../../../lib/omdb_api'
 require_relative '../../../lib/metadata'
 require_relative '../../../lib/simple_speaker'
@@ -1044,17 +1042,17 @@ module MediaLibrarian
               case kind
               when :movie
                 if path == '/movie/upcoming' && client.const_defined?(:Movie) && client::Movie.respond_to?(:upcoming)
-                  return log_tmdb_request(path, params, client::Movie.upcoming)
+                  return client::Movie.upcoming
                 end
                 if path == '/movie/now_playing' && client.const_defined?(:Movie) && client::Movie.respond_to?(:now_playing)
-                  return log_tmdb_request(path, params, client::Movie.now_playing)
+                  return client::Movie.now_playing
                 end
               when :tv
                 if path == '/tv/on_the_air' && client.const_defined?(:TV) && client::TV.respond_to?(:on_the_air)
-                  return log_tmdb_request(path, params, client::TV.on_the_air)
+                  return client::TV.on_the_air
                 end
                 if path == '/tv/airing_today' && client.const_defined?(:TV) && client::TV.respond_to?(:airing_today)
-                  return log_tmdb_request(path, params, client::TV.airing_today)
+                  return client::TV.airing_today
                 end
               end
             rescue ArgumentError
@@ -1063,7 +1061,7 @@ module MediaLibrarian
           end
 
           if client.const_defined?(:Api) && client::Api.respond_to?(:request)
-            return log_tmdb_request(path, params, client::Api.request(path, params))
+            return client::Api.request(path, params)
           end
 
           http_request(path, params)
@@ -1075,7 +1073,6 @@ module MediaLibrarian
         def http_request(path, params)
           query = params.merge(api_key: @api_key, language: language, region: region).compact
           response = HTTParty.get("https://api.themoviedb.org/3#{path}", query: query)
-          log_tmdb_request(path, query, response)
           return JSON.parse(response.body) if response.success?
 
           report_error(StandardError.new("TMDB #{response.code}"), "Calendar TMDB fetch failed for #{path}")
@@ -1087,25 +1084,6 @@ module MediaLibrarian
 
         def release_from(item, kind)
           parse_date(value_from(item, kind == :movie ? :release_date : :first_air_date))
-        end
-
-        def log_tmdb_request(path, params, response)
-          HttpDebugLogger.log_request(
-            provider: 'TMDb',
-            response: response,
-            method: 'GET',
-            url: tmdb_url(path, params),
-            payload: params,
-            speaker: @speaker
-          )
-          response
-        end
-
-        def tmdb_url(path, params)
-          base = "https://api.themoviedb.org/3#{path}"
-          return base if params.nil? || params.empty?
-
-          "#{base}?#{URI.encode_www_form(params)}"
         end
 
         def fetch_paths(kind, date_range)

--- a/init/tmdb.rb
+++ b/init/tmdb.rb
@@ -4,31 +4,3 @@ require_relative '../lib/http_debug_logger'
 
 app = MediaLibrarian::Boot.application
 Tmdb::Api.key(app.config['tmdb']['api_key']) if app.config['tmdb'] && app.config['tmdb']['api_key']
-
-if defined?(Tmdb::Api)
-  class << Tmdb::Api
-    unless instance_variable_defined?(:@http_debug_wrapped)
-      @http_debug_wrapped = true
-      alias_method :http_debug_original_get, :get
-
-      def get(path, options = {}, &block)
-        url = HttpDebugLogger.build_url(base_uri, path)
-        payload = options[:body] || options[:query] || options[:payload]
-        HttpDebugLogger.log(provider: 'TMDb', method: :get, url: url, payload: payload)
-
-        response = http_debug_original_get(path, options, &block)
-        HttpDebugLogger.log_request(provider: 'TMDb', response: response, method: :get, url: url, payload: payload)
-        response
-      rescue StandardError => e
-        HttpDebugLogger.log(
-          provider: 'TMDb',
-          method: :get,
-          url: url,
-          payload: payload,
-          response: "exception #{e.class}: #{e.message}"
-        )
-        raise
-      end
-    end
-  end
-end

--- a/init/trakt.rb
+++ b/init/trakt.rb
@@ -6,54 +6,6 @@ require_relative '../boot/librarian'
 require_relative 'db'
 require_relative '../lib/http_debug_logger'
 
-if defined?(Trakt::Request)
-  class << Trakt::Request
-    unless instance_variable_defined?(:@http_debug_wrapped)
-      @http_debug_wrapped = true
-      alias_method :http_debug_original_get, :get
-      alias_method :http_debug_original_post, :post
-
-      def get(path, options = {}, &block)
-        url = HttpDebugLogger.build_url(base_uri, path)
-        payload = options[:body] || options[:query] || options[:payload]
-        HttpDebugLogger.log(provider: 'Trakt', method: :get, url: url, payload: payload)
-
-        response = http_debug_original_get(path, options, &block)
-        HttpDebugLogger.log_request(provider: 'Trakt', response: response, method: :get, url: url, payload: payload)
-        response
-      rescue StandardError => e
-        HttpDebugLogger.log(
-          provider: 'Trakt',
-          method: :get,
-          url: url,
-          payload: payload,
-          response: "exception #{e.class}: #{e.message}"
-        )
-        raise
-      end
-
-      def post(path, options = {}, &block)
-        url = HttpDebugLogger.build_url(base_uri, path)
-        payload = options[:body] || options[:query] || options[:payload]
-        HttpDebugLogger.log(provider: 'Trakt', method: :post, url: url, payload: payload)
-
-        response = http_debug_original_post(path, options, &block)
-        HttpDebugLogger.log_request(provider: 'Trakt', response: response, method: :post, url: url, payload: payload)
-        response
-      rescue StandardError => e
-        HttpDebugLogger.log(
-          provider: 'Trakt',
-          method: :post,
-          url: url,
-          payload: payload,
-          response: "exception #{e.class}: #{e.message}"
-        )
-        raise
-      end
-    end
-  end
-end
-
 app = MediaLibrarian::Boot.application
 trakt_config = app.config['trakt']
 

--- a/lib/http_debug_logger.rb
+++ b/lib/http_debug_logger.rb
@@ -112,12 +112,11 @@ class HttpDebugLogger
         return super(path, options, &block) unless provider && Env.debug?
 
         payload = HttpDebugLogger.payload_for(options)
-        HttpDebugLogger.log_request(provider: provider, response: nil, method: method, url: full_url, payload: payload)
         response = super(path, options, &block)
         HttpDebugLogger.log_request(provider: provider, response: response, method: method, url: full_url, payload: payload)
         response
-      rescue StandardError
-        HttpDebugLogger.log_request(provider: provider, response: nil, method: method, url: full_url, payload: payload)
+      rescue StandardError => e
+        HttpDebugLogger.log(provider: provider, method: method, url: full_url, payload: payload, response: "exception #{e.class}: #{e.message}")
         raise
       end
     end


### PR DESCRIPTION
### Motivation

- Consolidate HTTP request logging for TMDb and Trakt into the shared HTTParty wrapper to ensure every request is logged consistently with method, URL, payload, and response.
- Remove duplicate, per-call logging helpers to reduce noisy output and keep runtime output lean.
- Rely on the centralized logger while keeping runtime logging gated behind `Env.debug?` for production performance.

### Description

- Adjusted `lib/http_debug_logger.rb` to rely on the HTTParty wrapper for request/response logging and to log exceptions via the central `log` method instead of emitting a duplicate pre-request log.
- Removed per-call TMDb logging helpers and calls from `app/movie.rb` and `app/media_librarian/services/calendar_feed_service.rb`, and replaced them with direct `Tmdb::` calls so the HTTParty wrapper handles logging.
- Removed Trakt-specific per-call logging from `lib/trakt_agent.rb` and cleaned up redundant requires and helper URL builders that duplicated the centralized output.
- Stripped manual HTTP-wrapping logic from `init/tmdb.rb` and `init/trakt.rb` to avoid double-wrapping and rely on the single centralized logging implementation.

### Testing

- Ran the project test suite with `bundle exec rake test`, which failed due to missing bundle dependencies (`bundle install` required), so unit tests could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946f6ff53fc83279cca6d05e1e5c41c)