### PR TITLE
Add structured configuration form with YAML toggle

### DIFF
--- a/app/web/app.css
+++ b/app/web/app.css
@@ -317,6 +317,53 @@ main {
   color: inherit;
 }
 
+.config-form {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.config-section {
+  display: grid;
+  gap: 0.75rem;
+  padding: 1rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(15, 23, 42, 0.35);
+}
+
+.config-section h3 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.config-section .grid {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.config-section label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-weight: 600;
+}
+
+.config-section input,
+.config-section select {
+  padding: 0.6rem 0.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(17, 24, 39, 0.6);
+  color: inherit;
+}
+
+.config-section .field-hint {
+  font-weight: 400;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
 .download-list-table {
   margin-top: 0.5rem;
 }

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -378,10 +378,12 @@
             <div class="panel-header">
               <h2>Configuration</h2>
               <div class="actions">
+                <button id="toggle-config-view" type="button">YAML brut</button>
                 <button id="reload-config" type="button">Recharger</button>
                 <button id="save-config" type="button" class="primary">Sauvegarder</button>
               </div>
             </div>
+            <div id="config-form" class="config-form"></div>
             <textarea id="config-editor" spellcheck="false" placeholder="Configuration YAML"></textarea>
             <p class="hint">Les modifications sont validées côté serveur (syntaxe YAML) avant d'être enregistrées.</p>
           </section>


### PR DESCRIPTION
### Motivation
- Provide a structured, user-friendly way to edit the application's YAML configuration without duplicating existing server-side save logic.
- Surface helpful comments and descriptions from the example config as tooltips to guide users when editing options.
- Keep the advanced workflow available by allowing users to toggle between the form and raw YAML.

### Description
- Add a `toggle-config-view` button and a `config-form` container in `app/web/index.html`, and hide/show the existing `config-editor` textarea based on the selected view.
- Implement a compact declarative `CONFIG_FORM_SCHEMA` and minimal form builder in `app/web/app.js` that generates sectioned inputs, hydrates values from `/config`, and collects updates.
- Introduce small YAML parsing and stringification helpers (`parseConfigYaml`, `buildConfigYaml`, `parseConfigScalar`, `stringifyConfigScalar`) and wire them into the existing `config` file editor via `afterLoad` and `buildPayload` so the existing `save-config` flow is reused.
- Add styling for the form in `app/web/app.css` and wire the toggle and initialization logic in DOMContentLoaded to default to the form view.

### Testing
- Rendered the updated UI and captured a screenshot via a Playwright script, which produced the artifact `artifacts/config-form.png` successfully.
- Served `app/web` with a simple HTTP server to exercise the page rendering used by the Playwright run.
- Ran `bundle exec rake test` which failed due to an external dependency not checked out (`https://github.com/raphyduck/archive-zip.git`), so the test suite did not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694948bd475483279c40078ebdb6b904)