### PR TITLE
Handle unpacked torrent attributes

### DIFF
--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -1825,7 +1825,7 @@ class Daemon
     def format_pending_torrent(row)
       attributes = row[:tattributes]
       attributes = Cache.object_unpack(attributes) unless attributes.is_a?(Hash)
-      attributes ||= {}
+      attributes = {} unless attributes.is_a?(Hash)
 
       {
         name: row[:name].to_s,

--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -15,6 +15,7 @@ require 'fileutils'
 require 'base64'
 require 'get_process_mem'
 
+require_relative '../lib/cache'
 require_relative '../lib/logger'
 require_relative '../lib/watchlist_store'
 require_relative '../lib/utils'
@@ -1822,7 +1823,9 @@ class Daemon
     end
 
     def format_pending_torrent(row)
-      attributes = row[:tattributes].is_a?(Hash) ? row[:tattributes] : {}
+      attributes = row[:tattributes]
+      attributes = Cache.object_unpack(attributes) unless attributes.is_a?(Hash)
+      attributes ||= {}
 
       {
         name: row[:name].to_s,


### PR DESCRIPTION
### Motivation
- Some `tattributes` rows are stored in a packed form and are not `Hash` instances, which causes missing `tracker`/`category` when formatting pending torrents.
- `tattributes` need to be unpacked before reading fields to ensure consistent JSON output.

### Description
- Add `require_relative '../lib/cache'` so `Cache` is available in this context.
- Update `format_pending_torrent` to set `attributes = row[:tattributes]` and call `Cache.object_unpack(attributes)` when `attributes` is not a `Hash`, then fallback to `{}`.
- Preserve `tracker` and `category` in the returned pending-torrent JSON.

### Testing
- Ran `ruby -c app/daemon.rb` and it returned `Syntax OK` (syntax check passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952b0cba21c8327a417cca06720aad9)