### PR TITLE
Fix watchlist cleanup identifiers during file scan

### DIFF
--- a/app/media_librarian/services/file_system_scan_service.rb
+++ b/app/media_librarian/services/file_system_scan_service.rb
@@ -40,15 +40,19 @@ module MediaLibrarian
 
           subject = entry[:movie] || entry[:show]
           imdb_id = normalize_imdb_id(extract_imdb_id(subject))
-          next if imdb_id.empty?
+          watchlist_id = imdb_id
+          watchlist_id = normalize_imdb_id(extract_watchlist_id(entry, subject)) if watchlist_id.empty?
 
-          cached_calendar[imdb_id] = ensure_calendar_entry(imdb_id, normalized_type, entry, existing_calendar_ids) unless cached_calendar.key?(imdb_id)
+          cached_calendar[imdb_id] = ensure_calendar_entry(imdb_id, normalized_type, entry, existing_calendar_ids) unless imdb_id.empty? || cached_calendar.key?(imdb_id)
 
-          files_persisted = false
+          files_found = false
 
           Array(entry[:files]).each do |file|
             local_path = file[:name]
             next unless local_path && File.file?(local_path)
+
+            files_found = true
+            next if imdb_id.empty?
 
             metadata = {
               media_type: normalized_type,
@@ -56,11 +60,10 @@ module MediaLibrarian
               local_path: local_path
             }
             persist(metadata)
-            files_persisted = true
             memo << metadata
           end
 
-          remove_from_watchlist(imdb_id, normalized_type, cleaned_watchlist) if files_persisted
+          remove_from_watchlist(watchlist_id, normalized_type, cleaned_watchlist) if files_found
         end
       end
 
@@ -70,6 +73,28 @@ module MediaLibrarian
         imdb_id = ids['imdb'] || ids[:imdb]
         imdb_id ||= subject.respond_to?(:imdb_id) ? subject.imdb_id : nil
         imdb_id.to_s
+      end
+
+      def extract_watchlist_id(entry, subject)
+        metadata = entry[:metadata] || entry['metadata']
+        metadata = metadata.is_a?(Hash) ? metadata : {}
+        ids = metadata[:ids] || metadata['ids'] || {}
+        ids = ids.is_a?(Hash) ? ids : {}
+
+        [
+          entry[:external_id],
+          entry['external_id'],
+          metadata[:imdb_id],
+          metadata['imdb_id'],
+          metadata[:external_id],
+          metadata['external_id'],
+          ids[:imdb],
+          ids['imdb'],
+          subject.respond_to?(:imdb_id) ? subject.imdb_id : nil,
+          subject.respond_to?(:external_id) ? subject.external_id : nil,
+          (subject.respond_to?(:ids) && subject.ids.is_a?(Hash)) ? subject.ids[:imdb] : nil,
+          (subject.respond_to?(:ids) && subject.ids.is_a?(Hash)) ? subject.ids['imdb'] : nil
+        ].compact.map(&:to_s).map(&:strip).find { |value| !value.empty? }.to_s
       end
 
       def normalize_imdb_id(value)
@@ -141,10 +166,15 @@ module MediaLibrarian
       end
 
       def remove_from_watchlist(imdb_id, type, cleaned_watchlist)
-        return if imdb_id.empty? || cleaned_watchlist.include?(imdb_id)
+        normalized_type = normalize_watchlist_type(type)
+        if imdb_id.empty? || normalized_type.empty?
+          speaker&.speak_up("File system scan watchlist skip: imdb_id='#{imdb_id}', type='#{type}'", 0) if Env.debug?
+          return
+        end
+        return if cleaned_watchlist.include?(imdb_id)
         return unless watchlist_table?
 
-        conditions = { imdb_id: imdb_id, type: normalize_watchlist_type(type) }
+        conditions = { imdb_id: imdb_id, type: normalized_type }
         app.db.delete_rows(:watchlist, conditions)
         cleaned_watchlist << imdb_id
       rescue StandardError => e
@@ -152,7 +182,11 @@ module MediaLibrarian
       end
 
       def normalize_watchlist_type(type)
-        normalize_media_type(type)
+        normalized = type.to_s.strip.downcase
+        return 'movies' if normalized.start_with?('movie')
+        return 'shows' if normalized.start_with?('show') || normalized.start_with?('tv') || normalized.start_with?('series')
+
+        normalized
       end
 
       def watchlist_table?


### PR DESCRIPTION
### Motivation
- Ensure the media type used to remove watchlist entries matches how `WatchlistStore` stores types (plural `movies`/`shows`).
- Allow watchlist cleanup to work when the primary IMDb identifier is missing by falling back to other IDs stored on the entry.
- Avoid creating calendar entries or attempting removals when the IMDb identifier is empty.
- Provide targeted debug logging when a watchlist removal is skipped so missing cases can be diagnosed.

### Description
- Added `extract_watchlist_id` to collect fallback identifiers from `entry`, `entry[:metadata]`, `ids`, and the `subject` to use when `imdb_id` is empty. 
- Use a `watchlist_id` fallback in `persist_media_entries` and only attempt calendar upserts for non-empty `imdb_id`. 
- Replace `normalize_watchlist_type` implementation to return plural types (`movies`/`shows`) to match stored watchlist `type` values. 
- Guard `remove_from_watchlist` with normalized type checks and add a debug `speaker.speak_up` message when removal is skipped due to missing identifier or type.

### Testing
- Attempted to run the test suite with `bundle exec rake test` but it failed before running tests because `bundle install` is required. 
- No automated tests were executed successfully in this environment after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e2b8d04308327a8179ecdf1d6cdaf)