### PR TITLE
Add calendar import endpoint with watchlist support

### DIFF
--- a/app/media_librarian/services/calendar_feed_service.rb
+++ b/app/media_librarian/services/calendar_feed_service.rb
@@ -67,6 +67,12 @@ module MediaLibrarian
         normalized
       end
 
+      def persist_entry(entry)
+        return nil unless entry.is_a?(Hash)
+
+        persist_entries([entry]).first
+      end
+
       private
 
       attr_reader :db, :providers


### PR DESCRIPTION
### Motivation

- Provide a lightweight API to import a single calendar entry and persist it to the `calendar_entries` table. 
- Avoid duplicating persistence logic by exposing a reusable method to persist single normalized entries. 
- Allow callers to optionally add the imported entry to the watchlist and keep calendar cache in sync. 
- Integrate the new endpoint into the frontend so import/watchlist actions refresh the calendar state.

### Description

- Added a new POST endpoint mounted at `/calendar/import` in `app/daemon.rb` with request validation and normalization helpers (`normalize_calendar_import_payload` and supporting methods). 
- Implemented `MediaLibrarian::Services::CalendarFeedService#persist_entry` to persist a single normalized entry by reusing existing `persist_entries` logic. 
- On import, the handler persists the entry, optionally calls `WatchlistStore.upsert` when watchlist flags are present, clears `Calendar` cache and returns a combined status. 
- Updated `app/web/app.js` to build a full import payload (`buildCalendarImportPayload`), submit it to `/calendar/import`, mark UI state for imports/watchlist, and refresh the calendar view.

### Testing

- Ran `ruby -c app/daemon.rb` and it returned `Syntax OK`.
- Ran `ruby -c app/media_librarian/services/calendar_feed_service.rb` and it returned `Syntax OK`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ebbcbe2688327a98c512bf7d8f764)