### PR TITLE
Avoid persisting calendar searches

### DIFF
--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -1561,7 +1561,7 @@ class Daemon
       limit = clamp_positive_integer(req.query['limit'], default: 50, max: 50)
 
       service = MediaLibrarian::Services::CalendarFeedService.new(app: app)
-      entries = service.search(title: title, year: year, type: type)
+      entries = service.search(title: title, year: year, type: type, persist: false)
       entries = entries.select { |entry| sources.include?(entry[:source].to_s.downcase) } if sources.any?
       entries = entries.first(limit)
 

--- a/app/media_librarian/services/calendar_feed_service.rb
+++ b/app/media_librarian/services/calendar_feed_service.rb
@@ -58,14 +58,14 @@ module MediaLibrarian
         normalized
       end
 
-      def search(title:, year: nil, type: nil)
+      def search(title:, year: nil, type: nil, persist: true)
         return [] unless calendar_table_available?
         return [] if title.to_s.strip.empty?
 
         date_range = year ? Date.new(year.to_i, 1, 1)..Date.new(year.to_i, 12, 31) : nil
         normalized = normalize_entries(provider_search(title: title, year: year, type: type), date_range)
         normalized = filter_existing_entries(normalized)
-        persist_entries(normalized)
+        persist_entries(normalized) if persist
         normalized
       end
 


### PR DESCRIPTION
### Motivation

- Prevent calendar search requests from causing database writes so lookups don't create entries.
- Ensure only explicit imports (`POST /calendar/import`) trigger persistence and side-effects.
- Reduce unexpected state changes and keep search operations read-only.

### Description

- Add an optional `persist:` parameter to `MediaLibrarian::Services::CalendarFeedService#search` with a default of `true` so callers can opt out of persistence.
- Only call `persist_entries` inside `#search` when `persist` is truthy.
- Update `handle_calendar_search_request` in `app/daemon.rb` to call `service.search(..., persist: false)` so HTTP GET searches do not write to the DB.

### Testing

- Ran `ruby -c app/media_librarian/services/calendar_feed_service.rb` and it reported syntax OK.
- Ran `ruby -c app/daemon.rb` and it reported syntax OK.
- No automated integration tests were run in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951824d1f90832780fa16ea4c98b514)