### PR TITLE
Add compact thread context prefix to error logging

### DIFF
--- a/lib/simple_speaker.rb
+++ b/lib/simple_speaker.rb
@@ -75,9 +75,13 @@ module SimpleSpeaker
     def tell_error(e, src, in_mail = 1, thread = Thread.current)
       err = e.is_a?(Exception) ? e : StandardError.new(e.to_s)
       @logger_error.error(err) if @logger_error
-      speak_up("ERROR in '#{src}'" + @new_line, in_mail, thread)
-      speak_up(err.to_s + @new_line, in_mail, thread)
-      speak_up(Array(err.backtrace)[0..2].join(@new_line) + @new_line, in_mail, thread)
+      parts = []
+      parts << "jid=#{thread[:jid]}" if thread[:jid].to_s != ''
+      parts << "obj=#{thread[:object]}" if thread[:object].to_s != ''
+      prefix = parts.empty? ? '' : "[#{parts.join(' ')}] "
+      speak_up("#{prefix}ERROR in '#{src}'" + @new_line, in_mail, thread)
+      speak_up(prefix + err.to_s + @new_line, in_mail, thread)
+      speak_up(prefix + Array(err.backtrace)[0..2].join(@new_line) + @new_line, in_mail, thread)
     end
 
     def user_input(input)


### PR DESCRIPTION
### Motivation
- Improve error logs with lightweight context so issues can be traced to a job or object instance. 
- Prefer a minimal change that avoids new dependencies and keeps log output compact. 
- Include available thread-local fields such as `thread[:jid]` and `thread[:object]` so logs show runtime context when present.

### Description
- In `SimpleSpeaker::Speaker#tell_error` build a small `parts` array and append `jid=#{thread[:jid]}` and `obj=#{thread[:object]}` when non-empty.
- Assemble a `prefix` like `[jid=... obj=...] ` only when values exist and prepend it to the `speak_up` calls for the error header, message, and backtrace.
- No new libraries or dependencies were added and the change is kept concise.

### Testing
- Ran `bundle exec rake test` which failed due to missing bundle dependencies and needs `bundle install` first. 
- No automated tests were run successfully in this environment due to the dependency issue.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952b852bfe4832780d018856c917d4c)