### PR TITLE
Handle nested commands as child jobs

### DIFF
--- a/librarian.rb
+++ b/librarian.rb
@@ -240,7 +240,10 @@ class Librarian
         app.librarian.load_requirements unless app.librarian.loaded?
         thread = Thread.current
         LibraryBus.initialize_queue(thread)
-        ThreadState.around(thread) { |_snapshot| run_command(args, direct_flag) }
+        ThreadState.around(thread) do |_snapshot|
+          thread[:child_job_override] = 1 if thread[:is_active].to_i > 0
+          run_command(args, direct_flag)
+        end
       end
     end
 


### PR DESCRIPTION
### Motivation
- Prevent nested in-process command routing from triggering top-level email notifications by marking them as child jobs.
- Ensure that nested executions behave like inline child jobs so notification merging/deferment logic in `terminate_command` applies.
- Rely on existing `run_termination` handling of `:child_job_override` so no extra state-management logic is required.
- Keep the change minimal and avoid persistent thread-state changes by leveraging `ThreadState.around` to restore state.

### Description
- In `route_cmd`, wrap the `run_command` invocation with `ThreadState.around` and set `thread[:child_job_override] = 1` when `thread[:is_active].to_i > 0` to mark nested runs as child jobs.
- The change is a small inline modification (few lines) and relies on existing `run_termination` to copy `:child_job_override` into `:child_job` and on `terminate_command` to suppress email for child jobs.
- No other behavioral changes or new helpers were added to keep the implementation lean.
- State restoration is delegated to `ThreadState.around`, so no persistent thread flags remain after execution.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d3585f2608327842f7593094773e0)