### PR TITLE
Normalize keys in Movie.movie_get ids

### DIFF
--- a/app/movie.rb
+++ b/app/movie.rb
@@ -165,6 +165,7 @@ class Movie
   end.freeze
 
   def self.movie_get(ids, type = 'movie_get', movie = nil, app: self.app)
+    ids = ids.transform_keys(&:to_s)
     cache_name = ids.map { |k, v| v.to_s.empty? ? nil : "#{k}#{v}" }.compact.join
     return '', nil if cache_name.empty?
 


### PR DESCRIPTION
### Motivation

- Ensure `Movie.movie_get` handles `ids` passed with symbol keys so lookups like `ids['tmdb']` and `ids['imdb']` work reliably.
- Prevent subtle bugs when callers provide symbol keys instead of string keys without changing call sites.
- Keep the change minimal and low-risk by normalizing keys only inside the method.

### Description

- Normalize the incoming `ids` hash with `ids = ids.transform_keys(&:to_s)` at the start of `self.movie_get` so subsequent `ids['tmdb']` style access always works.
- No other logic was changed and the rest of the method uses the normalized `ids` as before.
- Change is intentionally minimal to remain lean and non-invasive.

### Testing

- Ran `bundle exec rake test`, which could not run because dependencies are not installed and `bundle install` is required (tests did not execute).
- No other automated tests were run in this environment due to missing dependency setup.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69481136dfa48327b58cef74c2c24bfe)