### PR TITLE
Remove scheduled runs panel

### DIFF
--- a/app/web/index.html
+++ b/app/web/index.html
@@ -176,16 +176,6 @@
             </div>
           </section>
 
-          <section class="panel" id="scheduler-runs-panel">
-            <div class="panel-header">
-              <h2>Exécutions planifiées</h2>
-            </div>
-            <div id="scheduler-runs-container" class="scheduler-tasks">
-              <ul id="scheduler-runs-list"></ul>
-              <p class="hint">Aucune exécution planifiée.</p>
-            </div>
-          </section>
-
           <section class="panel" id="unscheduled-templates-panel">
             <div class="panel-header">
               <h2>Commandes de template non planifiées</h2>


### PR DESCRIPTION
### Motivation
- Remove an unused UI panel to declutter the scheduler tab and keep the code lean.
- Satisfy the request to remove the panel and eliminate dead HTML.

### Description
- Deleted the `<section>` with `id="scheduler-runs-panel"` from `app/web/index.html`.
- Removed its child elements including `scheduler-runs-container`, `scheduler-runs-list`, and the hint paragraph.
- No other files were modified and the surrounding layout is preserved.

### Testing
- No automated tests were executed for this change.
- Change is a simple HTML removal with low risk to other code paths.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69521e9c60b08327ac45750c0e861c2c)