### PR TITLE
Update collection search label

### DIFF
--- a/app/web/index.html
+++ b/app/web/index.html
@@ -343,7 +343,7 @@
               <h2>Collection</h2>
               <div class="panel-tools">
                 <form id="collection-search-form" class="collection-search" role="search" autocomplete="off">
-                  <label for="collection-search">Rechercher un film</label>
+                  <label for="collection-search">Rechercher un titre</label>
                   <input id="collection-search" name="search" type="search" placeholder="Titre" />
                   <button type="submit">Chercher</button>
                 </form>


### PR DESCRIPTION
### Motivation
- Update the wording in the Collection tab search control to be more accurate and consistent with other UI texts. 
- Replace the phrase referencing specifically a "film" with the more generic "titre" to match search behaviour.

### Description
- Changed the label text in `app/web/index.html` from `Rechercher un film` to `Rechercher un titre`.
- No other UI or logic changes were made to keep the patch minimal and focused.

### Testing
- Ran `bundle exec rake test`, which failed due to an unchecked out dependency (`archive-zip`) and requiring `bundle install` before tests can run successfully.
- The modified file was committed and the change confirmed in the working tree.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69521d0db50c8327a4cb4ce4a3b5255d)