### PR TITLE
Route calendar IMDb search button to calendar search tab

### DIFF
--- a/app/web/app.js
+++ b/app/web/app.js
@@ -3785,8 +3785,8 @@ function setupCalendarEvents() {
       if (!query) {
         return;
       }
-      const target = `https://www.imdb.com/find?q=${encodeURIComponent(query)}`;
-      window.open(target, '_blank', 'noopener');
+      setActiveTab('calendar-search');
+      loadCalendarSearch(query);
     });
   }
   const ids = [


### PR DESCRIPTION
### Motivation
- Change the calendar "Rechercher sur IMDb" button so it searches the app's calendar search tab instead of opening external IMDb results.
- Keep the UI flow inside the single-page app and reuse existing calendar search logic.

### Description
- Replaced the IMDb external link in the calendar search button click handler with a call to `setActiveTab('calendar-search')` and `loadCalendarSearch(query)` in `app/web/app.js`.
- No other files were modified and no UI elements were removed or added.

### Testing
- Attempted `bundle exec rake test`, but it failed because gems were not installed in the environment (requires `bundle install`).
- Ran `bundle install` in this environment but the install was interrupted and could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69500d22802c8327885030dc7cebd399)