### PR TITLE
Add tracker form hydration and defaults

### DIFF
--- a/app/web/index.html
+++ b/app/web/index.html
@@ -446,6 +446,7 @@
                 </div>
               </div>
             </div>
+            <div id="trackers-form" class="config-form hidden"></div>
             <textarea id="trackers-editor" spellcheck="false" placeholder="Configuration YAML du tracker"></textarea>
             <p class="hint" id="trackers-hint">Sélectionnez un tracker pour l'éditer.</p>
           </section>


### PR DESCRIPTION
### Motivation
- Provide a per-field form UI for tracker configuration driven by the tracker schema so users can edit trackers field-by-field instead of raw YAML.
- Hydrate the form when a tracker is loaded and regenerate the YAML on save to avoid manual YAML editing errors.
- Prefill form inputs with example/default values from the tracker schema so users get sensible starting values.
- Surface guidance for `url_template` placeholders (`%title%`, `%year%`, `%imdbid%`) to reduce mistakes.

### Description
- Add a `TRACKER_FORM_SCHEMA` and `trackerFormState` and render a new `div#trackers-form` in `app/web/index.html` used by the form builder.
- Implement `buildSchemaDefaults` and `mergeConfigDefaults` to derive `TRACKER_FORM_DEFAULTS` from the schema and merge them with loaded content.
- Hydrate the trackers form in `afterLoad` for the `trackers` file editor and regenerate the YAML before save via a custom `buildPayload` that calls `configFormToYaml`.
- Wire the form builder by calling `buildConfigForm('trackers-form', trackerFormState, TRACKER_FORM_SCHEMA, 'trackers')` at DOMContentLoaded.

### Testing
- Attempted `bundle exec rake test`, which failed because project dependencies need to be installed (`bundle install` required) so the test run did not complete.
- Performed a UI smoke check by serving `app/web` and running a Playwright script that opened `index.html`, revealed and populated the trackers form, and produced a screenshot artifact (`artifacts/tracker-form.png`) which succeeded.
- No other automated tests were added or modified in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69494ee26c548327b3680848e49a06a2)