### PR TITLE
Load template args for template commands

### DIFF
--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -1487,11 +1487,27 @@ class Daemon
       args = data['args'] || data[:args]
       return unless args.is_a?(Hash)
 
-      args.each_with_object({}) do |(key, value), memo|
+      template_name = args['template_name'] || args[:template_name]
+      template_values = {}
+      if template_name.to_s != ''
+        template = app.args_dispatch.load_template(template_name, app.template_dir)
+        template_values = app.args_dispatch.parse_template_args(template, app.template_dir)
+        template_values = {} unless template_values.is_a?(Hash)
+      end
+
+      merged = template_values.each_with_object({}) do |(key, value), memo|
         next if value.nil?
 
         memo[key.to_s] = value.is_a?(String) ? value : value.to_s
       end
+
+      args.each do |key, value|
+        next if key.to_s == 'template_name' || value.nil?
+
+        merged[key.to_s] = value.is_a?(String) ? value : value.to_s
+      end
+
+      merged
     end
 
     def template_directories


### PR DESCRIPTION
### Motivation
- Ensure template command entries expose argument defaults from a referenced template so UI inputs can be pre-filled with `arg_values` keys like `torrent_sources` and `category`.
- Support templates that `load_template` other templates by reusing the existing template parsing logic.
- Allow explicit args declared in the template command to override values coming from the referenced template.
- Keep the change minimal and focused inside the template argument extraction logic for lean code impact.

### Description
- Updated `template_command_arg_values` in `app/daemon.rb` to detect `template_name` and call `app.args_dispatch.load_template(template_name, app.template_dir)`.
- Parsed nested template defaults with `app.args_dispatch.parse_template_args(...)` and normalized them to a flat string-key/value hash.
- Merged those template defaults with explicit `args` from the command entry while ignoring `template_name` and preserving explicit values when both exist.
- Continued to attach the merged result as `arg_values` in the existing `build_template_command_entry` return structure.

### Testing
- Ran `bundle exec rake test`, which failed because `bundle install` is required for the `archive-zip` dependency and tests could not complete. 
- No other automated test failures were observed in this change set because full test execution was blocked by the dependency issue. 
- Manual inspections and repository searches were used to confirm usage points (`build_template_command_entry` and `app.args_dispatch`) were correctly integrated. 
- Recommend running `bundle install` and re-running `bundle exec rake test` to validate the full test suite after dependencies are installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69501be0f59c8327aad691815f9e5ae4)