### PR TITLE
Prefill scheduler command arguments from template data

### DIFF
--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -1441,6 +1441,8 @@ class Daemon
         'command' => command_parts,
         'args' => command_arguments(action)
       }
+      arg_values = template_command_arg_values(data)
+      entry['arg_values'] = arg_values if arg_values&.any?
       queue = template_command_queue(data, action)
       entry['queue'] = queue if queue
       entry
@@ -1473,6 +1475,17 @@ class Daemon
       return queue if queue.is_a?(String) && !queue.empty?
 
       command_queue(action)
+    end
+
+    def template_command_arg_values(data)
+      args = data['args'] || data[:args]
+      return unless args.is_a?(Hash)
+
+      args.each_with_object({}) do |(key, value), memo|
+        next if value.nil?
+
+        memo[key.to_s] = value.is_a?(String) ? value : value.to_s
+      end
     end
 
     def template_directories

--- a/app/web/app.js
+++ b/app/web/app.js
@@ -3310,6 +3310,7 @@ function renderCommandList(container, commands = [], emptyMessage) {
     argsContainer.className = 'command-args';
 
     const inputs = [];
+    const argValues = command.arg_values || command.argValues || {};
     if (Array.isArray(command.args) && command.args.length) {
       command.args.forEach((arg) => {
         if (!arg?.name) {
@@ -3324,6 +3325,10 @@ function renderCommandList(container, commands = [], emptyMessage) {
         input.dataset.argName = arg.name;
         input.placeholder = arg.required ? 'Requis' : 'Optionnel';
         input.required = Boolean(arg.required);
+        const value = argValues[arg.name];
+        if (value != null) {
+          input.value = String(value);
+        }
         wrapper.appendChild(input);
         argsContainer.appendChild(wrapper);
         inputs.push(input);


### PR DESCRIPTION
### Motivation
- Templates may include specific argument values that should prefill the scheduler UI rather than using generic command defaults.
- Keep the scheduler UX consistent by showing template-provided values when available.

### Description
- Added `template_command_arg_values` in `app/daemon.rb` to extract stringified argument values from a template's `args` hash.
- Include an `arg_values` key in the template command metadata when template values are present.
- Updated `app/web/app.js` to read `command.arg_values` (or `command.argValues`) and set input `value` for matching argument names.
- Changes are minimal and focused to avoid bloating code while preserving existing behavior.

### Testing
- ❌ Ran `bundle exec rake test`, which failed due to missing dependencies (`archive-zip` not checked out); tests were not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e58c2b1748327a78561d9b0a538bc)