### PR TITLE
Afficher l'année pour les dates hors année courante

### DIFF
--- a/app/web/app.js
+++ b/app/web/app.js
@@ -2042,13 +2042,19 @@ function buildCalendarEntryCard(entry, date = resolveCalendarDate(entry)) {
   }
   const dateLabel = document.createElement('span');
   dateLabel.className = 'calendar-meta';
-  dateLabel.textContent = date
-    ? new Intl.DateTimeFormat('fr-FR', {
-        weekday: 'short',
-        day: 'numeric',
-        month: 'short',
-      }).format(date)
-    : 'Date inconnue';
+  if (!date) {
+    dateLabel.textContent = 'Date inconnue';
+  } else {
+    const options = {
+      weekday: 'short',
+      day: 'numeric',
+      month: 'short',
+    };
+    if (date.getFullYear() !== new Date().getFullYear()) {
+      options.year = 'numeric';
+    }
+    dateLabel.textContent = new Intl.DateTimeFormat('fr-FR', options).format(date);
+  }
   header.append(titleEl, dateLabel);
   body.appendChild(header);
 


### PR DESCRIPTION
### Motivation
- Le libellé de date du calendrier n'affichait pas l'année, ce qui prête à confusion pour les entrées hors de l'année en cours.
- Il faut afficher l'année uniquement quand la date n'est pas dans l'année courante pour rester concis tout en étant informatif.

### Description
- Mise à jour de `app/web/app.js` pour construire les `options` passées à `Intl.DateTimeFormat` et ajouter `year: 'numeric'` quand `date.getFullYear() !== new Date().getFullYear()`.
- Préservation du rendu existant (`weekday`, `day`, `month`) pour les dates de l'année courante et du texte `Date inconnue` quand `date` est nul.
- Le changement est minimal et ciblé dans la fonction `buildCalendarEntryCard` pour limiter l'impact.

### Testing
- `bundle exec rake test` a été lancé et a échoué en local à cause de dépendances manquantes (message: run `bundle install`).
- Aucun test automatique additionnel n'a été ajouté pour ce petit rendu front-end et la modification est couverte par inspection statique du code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695280be46148327901ce563895c080c)