### PR TITLE
Allow OMDb enrichment for non-movie entries

### DIFF
--- a/app/media_librarian/services/calendar_feed_service.rb
+++ b/app/media_librarian/services/calendar_feed_service.rb
@@ -414,11 +414,6 @@ module MediaLibrarian
         return entries unless api
 
         entries.each do |entry|
-          unless entry[:media_type] == 'movie'
-            omdb_enrichment_debug("OMDb enrichment skipped for #{entry[:title] || entry[:external_id]} (media_type=#{entry[:media_type].inspect})")
-            next
-          end
-
           imdb_id = imdb_id_for(entry)
           omdb_enrichment_debug("OMDb enrichment fetching #{entry[:title] || entry[:external_id]} via IMDb #{imdb_id}") if imdb_id
           details = imdb_id ? omdb_details(api, imdb_id) : nil


### PR DESCRIPTION
### Motivation
- Enable OMDb enrichment for calendar entries that are not strictly `media_type == 'movie'` so shows can receive rating and votes from OMDb. 
- Keep the existing title matching and safety checks in place to avoid incorrect matches for non-movie entries. 
- Ensure `entry[:rating]` and `entry[:imdb_votes]` are populated for `media_type: 'show'` when OMDb details are found. 

### Description
- Removed the early `next` branch that skipped enrichment when `entry[:media_type] != 'movie'` in `enrich_with_omdb`. 
- Continued to use `omdb_titles_match?` for validating detail results, which already supports `media_type == 'show'`. 
- Continued to assign `entry[:rating]` and `entry[:imdb_votes]` from OMDb `details` when present. 

### Testing
- Ran a Ruby syntax check with `ruby -c app/media_librarian/services/calendar_feed_service.rb`, which succeeded. 
- No other automated tests were modified or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694954647acc8327b71998ce14215bb7)