### PR TITLE
Add per-log filtering in log viewer

### DIFF
--- a/app/web/app.css
+++ b/app/web/app.css
@@ -617,6 +617,22 @@ button.danger:hover {
   padding: 0;
 }
 
+.log-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.log-filter {
+  max-width: 10rem;
+  padding: 0.3rem 0.5rem;
+  border-radius: 0.6rem;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(15, 23, 42, 0.65);
+  color: inherit;
+  font-size: 0.8rem;
+}
+
 .log-content {
   margin: 0;
   max-height: 18rem;

--- a/app/web/app.js
+++ b/app/web/app.js
@@ -1639,6 +1639,25 @@ function renderJobs(data = {}) {
   }
 }
 
+function updateLogFilter(logEntry) {
+  const logContent = logEntry.querySelector('.log-content');
+  const filterInput = logEntry.querySelector('.log-filter');
+  if (!logContent || !filterInput) {
+    return;
+  }
+  const logText = logEntry.dataset.logText || '';
+  const query = filterInput.value.trim().toLowerCase();
+  if (!query) {
+    logContent.textContent = logText || '—';
+    return;
+  }
+  const filtered = logText
+    .split('\n')
+    .filter((line) => line.toLowerCase().includes(query))
+    .join('\n');
+  logContent.textContent = filtered || '—';
+}
+
 function renderLogs(logs = {}) {
   const container = document.getElementById('logs-container');
   const template = document.getElementById('log-entry-template');
@@ -1653,6 +1672,9 @@ function renderLogs(logs = {}) {
       logEntry = fragment.querySelector('.log-entry');
       logEntry.dataset.logName = name;
       fragment.querySelector('.log-name').textContent = name;
+      fragment.querySelector('.log-filter')?.addEventListener('input', () => {
+        updateLogFilter(logEntry);
+      });
       fragment.querySelector('.copy-log').addEventListener('click', async () => {
         try {
           await navigator.clipboard.writeText(logEntry.dataset.logText || '');
@@ -1665,15 +1687,9 @@ function renderLogs(logs = {}) {
     }
 
     const { text: displayContent, truncated } = getLogTail(content || '');
-    const logContent = logEntry.querySelector('.log-content');
-    const previousText = logContent.textContent || '';
-    const normalizedText = displayContent || '—';
-    if (!previousText || !displayContent || !displayContent.startsWith(previousText)) {
-      logContent.textContent = normalizedText;
-    } else if (displayContent.length > previousText.length) {
-      logContent.append(displayContent.slice(previousText.length));
-    }
     logEntry.dataset.logText = displayContent || '';
+    updateLogFilter(logEntry);
+    const logContent = logEntry.querySelector('.log-content');
 
     let hint = logEntry.querySelector('.log-hint');
     if (truncated) {

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -574,7 +574,15 @@
       <article class="log-entry">
         <header>
           <h3 class="log-name"></h3>
-          <button type="button" class="copy-log">Copier</button>
+          <div class="log-actions">
+            <input
+              type="search"
+              class="log-filter"
+              placeholder="Filtrer"
+              aria-label="Filtrer ce log"
+            />
+            <button type="button" class="copy-log">Copier</button>
+          </div>
         </header>
         <pre class="log-content"></pre>
       </article>


### PR DESCRIPTION
### Motivation
- Add a compact per-log filter to allow quick searching inside each log view without affecting other logs.
- Keep the filter local to each `log-entry` so filtering one log does not change others.
- Reuse the already-stored `dataset.logText` for filtering to avoid extra fetching or heavy DOM operations.
- Make the input visually compact and aligned with the existing copy action.

### Description
- Update the `#log-entry-template` in `index.html` to include a `div.log-actions` containing an `input.log-filter` and the existing `button.copy-log`.
- Add `updateLogFilter(logEntry)` in `app.js` to compute a per-log filtered view from `logEntry.dataset.logText` and set the `.log-content` text accordingly.
- Attach an `input` listener to each newly-created fragment to call `updateLogFilter`, and call `updateLogFilter` inside `renderLogs` after updating `dataset.logText` so the active filter is reapplied on updates.
- Add minimal CSS for `.log-actions` and `.log-filter` in `app.css` to keep the filter compact and aligned with the header actions.

### Testing
- Started a static server with `python -m http.server` and ran a Playwright script that loaded `/index.html` and captured a screenshot, which succeeded.
- Ran `bundle exec rake test`, which failed due to missing dependencies (requires `bundle install`); this is unrelated to the UI change.
- No automated UI failures observed; the screenshot confirms the filter input renders next to the copy button.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952bafb89f4832780e5f64ffd7882db)