### PR TITLE
Add IMDb search button to calendar

### DIFF
--- a/app/web/app.css
+++ b/app/web/app.css
@@ -712,6 +712,12 @@ button:disabled {
   margin-bottom: 1rem;
 }
 
+.calendar-imdb-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin: -0.25rem 0 1rem;
+}
+
 .calendar-filter-field {
   display: flex;
   flex-direction: column;

--- a/app/web/app.js
+++ b/app/web/app.js
@@ -3626,12 +3626,38 @@ function setupCalendarEvents() {
   if (refreshFeed) {
     refreshFeed.addEventListener('click', refreshCalendarFeed);
   }
+  const titleFilter = document.getElementById('calendar-title-filter');
+  const imdbSearchButton = document.getElementById('calendar-imdb-search');
+  const toggleImdbButton = () => {
+    if (!imdbSearchButton || !titleFilter) {
+      return;
+    }
+    const query = titleFilter.value.trim();
+    const shouldShow = Boolean(query);
+    imdbSearchButton.hidden = !shouldShow;
+    imdbSearchButton.disabled = !shouldShow;
+  };
   const calendarView = document.getElementById('calendar-view');
   if (calendarView) {
     calendarView.addEventListener('change', () => loadCalendar({ preserveFilters: true, resetWindow: true }));
   }
+  if (titleFilter) {
+    titleFilter.addEventListener('input', () => {
+      toggleImdbButton();
+      loadCalendar({ preserveFilters: true });
+    });
+  }
+  if (imdbSearchButton) {
+    imdbSearchButton.addEventListener('click', () => {
+      const query = titleFilter?.value.trim();
+      if (!query) {
+        return;
+      }
+      const target = `https://www.imdb.com/find?q=${encodeURIComponent(query)}`;
+      window.open(target, '_blank', 'noopener');
+    });
+  }
   const ids = [
-    'calendar-title-filter',
     'calendar-type',
     'calendar-genres',
     'calendar-rating-min',
@@ -3648,6 +3674,7 @@ function setupCalendarEvents() {
       const event = input.tagName === 'SELECT' ? 'change' : 'input';
       input.addEventListener(event, () => loadCalendar({ preserveFilters: true }));
     });
+  toggleImdbButton();
   wireCalendarNavigation(
     {
       previous: document.getElementById('calendar-prev'),

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -297,6 +297,10 @@
               </div>
             </div>
 
+            <div class="calendar-imdb-actions">
+              <button id="calendar-imdb-search" type="button" hidden>Rechercher sur IMDb</button>
+            </div>
+
             <div id="calendar-content" class="calendar-content">
               <p class="hint">Aucun contenu calendrier pour le moment.</p>
             </div>


### PR DESCRIPTION
### Motivation
- Provide a quick way to search the calendar title on IMDb from the calendar UI.  
- Show the action only when the user has entered a title filter to avoid UI clutter.  
- Keep the UI lean with a minimal style that aligns the button with existing calendar actions.  

### Description
- Add a new button element `#calendar-imdb-search` below the calendar filters in `app/web/index.html`.  
- Wire a small, compact handler in `app/web/app.js` that toggles visibility based on `#calendar-title-filter` and opens `https://www.imdb.com/find?q=<query>` in a new tab on click.  
- Reuse the existing calendar input change handling to call `loadCalendar` and to update the button state, keeping logic minimal.  
- Add a tiny CSS block `.calendar-imdb-actions` in `app/web/app.css` to align the button with calendar controls without altering existing layout.  

### Testing
- Launched a local static server with `python -m http.server 8000` to serve `app/web` and confirmed `index.html` is reachable via `curl -I` which returned `200 OK`.  
- Ran Playwright scripts to exercise the UI; initial attempts to click `#tab-calendar` timed out and a later check reported the `#tab-calendar` locator count as `0`, so headless navigation could not be fully validated.  
- No automated unit tests were added or modified for this UI-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e67880f7c83278c527de811c74fae)