### PR TITLE
Use `title` query param for calendar search requests

### DIFF
--- a/app/web/app.js
+++ b/app/web/app.js
@@ -2473,7 +2473,7 @@ async function loadCalendarSearch(query) {
   }
   state.calendarSearch.loading = true;
   try {
-    const search = new URLSearchParams({ query: normalized });
+    const search = new URLSearchParams({ title: normalized });
     const data = await fetchJson(`/calendar/search?${search.toString()}`);
     renderCalendarSearchResults(data);
   } catch (error) {


### PR DESCRIPTION
### Motivation
- The calendar search endpoint expects a `title` parameter but the client was sending `query`, causing an error response when a search string was present.
- Keep the fix minimal and lean by changing only the request key in the client.

### Description
- Updated `loadCalendarSearch` in `app/web/app.js` to build `URLSearchParams` with `title` instead of `query`.
- The single-line change replaces `new URLSearchParams({ query: normalized })` with `new URLSearchParams({ title: normalized })`.

### Testing
- No automated tests were found or run for this change.
- Change is a small client-side param rename and was committed for manual verification in the web UI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695010d616bc83279c27a9ab75d2d31d)