### PR TITLE
Skip redundant calendar search fetches

### DIFF
--- a/app/web/app.js
+++ b/app/web/app.js
@@ -30,6 +30,7 @@ const state = {
   },
   calendarSearch: {
     query: '',
+    lastLoadedQuery: '',
     results: [],
     loading: false,
   },
@@ -2470,6 +2471,13 @@ async function loadCalendarSearch(query) {
   const input = document.getElementById('calendar-search-query');
   const normalized = (query ?? input?.value ?? state.calendarSearch.query ?? '').toString().trim();
   state.calendarSearch.query = normalized;
+  if (
+    normalized
+    && normalized === state.calendarSearch.lastLoadedQuery
+    && state.calendarSearch.results.length
+  ) {
+    return;
+  }
   if (input && input.value !== normalized) {
     input.value = normalized;
   }
@@ -2489,6 +2497,7 @@ async function loadCalendarSearch(query) {
     const search = new URLSearchParams({ title: normalized });
     const data = await fetchJson(`/calendar/search?${search.toString()}`);
     renderCalendarSearchResults(data);
+    state.calendarSearch.lastLoadedQuery = normalized;
   } catch (error) {
     if (state.authenticated) {
       showNotification(error.message, 'error');


### PR DESCRIPTION
### Motivation
- Avoid issuing duplicate network requests when the user searches the same title repeatedly by mistake or via UI events.
- Prevent overwriting or flashing existing search results when the query has not changed.
- Reduce unnecessary DOM updates and keep the UI responsive and lean.

### Description
- Added a `lastLoadedQuery` field to `state.calendarSearch` to remember the last successfully fetched query.
- In `loadCalendarSearch` the `query` is normalized and if it equals `state.calendarSearch.lastLoadedQuery` and `state.calendarSearch.results` is non-empty the function returns early without touching the DOM or calling `fetchJson`.
- `state.calendarSearch.lastLoadedQuery` is set to the normalized query only after a successful `fetchJson` and `renderCalendarSearchResults` call.
- The early-return guard ensures the "Recherche en cours…" placeholder does not overwrite existing results when the query is unchanged.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69527f63a7848327a5e29fb3a38485af)