### PR TITLE
Prefill template command args in scheduler and use command string for template titles

### DIFF
--- a/app/web/app.js
+++ b/app/web/app.js
@@ -3374,8 +3374,9 @@ function normalizeCommandEntries(entries) {
     .filter(Boolean);
 }
 
-function renderCommandList(container, commands = [], emptyMessage) {
+function renderCommandList(container, commands = [], emptyMessage, options = {}) {
   container.innerHTML = '';
+  const { titleFromCommand = false } = options;
 
   if (!commands.length) {
     const hint = document.createElement('p');
@@ -3393,7 +3394,8 @@ function renderCommandList(container, commands = [], emptyMessage) {
     body.className = 'task-body';
 
     const title = document.createElement('h3');
-    title.textContent = command.name || (command.command || []).join(' ');
+    const commandTitle = (command.command || []).join(' ');
+    title.textContent = titleFromCommand ? commandTitle : (command.name || commandTitle);
     body.appendChild(title);
 
     const queueLabel = command.queue ? [`File : ${command.queue}`] : [];
@@ -3409,11 +3411,11 @@ function renderCommandList(container, commands = [], emptyMessage) {
 
     const inputs = [];
     const argValues = command.arg_values || command.argValues || {};
-    if (Array.isArray(command.args) && command.args.length) {
-      command.args.forEach((arg) => {
-        if (!arg?.name) {
-          return;
-        }
+    const argList = Array.isArray(command.args) && command.args.length
+      ? command.args.filter((arg) => arg?.name)
+      : Object.keys(argValues).map((name) => ({ name, required: false }));
+    if (argList.length) {
+      argList.forEach((arg) => {
         const wrapper = document.createElement('label');
         wrapper.className = 'command-arg';
         wrapper.textContent = arg.name;
@@ -3489,7 +3491,8 @@ function renderUnscheduledTemplateCommands(commands = [], scheduledKeys = new Se
   renderCommandList(
     container,
     unscheduled,
-    'Aucune commande de template disponible.'
+    'Aucune commande de template disponible.',
+    { titleFromCommand: true }
   );
 }
 


### PR DESCRIPTION
### Motivation
- Unscheduled template command entries were not showing the command string as the title, causing confusing labels.
- Template-provided argument values were not being prefilled when the `args` metadata was missing.
- Keep the scheduler UI lean and robust when commands come from templates with minimal metadata.

### Description
- Updated `renderCommandList` signature to accept an `options` object and a `titleFromCommand` flag to control title rendering.
- When `titleFromCommand` is set, the title is rendered from the command string instead of `command.name` for template entries.
- Build `argList` fallback from `Object.keys(argValues)` when `command.args` is missing so input fields are created and prefilled from `arg_values`/`argValues`.
- Call `renderCommandList` with `{ titleFromCommand: true }` from `renderUnscheduledTemplateCommands`; changes are in `app/web/app.js`.

### Testing
- Started a local static server with `python -m http.server 8000` and captured a Playwright screenshot of the Scheduler page, which succeeded.
- `bundle exec rake test` was run but failed due to missing dependencies requiring `bundle install` (test run failed).
- Confirmed the modified file was committed and the UI behavior visually inspected via the screenshot (manual verification).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953fe02398883279dc40554934bdfb1)