### PR TITLE
Streamline tighten_json and preserve no-whitespace key handling

### DIFF
--- a/lib/omdb_api.rb
+++ b/lib/omdb_api.rb
@@ -279,9 +279,7 @@ class OmdbApi
 
   def tighten_json(body)
     closing = body.rindex(/[}\]]/)
-    return nil unless closing
-
-    body[0..closing].gsub(/([\]\}"0-9])\s*"(?=[A-Za-z0-9_]+":)/, '\\1,"')
+    closing ? body[0..closing].gsub(/([\]\}"0-9])\s*"(?=[A-Za-z0-9_]+":)/, '\\1,"') : nil
   end
 
   def report_error(error, message)


### PR DESCRIPTION
### Motivation
- Make `tighten_json` leaner while ensuring it still handles cases where a closing JSON token is immediately followed by a next key with no whitespace.
- Reuse the existing `gsub` approach rather than adding parsing passes or dependencies.
- Reduce method size and remove an explicit early return for a more concise implementation.

### Description
- Replace the `return nil unless closing` branch with a single-line ternary that returns the transformed substring or `nil` in-place.
- Keep the existing regex `([\\]\"0-9])\s*"(?=[A-Za-z0-9_]+":)` which already allows zero-or-more whitespace and inserts a comma via `gsub`. 
- No new dependencies or additional JSON parsing passes were added.

### Testing
- Ran `bundle exec rake test` which failed due to missing gem checkout and requiring `bundle install` (the failure is unrelated to the change in `tighten_json`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69541df50b648327bbf38810e16c1108)