### PR TITLE
Add API config editor and server endpoints with masked sensitive fields

### DIFF
--- a/app/web/app.css
+++ b/app/web/app.css
@@ -349,6 +349,26 @@ main {
   font-weight: 600;
 }
 
+.config-section .field-input-row {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.config-section .field-input-row input {
+  flex: 1;
+}
+
+.config-section .field-toggle {
+  padding: 0.5rem 0.65rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(17, 24, 39, 0.6);
+  color: inherit;
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+
 .config-section input,
 .config-section select {
   padding: 0.6rem 0.75rem;

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -388,6 +388,20 @@
             <p class="hint">Les modifications sont validées côté serveur (syntaxe YAML) avant d'être enregistrées.</p>
           </section>
 
+          <section class="panel" id="api-config-panel">
+            <div class="panel-header">
+              <h2>API</h2>
+              <div class="actions">
+                <button id="toggle-api-config-view" type="button">YAML brut</button>
+                <button id="reload-api-config" type="button">Recharger</button>
+                <button id="save-api-config" type="button" class="primary">Sauvegarder</button>
+              </div>
+            </div>
+            <div id="api-config-form" class="config-form"></div>
+            <textarea id="api-config-editor" spellcheck="false" placeholder="Configuration YAML de l'API"></textarea>
+            <p class="hint">Les modifications sont validées côté serveur (syntaxe YAML) avant d'être enregistrées.</p>
+          </section>
+
           <section class="panel" id="scheduler-panel">
             <div class="panel-header">
               <h2>Planificateur</h2>


### PR DESCRIPTION
### Motivation

- Surface `config/api.yml.example` fields in the web UI and allow editing API-specific options separately from the main config. 
- Keep sensitive values like `password_hash`, `session_secret`, `api_token` and `control_token` hidden by default while allowing the operator to reveal them on demand. 
- Provide a dedicated load/save/reload flow for the API config so in-memory auth/tokens are refreshed without restarting the daemon. 
- Keep the front-end form generation lean and reusable for both main config and API config panels.

### Description

- Add a new API configuration panel in the web UI (`app/web/index.html`) with a form and raw YAML editor for the API config. 
- Introduce `API_CONFIG_FORM_SCHEMA` and `apiConfig` editor in `app/web/app.js`, including masked `password` inputs with a show/hide toggle and concise help text taken from the example file. 
- Generalize the config form builder and YAML conversion functions to accept a schema so both the main config and API config reuse the same logic. 
- Add UI styles for masked-field toggle controls in `app/web/app.css`. 
- Wire new server endpoints in `app/daemon.rb`: `GET/PUT /api-config` and `POST /api-config/reload`, plus an `api_config_mutex`. 
- Implement `reload_api_option_config` in the daemon to call `app.container.reload_api_option!`, refresh `@api_token` and normalized `@auth_config`, and clear cached `@session_secret` so the control server uses updated in-memory auth immediately.

### Testing

- Ran `bundle exec rake test`, which did not complete due to missing dependencies and failed with a message that `bundle install` is required to fetch `archive-zip` (automated test run failed). 
- Attempted a quick UI smoke test by serving `app/web` and taking a Playwright screenshot, but the playwright runs timed out / failed to load the page in this environment (automated UI check failed).
- No server-side unit or integration tests were added in this change. 
- All code changes were locally committed; manual runtime verification is recommended after running `bundle install` and starting the daemon to confirm `/api-config` endpoints and the UI behave as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69494a8c71dc8327b8ed224f5c5cdf9a)