### PR TITLE
Fix OMDb series search type mapping

### DIFF
--- a/app/media_librarian/services/calendar_feed_service.rb
+++ b/app/media_librarian/services/calendar_feed_service.rb
@@ -470,7 +470,8 @@ module MediaLibrarian
         return nil unless entry[:title]
 
         year = entry[:release_date]&.year
-        api.find_by_title(title: entry[:title], year: year, type: entry[:media_type]) if api.respond_to?(:find_by_title)
+        omdb_type = entry[:media_type] == 'show' ? 'series' : entry[:media_type]
+        api.find_by_title(title: entry[:title], year: year, type: omdb_type) if api.respond_to?(:find_by_title)
       end
 
       def omdb_details(api, imdb_id)


### PR DESCRIPTION
### Motivation

- OMDb title searches need the `series` type when resolving TV shows so lookups succeed for shows without an IMDb ID.
- Existing code had been passing `entry[:media_type]` directly which can be `'show'` and OMDb expects `'series'`.

### Description

- Update `omdb_search_details` to translate `entry[:media_type] == 'show'` to `type: 'series'` when calling `api.find_by_title` and otherwise pass the original media type via `omdb_type` variable. 
- Add test `test_omdb_search_uses_series_type_for_shows` in `test/services/calendar_feed_service_test.rb` to assert that a show triggers a `find_by_title` call with type `'series'`.
- Keep change minimal and focused to avoid added complexity.

### Testing

- Added unit test `test_omdb_search_uses_series_type_for_shows` to verify the mapping behavior using a stubbed `OmdbApi` client. 
- Attempted to run `bundle exec ruby -Itest test/services/calendar_feed_service_test.rb` but it failed due to missing bundle dependencies (`archive-zip` not checked out), so tests could not be executed in this environment. 
- No other automated test runs were performed in this session.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69495626b8048327a664f75c06cafc9f)