### PR TITLE
Remove tracker YAML editor in favor of form-only flow

### DIFF
--- a/app/web/index.html
+++ b/app/web/index.html
@@ -463,8 +463,7 @@
               </div>
             </div>
             <div id="trackers-form" class="config-form hidden"></div>
-            <textarea id="trackers-editor" spellcheck="false" placeholder="Configuration YAML du tracker"></textarea>
-            <p class="hint" id="trackers-hint">Sélectionnez un tracker pour l'éditer.</p>
+            <p class="hint" id="trackers-hint">Sélectionnez un tracker pour le configurer.</p>
           </section>
         </section>
 


### PR DESCRIPTION
### Motivation
- Remove the freeform YAML editor for per-tracker configs and make the form the single source of truth for tracker configuration.
- Ensure save/hydration use the form schema/defaults and the example YAML structure rather than an arbitrary textarea payload.
- Make file editor machinery tolerant of editors that do not have an associated textarea to keep the API generic and lean.

### Description
- Removed the `textarea#trackers-editor` from `app/web/index.html` and updated the panel hint to focus on form-based configuration.
- Updated `registerFileEditor` in `app/web/app.js` to accept `allowMissingTextarea`, guard all textarea usages, and avoid early return when an editor intentionally has no textarea.
- Changed editor payload plumbing to pass `{ includeContent, includeSelection }` into `options.buildPayload`, and updated the `trackers` editor registration to generate `payload.content` from `collectConfigFormData(trackerFormState)` merged with `TRACKER_FORM_DEFAULTS` and serialized with `buildConfigYaml` using `TRACKER_FORM_SCHEMA`.
- Kept the form hydration (`hydrateConfigForm`) on load and removed any dependence on `editor.applyContent` / freeform textarea as the authoritative source for tracker data.

### Testing
- Launched a local static server (`python -m http.server`) serving `app/web` and loaded `index.html` with Playwright to capture a screenshot of the trackers panel, which completed successfully.
- Verified via a quick search that references to `trackers-editor` are no longer present in `app/web` (no matches found).
- No automated unit tests exist for the frontend; changes were validated via the browser smoke test above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694bef1d04d48327ae68dcfaaf809dde)