### PR TITLE
Replace calendar search form with simple title filter

### DIFF
--- a/app/web/index.html
+++ b/app/web/index.html
@@ -233,32 +233,10 @@
             </div>
 
             <div class="calendar-filters" aria-label="Filtres calendrier">
-              <form id="calendar-search-form" class="calendar-search" role="search" autocomplete="off">
-                <div class="calendar-filter-field">
-                  <label for="calendar-search-query">Recherche</label>
-                  <input
-                    id="calendar-search-query"
-                    name="query"
-                    type="search"
-                    placeholder="Titre ou mots-clés"
-                    required
-                  />
-                </div>
-
-                <div class="calendar-filter-field">
-                  <label for="calendar-search-year">Année</label>
-                  <input
-                    id="calendar-search-year"
-                    name="year"
-                    type="number"
-                    inputmode="numeric"
-                    min="1900"
-                    max="2100"
-                  />
-                </div>
-
-                <button type="submit">Chercher</button>
-              </form>
+              <div class="calendar-filter-field">
+                <label for="calendar-title-filter">Titre</label>
+                <input id="calendar-title-filter" name="title" type="search" placeholder="Titre" />
+              </div>
 
               <div class="calendar-filter-field">
                 <label for="calendar-type">Type</label>
@@ -317,11 +295,6 @@
                 <label for="calendar-country">Pays</label>
                 <input id="calendar-country" name="country" type="text" />
               </div>
-            </div>
-
-            <div id="calendar-search-results" class="calendar-content" hidden>
-              <h3>Résultats de recherche</h3>
-              <p class="hint">Aucun résultat pour le moment.</p>
             </div>
 
             <div id="calendar-content" class="calendar-content">


### PR DESCRIPTION
### Motivation
- Remove the heavy calendar search form and its separate search UI in favor of a lightweight inline title filter to simplify UX and code.
- Eliminate duplicated search state and async search plumbing to make calendar filtering leaner and easier to maintain.

### Description
- Replaced the calendar search form and `#calendar-search-results` block in `app/web/index.html` with a single input `#calendar-title-filter` and kept the other filter controls intact.
- Removed `state.calendar.search` and the related helper functions `readCalendarSearchForm`, `renderCalendarSearchResults`, and `searchCalendar` from `app/web/app.js` to avoid dead code.
- Added `filters.title` to `state.calendar.filters` and populated it in `readCalendarFilters()` from `#calendar-title-filter` (trimmed and lowercased), and added a case-insensitive title check in `entryMatchesFilters()` using `pickEntryValue(entry, ['title','name'])`.
- Updated `setupCalendarEvents()` to stop wiring the old search form and instead include `calendar-title-filter` in the existing filter event wiring so changes trigger `loadCalendar({ preserveFilters: true })` through the existing flow.

### Testing
- Ran the project's test task with `bundle exec rake test` which failed due to missing dependencies and requires running `bundle install` first.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e64bb153c83278af2d876af9b9d9d)