### PR TITLE
Use /template_commands and accept `{ commands: [...] }` payload

### DIFF
--- a/app/web/app.js
+++ b/app/web/app.js
@@ -3232,10 +3232,12 @@ function addBaseCommandKey(commands = []) {
 }
 
 function normalizeCommandEntries(entries) {
-  if (!Array.isArray(entries)) {
-    return [];
-  }
-  return entries
+  const list = Array.isArray(entries)
+    ? entries
+    : Array.isArray(entries?.commands)
+      ? entries.commands
+      : [];
+  return list
     .map((entry) => {
       if (entry == null) {
         return null;
@@ -3443,9 +3445,9 @@ async function loadSchedulerTasks() {
   }
 
   try {
-    const templateData = await fetchJson('/templates');
+    const templateData = await fetchJson('/template_commands');
     templateCommands = addBaseCommandKey(
-      normalizeCommandEntries(extractEntries(templateData))
+      normalizeCommandEntries(templateData)
     );
     renderUnscheduledTemplateCommands(templateCommands, scheduledKeys);
   } catch (error) {


### PR DESCRIPTION
### Motivation
- Switch scheduler template load to the new endpoint `fetchJson('/template_commands')` which returns `{ commands: [...] }` instead of the previous `/templates` shape.
- Accept and consume the `commands` key from the returned JSON so template commands are normalized directly on the front-end.
- Keep front-end logic minimal and avoid adding YAML parsing or extra structures to keep the UI code lean.

### Description
- Updated `normalizeCommandEntries` to accept either an array or an object with a `commands` array by checking `entries` or `entries?.commands` and normalizing that list.
- Replaced the call in `loadSchedulerTasks` from `fetchJson('/templates')` to `fetchJson('/template_commands')` and pass the response directly to `normalizeCommandEntries`.
- Continued to use `addBaseCommandKey` and `renderUnscheduledTemplateCommands` unchanged so rendering and filtering remain the same and lightweight.

### Testing
- Patch was applied to `app/web/app.js` and committed successfully to the working branch.
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694bf42b9e608327868c9b2f44ec5f91)