### PR TITLE
Add 'Restart + update' dashboard control and daemon update flow

### DIFF
--- a/app/web/app.js
+++ b/app/web/app.js
@@ -3627,6 +3627,14 @@ async function restartDaemon() {
   });
 }
 
+async function restartDaemonWithUpdate() {
+  await controlDaemon({
+    path: '/restart-update',
+    buttonId: 'restart-daemon-update',
+    message: 'Mise à jour et redémarrage du démon en cours…',
+  });
+}
+
 async function stopDaemon() {
   await controlDaemon({
     path: '/stop',
@@ -3938,6 +3946,7 @@ function setupEventListeners() {
   document.getElementById('refresh-status').addEventListener('click', loadStatus);
   document.getElementById('stop-daemon').addEventListener('click', stopDaemon);
   document.getElementById('restart-daemon').addEventListener('click', restartDaemon);
+  document.getElementById('restart-daemon-update').addEventListener('click', restartDaemonWithUpdate);
   document.getElementById('refresh-logs').addEventListener('click', loadLogs);
   const refreshSchedulerTasks = document.getElementById('refresh-scheduler-tasks');
   if (refreshSchedulerTasks) {

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -118,6 +118,7 @@
               <div class="actions">
                 <button id="stop-daemon" type="button" class="danger">Arrêter</button>
                 <button id="restart-daemon" type="button" class="danger">Redémarrer</button>
+                <button id="restart-daemon-update" type="button" class="danger">Redémarrer + mise à jour</button>
                 <button id="refresh-status" type="button">Actualiser</button>
               </div>
             </div>


### PR DESCRIPTION
### Motivation
- Provide a single-dashboard action to pull the latest repository changes and restart the daemon in one operation.
- Add a guarded update flow to avoid concurrent update/restart races using atomic flags.
- Expose a new control endpoint so the web UI can trigger the update-and-restart sequence remotely via the control server.
- Note: the daemon restart model may not reload in-memory code automatically, so repository update semantics depend on how the daemon process is restarted by the existing loop.

### Description
- Add a new dashboard button `restart-daemon-update` and wire a new front-end function `restartDaemonWithUpdate` that posts to the `POST /restart-update` endpoint.
- Register a new control route `/restart-update` and implement `handle_restart_update_request` that maps HTTP outcomes to JSON responses.
- Implement `update_and_restart` which uses `update_requested_flag` and `restart_requested_flag` to prevent concurrent operations and performs a background `git pull --ff-only` via `update_repository` before triggering a restart.
- Add helper `update_requested_flag` and reuse existing restart flow to schedule the actual stop/restart sequence.

### Testing
- Ran a UI smoke test by serving `app/web` and capturing a screenshot via Playwright which succeeded and produced `artifacts/dashboard-restart-update.png`.
- Executed `bundle exec rake test` which failed due to a missing dependency (`archive-zip` not checked out); tests could not be fully run until `bundle install` is executed.
- Verified the new files load in the web UI and event listeners are attached by inspecting the served page during the smoke test.
- No additional automated unit tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695277217014832793a248047961e247)