### PR TITLE
Propagate IMDb ID from TMDb lookups for Trakt fallback

### DIFF
--- a/app/movie.rb
+++ b/app/movie.rb
@@ -181,8 +181,17 @@ class Movie
         if tmdb_movie
           movie = Cache.object_pack(tmdb_movie, 1)
           src = 'tmdb'
+          imdb_id = tmdb_movie['imdb_id']
+          ids['imdb'] = imdb_id if ids['imdb'].to_s == '' && imdb_id.to_s != ''
         elsif Env.debug?
           app.speaker.speak_up("tmdb detail lookup returned nil for id=#{ids['tmdb']}, source=tmdb")
+        end
+      end
+      if (movie.nil? || movie['title'].nil?)
+        if ids['imdb'].to_s == '' && ids['tmdb'].to_s != ''
+          tmdb_ids = lookup_with_timeout(app, 'tmdb') { Tmdb::Movie.external_ids(ids['tmdb']) }
+          imdb_id = tmdb_ids && (tmdb_ids['imdb_id'] || tmdb_ids.dig('external_ids', 'imdb_id'))
+          ids['imdb'] = imdb_id if imdb_id.to_s != ''
         end
       end
       if (movie.nil? || movie['title'].nil?) && (ids['trakt'].to_s != '' || ids['imdb'].to_s != '' || ids['slug'].to_s != '')


### PR DESCRIPTION
### Motivation
- Ensure `TraktAgent.movie__summary` can fall back to IMDb-based lookup by providing an IMDb ID when available from TMDb.
- Avoid unnecessary Trakt failures when TMDb already knows the IMDb identifier.
- Keep the logic minimal and only perform extra TMDb calls when strictly needed.

### Description
- After a successful `Tmdb::Movie.detail` lookup, extract `imdb_id` and set `ids['imdb']` when it is empty. 
- When no usable `movie` result is present and `ids['imdb']` is empty, do a lightweight `Tmdb::Movie.external_ids` lookup and populate `ids['imdb']` if found. 
- Preserve existing fallback to `TraktAgent.movie__summary` and avoid extra TMDb calls except when necessary. 

### Testing
- Ran `bundle exec rake test`, which failed due to missing dependencies with the message to run `bundle install`.
- No other automated tests were executed in this environment after the change due to the dependency issue.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69480d98b2548327b106485c32a97460)