### PR TITLE
Load scheduler template arguments

### DIFF
--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -2006,10 +2006,28 @@ class Daemon
             nil
           end
 
-        json_response(res, body: { 'content' => content, 'entries' => parsed })
+        json_response(res, body: { 'content' => content, 'entries' => scheduler_template_args(parsed) })
       else
         handle_file_request(req, res, path, scheduler_mutex, 'GET, PUT')
       end
+    end
+
+    def scheduler_template_args(template)
+      return template unless template.is_a?(Hash)
+
+      %w[periodic continuous].each do |section|
+        entries = template[section]
+        next unless entries.is_a?(Hash)
+
+        entries.each_value do |entry|
+          next unless entry.is_a?(Hash)
+
+          values = template_command_arg_values(entry)
+          entry['arg_values'] = values if values&.any?
+        end
+      end
+
+      template
     end
 
     def handle_watchlist_request(req, res)

--- a/app/web/app.js
+++ b/app/web/app.js
@@ -3168,12 +3168,12 @@ function parseSchedulerTemplate(content, parsed) {
   return null;
 }
 
-function normalizeSchedulerArgs(args, type) {
+function normalizeSchedulerParameters(parameters, type) {
   const list = [];
-  if (Array.isArray(args)) {
-    args.forEach((value) => list.push(String(value)));
-  } else if (args && typeof args === 'object') {
-    Object.entries(args).forEach(([key, value]) => {
+  if (Array.isArray(parameters)) {
+    parameters.forEach((value) => list.push(String(value)));
+  } else if (parameters && typeof parameters === 'object') {
+    Object.entries(parameters).forEach(([key, value]) => {
       list.push(`--${key}=${value}`);
     });
   }
@@ -3206,13 +3206,13 @@ function extractSchedulerTasks(template) {
       if (!base.length) {
         return;
       }
-      const args = normalizeSchedulerArgs(entry.args, type);
+      const parameters = normalizeSchedulerParameters(entry.arg_values || entry.argValues, type);
       const schedule = entry.every || entry.cron || entry.interval || '';
       tasks.push({
         name: name || base.join(' '),
         type,
         schedule: schedule ? String(schedule) : '',
-        command: [...base, ...args],
+        command: [...base, ...parameters],
         queue: entry.queue || '',
         task: name || '',
         description: entry.description || '',


### PR DESCRIPTION
### Motivation
- Reuse existing template-loading and argument-parsing logic to resolve scheduler template arguments instead of duplicating behavior. 
- Expose resolved argument values to the web UI so scheduled tasks can be executed with the right defaults. 
- Avoid using `args` payload for resolved values and keep the code lean and non-redundant. 

### Description
- Updated `handle_scheduler_request` to return enriched entries by calling a new `scheduler_template_args` helper. 
- Added `scheduler_template_args` in `app/daemon.rb` which walks `periodic` and `continuous` sections and attaches resolved `arg_values` using the existing `template_command_arg_values` helper. 
- Adjusted client code in `app/web/app.js` by renaming `normalizeSchedulerArgs` to `normalizeSchedulerParameters` and using `entry.arg_values || entry.argValues` when building the task command line so the UI consumes the server-provided resolved values. 

### Testing
- Ran `bundle exec rake test`; test run failed due to missing dependencies requiring `bundle install`. 
- Basic local inspection and JS function rename validated that scheduled task command construction now prefers `arg_values` from the scheduler payload. 
- No automated tests were added or modified in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69521ce870b08327be91d658162cf291)