### PR TITLE
Use '|'-delimited cache keys in Metadata.media_lookup

### DIFF
--- a/lib/metadata.rb
+++ b/lib/metadata.rb
@@ -286,7 +286,8 @@ class Metadata
   end
 
   def self.media_lookup(type, title, cache_category, keys, item_fetch_method, search_providers, no_prompt = 0, original_filename = '', ids = {}, force_refresh: 0)
-    cache_name = title.to_s + ids.map { |k, v| k.to_s + v.to_s if v.to_s != '' }.join + original_filename.to_s
+    ids_part = ids.map { |k, v| k.to_s + v.to_s if v.to_s != '' }.join
+    cache_name = [title, ids_part, original_filename].map(&:to_s).join('|')
     exact_title, item = title, nil
     cached = Cache.cache_get(cache_category, cache_name, 120, force_refresh)
     return cached if cached && cached[1] && force_refresh.to_i == 0


### PR DESCRIPTION
### Motivation
- Prevent accidental collisions when concatenating `title`, `ids`, and `original_filename` into a single cache key by adding an explicit delimiter.
- Ensure cache lookups and inserts use a consistent, unambiguous key format.

### Description
- Extract `ids_part` from `ids` and build `cache_name` as `[#title, ids_part, original_filename].map(&:to_s).join('|')` in `Metadata.media_lookup`.
- Leave subsequent `Cache.cache_get`/`Cache.cache_add` calls using the same `cache_name` variable so lookups remain aligned with inserts.

### Testing
- Attempted to run `bundle exec rake test`, which failed due to missing dependencies and an unchecked-out submodule (`archive-zip`), so tests were not executed.
- Confirmed the file change and committed the update with `git commit`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947fe68d3c08327ae815e0132edd525)