### PR TITLE
Normalize movie fallback metadata

### DIFF
--- a/lib/metadata.rb
+++ b/lib/metadata.rb
@@ -341,7 +341,10 @@ class Metadata
                   if detail_item.nil?
                     msg = "[#{provider_call}] detail lookup returned nil for ids #{detail_ids}"
                     Env.debug? ? MediaLibrarian.app.speaker.speak_up(msg, 0) : MediaLibrarian.app.speaker.tell_error(StandardError.new(msg), title_norm)
-                    v.merge('ids' => detail_ids, 'name' => v['name'] || v['title'])
+                    v['ids'] = detail_ids
+                    v['name'] ||= v['title']
+                    v['year'] ||= v['release_date'].to_s[0,4]
+                    v
                   else
                     detail_item
                   end


### PR DESCRIPTION
### Motivation
- Ensure `media_chose` receives a usable `name` and `year` when a provider detail lookup returns nil for movies.
- Prevent downstream selection logic from seeing incomplete fallback payloads and improve robustness of movie lookups.

### Description
- Modify `lib/metadata.rb` inside `Metadata.media_lookup` `when 'movies'` branch to set `v['ids'] = detail_ids`, `v['name'] ||= v['title']`, and `v['year'] ||= v['release_date'].to_s[0,4]` when `detail_item` is nil, then return `v`.
- Preserve the existing successful-detail-fetch code path and leave `shows` handling unchanged.
- Replace the previous `v.merge(...)` fallback with in-place normalization to keep the payload lean.

### Testing
- Ran `bundle exec rake test` and it failed due to missing dependencies (`archive-zip` not checked out), so tests did not complete successfully.
- No additional automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947faaee0dc83279421419ce1d0e151)