### PR TITLE
Adjust calendar labels to include year only when needed

### DIFF
--- a/app/web/app.js
+++ b/app/web/app.js
@@ -1948,6 +1948,7 @@ function entryMatchesFilters(entry, filters) {
 }
 
 function buildCalendarGroups(entries, view) {
+  const currentYear = new Date().getFullYear();
   const groups = new Map();
   const startOfWeek = (date) => {
     const copy = new Date(date);
@@ -1968,13 +1969,25 @@ function buildCalendarGroups(entries, view) {
       const label = (() => {
         if (!date) return 'Sans date';
         if (view === 'month') {
-          return new Intl.DateTimeFormat('fr-FR', { month: 'long', year: 'numeric' }).format(date);
+          const options = { month: 'long' };
+          if (date.getFullYear() !== currentYear) {
+            options.year = 'numeric';
+          }
+          return new Intl.DateTimeFormat('fr-FR', options).format(date);
         }
         const start = startOfWeek(date);
         const end = new Date(start);
         end.setDate(start.getDate() + 6);
+        const showYear =
+          start.getFullYear() !== currentYear ||
+          end.getFullYear() !== currentYear ||
+          start.getFullYear() !== end.getFullYear();
         const format = (value) =>
-          new Intl.DateTimeFormat('fr-FR', { day: 'numeric', month: 'short' }).format(value);
+          new Intl.DateTimeFormat('fr-FR', {
+            day: 'numeric',
+            month: 'short',
+            ...(showYear ? { year: 'numeric' } : {}),
+          }).format(value);
         return `Semaine du ${format(start)} au ${format(end)}`;
       })();
       groups.set(key, { label, sortKey: date ? date.getTime() : Number.POSITIVE_INFINITY, items: [] });


### PR DESCRIPTION
### Motivation
- Reduce visual clutter by omitting the year from calendar labels when the date falls in the current year.
- Avoid recomputing the current year repeatedly inside `buildCalendarGroups`.
- Ensure week labels still include the year when the week crosses or lies outside the current year.
- Preserve the existing label text (`Semaine du … au …`) and only extend date formats when necessary.

### Description
- Introduce `currentYear = new Date().getFullYear()` at the top of `buildCalendarGroups`.
- For month view, build `Intl.DateTimeFormat` options with `year: 'numeric'` only if `date.getFullYear() !== currentYear`.
- For week view, compute a `showYear` flag when `start` or `end` is outside the current year or when `start.getFullYear() !== end.getFullYear()` and include `year` in the formatter only when `showYear` is true.
- Change is limited to `app/web/app.js` and keeps the label strings unchanged while adjusting date formatting.

### Testing
- No automated tests were executed as part of this change.
- Changes were validated by inspecting the modified `buildCalendarGroups` logic for correct conditional formatting.
- No runtime test harness was run.
- Manual review confirmed formatting logic is minimal and avoids unnecessary allocations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951822592fc8327bea650fab49dbc30)