### PR TITLE
Remove search on removed local_media.title column

### DIFF
--- a/app/collection_repository.rb
+++ b/app/collection_repository.rb
@@ -66,8 +66,7 @@ class CollectionRepository
     pattern = "%#{search.to_s.strip}%"
     conditions = [
       Sequel.ilike(Sequel[:local_media][:local_path], pattern),
-      Sequel.ilike(Sequel[:local_media][:imdb_id], pattern),
-      Sequel.ilike(Sequel[:local_media][:title], pattern)
+      Sequel.ilike(Sequel[:local_media][:imdb_id], pattern)
     ]
     conditions << Sequel.ilike(Sequel[:calendar_entries][:title], pattern) if calendar_table?
 


### PR DESCRIPTION
### Motivation
- Remove the search predicate that referenced the removed `local_media.title` column to prevent SQL errors after migration `011_update_local_media_to_imdb_ids`.
- Preserve searching `calendar_entries.title` only when the `calendar_entries` table exists to avoid invalid column references.
- Keep `collection_dataset` and `apply_search` consistent so search queries do not raise SQL exceptions that would clear results.

### Description
- Drop `Sequel.ilike(Sequel[:local_media][:title], pattern)` from `CollectionRepository#apply_search`.
- Keep search predicates on `local_media.local_path` and `local_media.imdb_id`, and conditionally include `calendar_entries.title` when `calendar_table?` is true.
- No changes to `collection_dataset` join logic because it already checks `calendar_table?` before joining `calendar_entries`.

### Testing
- Ran `bundle exec rake test` and it failed due to missing dependencies; `bundle install` is required to run the test suite.
- No other automated tests were executed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ef5098c688327a58dfbaff7afd7d0)