### PR TITLE
Use strict Base64 encoding for torrent uploads

### DIFF
--- a/app/torrent_client.rb
+++ b/app/torrent_client.rb
@@ -62,7 +62,7 @@ class TorrentClient
     options['add_paused'] = true unless download[:type] > 1
     case download[:type]
     when 1
-      app.t_client.add_torrent_file(download[:filename], Base64.encode64(download[:file]), options)
+      app.t_client.add_torrent_file(download[:filename], Base64.strict_encode64(download[:file]), options)
       if meta_id.to_s != ''
         status = app.t_client.get_torrent_status(meta_id, ['name', 'progress', 'queue'])
         raise 'Download failed' if status.nil? || status.empty?


### PR DESCRIPTION
### Motivation
- Prevent inserted line breaks in torrent file payloads which can break remote API uploads by using a strict Base64 encoder.
- Keep behavior minimal and focused to avoid unintended changes to torrent handling logic.
- Ensure there are no other code paths still using non-strict Base64 encoding.

### Description
- Replaced `Base64.encode64(download[:file])` with `Base64.strict_encode64(download[:file])` inside `TorrentClient#download_file` when calling `add_torrent_file`.
- Kept the call to `add_torrent_file` and surrounding logic unchanged to minimize impact.
- Performed a repository scan for other `Base64.encode64` usages in `app` and found none to avoid reintroducing line breaks.

### Testing
- Ran `rg "Base64.encode64" -n app` which returned no matches, indicating no other occurrences in `app`.
- Ran `bundle exec rake test` which failed due to missing dependency checkout and a required `bundle install`, so full test suite could not be executed.
- No automated test failures were introduced by the local change itself based on the available checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ee5c809888327812713ed7ff6e6b8)