### PR TITLE
Guard TMDb movie lookup by tmdb id

### DIFF
--- a/app/movie.rb
+++ b/app/movie.rb
@@ -175,14 +175,14 @@ class Movie
     full_save = movie
     case type
     when 'movie_get'
-      if movie.nil? && (ids['tmdb'].to_s != '' || ids['imdb'].to_s != '')
-        tmdb_id = ids['tmdb'] || ids['imdb']
+      if movie.nil? && ids['tmdb'].to_s != ''
+        tmdb_id = ids['tmdb']
         tmdb_movie = lookup_with_timeout(app, 'tmdb') { Tmdb::Movie.detail(tmdb_id) }
         if tmdb_movie
           movie = Cache.object_pack(tmdb_movie, 1)
           src = 'tmdb'
         elsif Env.debug?
-          app.speaker.speak_up("tmdb detail lookup returned nil for id=#{ids['tmdb'] || ids['imdb']}, source=tmdb")
+          app.speaker.speak_up("tmdb detail lookup returned nil for id=#{ids['tmdb']}, source=tmdb")
         end
       end
       if (movie.nil? || movie['title'].nil?) && (ids['trakt'].to_s != '' || ids['imdb'].to_s != '' || ids['slug'].to_s != '')


### PR DESCRIPTION
### Motivation
- Avoid calling `Tmdb::Movie.detail` with non-TMDb identifiers and prevent passing IMDb IDs into TMDb lookups.
- Ensure that when only an IMDb ID is available the code skips TMDb and falls back to Trakt.
- Keep debug messaging accurate and aligned with the actual lookup parameter.

### Description
- Change `Movie.movie_get` to only attempt a TMDb detail lookup when `ids['tmdb']` is present by replacing the prior `tmdb || imdb` check with `ids['tmdb']`.
- Only assign `tmdb_id = ids['tmdb']` so IMDb IDs are no longer passed to `Tmdb::Movie.detail`.
- Update the debug message to reference `ids['tmdb']` instead of the previous `ids['tmdb'] || ids['imdb']`.
- Behavior now falls through to the Trakt lookup when TMDb ID is absent, preserving existing Trakt fallback logic.

### Testing
- Ran `bundle exec rake test`, which failed due to missing dependency during setup (the `archive-zip` dependency is not checked out), so tests did not complete.
- No other automated test runs were performed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947fc53f4c48327a995946c37c65985)