### PR TITLE
Fix pending torrents Actions column and add download-pending badge

### DIFF
--- a/app/web/app.js
+++ b/app/web/app.js
@@ -2837,7 +2837,8 @@ function renderPendingTorrentList(rowsId, emptyId, entries = []) {
   }
   emptyHint.classList.add('hidden');
 
-  const labels = ['Nom', 'Tracker', 'Catégorie', 'Ajouté', 'Disponible le', 'Identifiant', 'Actions'];
+  const labels = ['Nom', 'Tracker', 'Catégorie', 'Ajouté', 'Disponible le', 'Identifiant'];
+  const actionLabel = 'Actions';
   normalized.forEach((entry) => {
     const row = document.createElement('tr');
     const cells = [
@@ -2857,7 +2858,14 @@ function renderPendingTorrentList(rowsId, emptyId, entries = []) {
     });
 
     const cell = document.createElement('td');
-    cell.dataset.label = 'Actions';
+    cell.className = 'actions-cell';
+    cell.dataset.label = actionLabel;
+    if (Number(entry?.status) === 2) {
+      const pendingLabel = document.createElement('span');
+      pendingLabel.className = 'calendar-badge';
+      pendingLabel.textContent = 'En attente de téléchargement';
+      cell.appendChild(pendingLabel);
+    }
     if (Number(entry?.status) === 1) {
       const validateButton = document.createElement('button');
       validateButton.type = 'button';
@@ -2882,8 +2890,10 @@ function renderPendingTorrentList(rowsId, emptyId, entries = []) {
 }
 
 function renderPendingTorrents(data = {}) {
-  renderPendingTorrentList('pending-validation-rows', 'pending-validation-empty', data.validation);
-  renderPendingTorrentList('pending-download-rows', 'pending-download-empty', data.downloads);
+  const validation = Array.isArray(data.validation) ? data.validation : [];
+  const downloads = Array.isArray(data.downloads) ? data.downloads : [];
+  renderPendingTorrentList('pending-validation-rows', 'pending-validation-empty', validation);
+  renderPendingTorrentList('pending-download-rows', 'pending-download-empty', downloads);
 }
 
 async function loadPendingTorrents() {


### PR DESCRIPTION
### Motivation
- Ensure the pending torrents table always shows a consistent `Actions` column instead of conditionally hiding it based on `status`.
- Make the two pending lists (`validation` and `downloads`) clearly separated and immune to malformed payloads.
- Provide a small visual hint for entries with `status=2` so their state is not ambiguous.

### Description
- Remove the `Actions` header from the main `labels` array and introduce an explicit `actionLabel` used for the actions cell.
- Add `cell.className = 'actions-cell'` and always render an actions cell with buttons when appropriate and a fallback `—` when empty.
- Append a small badge (`<span class="calendar-badge">En attente de téléchargement</span>`) when `entry.status === 2` to indicate downloads awaiting processing.
- Harden `renderPendingTorrents` by normalizing `data.validation` and `data.downloads` with `Array.isArray(...)` before calling `renderPendingTorrentList`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a81bbbe6483278027f82ab42d8c1d)