### PR TITLE
Update unscheduled template command titles

### DIFF
--- a/app/web/app.js
+++ b/app/web/app.js
@@ -3376,7 +3376,7 @@ function normalizeCommandEntries(entries) {
 
 function renderCommandList(container, commands = [], emptyMessage, options = {}) {
   container.innerHTML = '';
-  const { titleSource } = options;
+  const { titleSource, titleFormat } = options;
 
   if (!commands.length) {
     const hint = document.createElement('p');
@@ -3395,7 +3395,11 @@ function renderCommandList(container, commands = [], emptyMessage, options = {})
 
     const title = document.createElement('h3');
     const commandTitle = (command.command || []).join(' ');
-    title.textContent = titleSource === 'command' ? commandTitle : (command.name || commandTitle);
+    let titleText = titleSource === 'command' ? commandTitle : (command.name || commandTitle);
+    if (titleFormat === 'commandWithTemplate') {
+      titleText = command.name ? `${commandTitle} - ${command.name}` : commandTitle;
+    }
+    title.textContent = titleText;
     body.appendChild(title);
 
     const queueLabel = command.queue ? [`File : ${command.queue}`] : [];
@@ -3488,7 +3492,9 @@ function renderUnscheduledTemplateCommands(commands = [], scheduledKeys = new Se
     ? commands.filter((command) => command.baseKey && !scheduledKeys.has(command.baseKey))
     : [];
 
-  renderCommandList(container, unscheduled, 'Aucune commande de template disponible.', { titleSource: 'command' });
+  renderCommandList(container, unscheduled, 'Aucune commande de template disponible.', {
+    titleFormat: 'commandWithTemplate',
+  });
 }
 
 function renderAvailableCommands(commands = [], scheduledKeys = new Set(), templateKeys = new Set()) {


### PR DESCRIPTION
### Motivation
- Make unscheduled template entries clearer by showing both the CLI command and the template name in the title.
- Use the existing `command.name` field from `/template_commands` as the template name to avoid extra lookups.
- Keep the shared command renderer minimal and flexible so only the unscheduled list changes presentation.

### Description
- Add an optional `titleFormat` option to `renderCommandList` and read it alongside `titleSource`.
- Implement a `commandWithTemplate` format that sets the title to ``<command> - <template name>`` using `command.name` when present.
- Update `renderUnscheduledTemplateCommands` to call `renderCommandList` with `titleFormat: 'commandWithTemplate'` and leave other lists unchanged.

### Testing
- No automated tests were run for this change.
- The change is limited to UI rendering in `app/web/app.js` and should not affect server behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69540e0c381c8327844b099dd4f2128b)