### PR TITLE
Add file creation timestamps during file system scans

### DIFF
--- a/app/media_librarian/services/file_system_scan_service.rb
+++ b/app/media_librarian/services/file_system_scan_service.rb
@@ -57,7 +57,8 @@ module MediaLibrarian
             metadata = {
               media_type: normalized_type,
               imdb_id: imdb_id,
-              local_path: local_path
+              local_path: local_path,
+              created_at: file_created_at(local_path)
             }
             persist(metadata)
             memo << metadata
@@ -163,6 +164,13 @@ module MediaLibrarian
 
       def persist(metadata)
         app.db.insert_row('local_media', metadata, 1)
+      end
+
+      def file_created_at(path)
+        stat = File.stat(path)
+        return stat.birthtime if stat.respond_to?(:birthtime) && stat.birthtime
+
+        stat.ctime || stat.mtime
       end
 
       def remove_from_watchlist(imdb_id, type, cleaned_watchlist)


### PR DESCRIPTION
### Motivation
- Persist filesystem file creation time into `local_media` so the stored `created_at` reflects the actual file creation time rather than the DB default.
- Prefer reliable creation timestamps when available (`birthtime`) and fall back to other file times when not supported.
- Ensure the UI continues to show the correct "Ajouté le …" date by keeping `created_at` exposed on collections.

### Description
- Update `app/media_librarian/services/file_system_scan_service.rb` to include `created_at` in the `metadata` passed to `persist` for each local file.
- Add a compact helper `file_created_at(path)` that does `File.stat(path)` and returns `stat.birthtime` if available, otherwise `stat.ctime || stat.mtime`.
- Leave `CollectionRepository#serialize_group` behavior unchanged since it already exposes `created_at` for the UI.

### Testing
- Ran `ruby -c app/media_librarian/services/file_system_scan_service.rb` to verify syntax and it succeeded.
- No additional automated DB or integration tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fd64534ac83278db299e924373525)