### PR TITLE
Parse CLI-style Array args in `template_command_arg_values`

### DIFF
--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -1497,6 +1497,16 @@ class Daemon
 
     def template_command_arg_values(data, template_dir = nil)
       template_params = data['args'] || data[:args]
+      if template_params.is_a?(Array)
+        template_params = template_params.each_with_object({}) do |arg, memo|
+          next unless arg.is_a?(String) && arg.start_with?('--')
+
+          key, value = arg[2..].split('=', 2)
+          next if key.nil? || key.empty?
+
+          memo[key] = value
+        end
+      end
       return unless template_params.is_a?(Hash)
 
       template_name = template_params['template_name'] || template_params[:template_name]


### PR DESCRIPTION
### Motivation
- Allow templates to accept `args` supplied as an Array of CLI-style strings like `--key=value` in addition to existing Hash args.
- Ensure parsed array entries are merged into the template argument values so templates still inherit defaults via `template_name`.
- Keep the change minimal and lean by adding a small, focused parser without changing existing behavior for Hash args.

### Description
- Added handling in `app/daemon.rb` inside `template_command_arg_values` to detect when `template_params` is an `Array` and parse entries like `--key=value` into a Hash using `each_with_object` and `split('=', 2)`.
- Converted parsed entries into a Hash that is then treated the same as existing Hash `args` and merged into the `merged` defaults.
- Preserved `template_name` resolution and the existing merging logic so template inheritance and Hash-based args behave unchanged.
- The change is intentionally small and uses concise Ruby idioms to keep the codebase lean.

### Testing
- Ran `bundle exec rake test`, which failed because project dependencies are not installed (error: `archive-zip` not checked out), so test suite did not complete.
- Confirmed the updated file `app/daemon.rb` was added and committed locally without runtime exceptions during the edit and commit steps.
- No additional automated tests were added for the new parsing behavior in this PR.
- Manual inspection of the diff shows the new parsing branch only triggers for `Array` input and returns unchanged behavior for `Hash` inputs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695410c76f948327b08811efc65b9043)