### PR TITLE
Add context to empty metadata lookup errors

### DIFF
--- a/lib/metadata.rb
+++ b/lib/metadata.rb
@@ -360,7 +360,10 @@ class Metadata
           summary = summary['title'] || summary['name'] if summary.respond_to?(:[])
           MediaLibrarian.app.speaker.speak_up("[#{provider_call}] => #{result_count} #{summary}", 0) if Env.debug?
           if result_count.zero?
-            MediaLibrarian.app.speaker.tell_error(StandardError.new("Provider #{provider_call} returned no results"), "#{title_norm}")
+            ids_info = ids_part.to_s == '' ? ids : ids_part
+            msg = "Provider #{provider_call} returned no results title=#{title.inspect} normalized=#{title_norm.inspect} ids=#{ids_info} raw=#{raw_info}"
+            msg << " file=#{original_filename}" if original_filename.to_s != ''
+            MediaLibrarian.app.speaker.tell_error(StandardError.new(msg), "#{title_norm}")
           end
           exact_title, item = media_chose(title, items, keys, type, no_prompt.to_i)
           exact_title, item = item_fetch_method.call(item['ids'].merge({ 'force_title' => exact_title })) unless item.nil?


### PR DESCRIPTION
### Motivation
- Improve diagnosability when a metadata provider returns zero results by including concise context in the error message.
- Surface key values (`provider_call`, `title`, normalized title, ids, raw response shape and optional filename) to make debugging easier.

### Description
- Extend the `result_count.zero?` branch in `Metadata.media_lookup` to build a single-line context message containing `provider_call`, `title` (and `title_norm`), `ids_part` (falling back to the `ids` hash), `raw_info`, and `original_filename` when present.
- Pass that message into `MediaLibrarian.app.speaker.tell_error` instead of the previous generic message.
- Keep the added logic compact and conditionalize appending the filename only when present.

### Testing
- Ran `ruby -c lib/metadata.rb` and received `Syntax OK`.
- No other automated test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952b43890508327ac466d0c3f08fe4a)