### PR TITLE
Normalize whitelisted extensions before queue update

### DIFF
--- a/app/media_librarian/services/torrent_queue_service.rb
+++ b/app/media_librarian/services/torrent_queue_service.rb
@@ -173,6 +173,7 @@ module MediaLibrarian
           info = BEncode.load(torrent, { ignore_trailing_junk: 1 }).dig('info')
           raise ArgumentError, "Missing torrent metadata for #{request.torrent_name}" unless info
           meta_id = Digest::SHA1.hexdigest(info.bencode)
+          request.options[:whitelisted_extensions] = Array(request.options[:whitelisted_extensions]).flatten.compact.map(&:to_s).uniq
           Cache.queue_state_add_or_update('deluge_options', { request.torrent_name => request.options.merge({ info_hash: meta_id }) })
           download = { type: 1, type_str: 'file', file: torrent, filename: File.basename(request.path) }
         elsif request.nodl.zero?


### PR DESCRIPTION
### Motivation
- Ensure `info_hash` update does not persist duplicated extensions when the `whitelisted_extensions` array is mutated before the queued options are stored.
- Keep normalization consistent with `build_download_options` to avoid diverging behavior.
- Make the change minimal and lean by reusing the existing normalization expression rather than adding a helper.

### Description
- In `app/media_librarian/services/torrent_queue_service.rb` normalize `request.options[:whitelisted_extensions]` in `process_download_request` with `Array(request.options[:whitelisted_extensions]).flatten.compact.map(&:to_s).uniq`.
- The normalization is applied immediately before the `Cache.queue_state_add_or_update('deluge_options', ...)` call so the cached options contain a deduplicated list.
- No new helper or API changes were introduced and the same expression from `build_download_options` is reused.

### Testing
- Ran `bundle exec rake test`, which failed because `bundle install` is required for the `archive-zip` dependency, so test suite could not complete.
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949581df970832784b59fbcbe02419f)