### PR TITLE
Handle template defaults for command args

### DIFF
--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -1495,7 +1495,8 @@ class Daemon
         template_values = {} unless template_values.is_a?(Hash)
       end
 
-      merged = template_values.each_with_object({}) do |(key, value), memo|
+      template_defaults = template_values['args'].is_a?(Hash) ? template_values['args'] : template_values
+      merged = template_defaults.each_with_object({}) do |(key, value), memo|
         next if value.nil?
 
         memo[key.to_s] = value.is_a?(String) ? value : value.to_s


### PR DESCRIPTION
### Motivation

- Fix handling of templates that define arguments at the root level instead of under `args` so defaults are not lost. 
- Ensure that command-level explicit arguments still take precedence over template-provided defaults. 
- Support templates like `config/templates/fetch_media_box.yml.example` which may place keys at the top level. 

### Description

- In `template_command_arg_values` (in `app/daemon.rb`) introduce `template_defaults` which is `template_values['args']` when it is a `Hash`, otherwise `template_values`.
- Use `template_defaults` when constructing the merged defaults to correctly pick up root-level template keys. 
- Preserve the existing merge priority so explicit `args` (except `template_name`) overwrite template defaults, and normalize values to strings. 
- Change is minimal and local to `template_command_arg_values` to keep the code lean. 

### Testing

- Ran `ruby -c app/daemon.rb` to verify syntax and the file parses successfully. 
- No additional automated test suite available or run in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69518c5576dc83278c5f089bbde74fdb)