### PR TITLE
Align pending torrent table headers

### DIFF
--- a/app/web/index.html
+++ b/app/web/index.html
@@ -487,7 +487,16 @@
 
             <div class="download-list-table">
               <div class="table-wrapper">
-                <table>
+                <table class="pending-torrents-table">
+                  <colgroup>
+                    <col style="width: 28%;">
+                    <col style="width: 12%;">
+                    <col style="width: 12%;">
+                    <col style="width: 12%;">
+                    <col style="width: 12%;">
+                    <col style="width: 12%;">
+                    <col style="width: 12%;">
+                  </colgroup>
                   <thead>
                     <tr>
                       <th>Nom</th>
@@ -507,7 +516,16 @@
 
             <div class="download-list-table">
               <div class="table-wrapper">
-                <table>
+                <table class="pending-torrents-table">
+                  <colgroup>
+                    <col style="width: 28%;">
+                    <col style="width: 12%;">
+                    <col style="width: 12%;">
+                    <col style="width: 12%;">
+                    <col style="width: 12%;">
+                    <col style="width: 12%;">
+                    <col style="width: 12%;">
+                  </colgroup>
                   <thead>
                     <tr>
                       <th>Nom</th>


### PR DESCRIPTION
### Motivation

- Ensure the two pending torrents lists render with stable, aligned headers across viewport sizes.  
- Prevent column shifting between the "validation" and "download" lists by providing explicit column width hints.  
- Keep existing pending list data sources (`validation` / `downloads`) and existing action badges/controls unchanged.  

### Description

- Add `class="pending-torrents-table"` to both pending torrents `<table>` elements in `app/web/index.html`.  
- Insert a `<colgroup>` with fixed percentage `col` widths (one wide name column and six equally sized columns) for each pending table to stabilize header alignment.  
- No changes to JavaScript logic or server endpoints were made, and the existing status label (`calendar-badge`) and action buttons remain intact.  

### Testing

- Ran `bundle exec rake test`, which failed due to an unmet dependency requiring `bundle install` for the `archive-zip` git dependency.  
- Served the web UI with `python -m http.server` and produced a headless browser screenshot of the Downloads tab using Playwright, yielding `artifacts/pending-torrents.png` to visually confirm the header alignment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ac09f53ac83279877cd33b7a91ff4)