### PR TITLE
Replace restart+update control with update-and-stop action

### DIFF
--- a/app/web/app.js
+++ b/app/web/app.js
@@ -3658,19 +3658,19 @@ async function restartDaemon() {
   });
 }
 
-async function restartDaemonWithUpdate() {
-  await controlDaemon({
-    path: '/restart-update',
-    buttonId: 'restart-daemon-update',
-    message: 'Mise à jour + redémarrage en cours…',
-  });
-}
-
 async function stopDaemon() {
   await controlDaemon({
     path: '/stop',
     buttonId: 'stop-daemon',
     message: 'Arrêt du démon en cours…',
+  });
+}
+
+async function updateCodeAndStop() {
+  await controlDaemon({
+    path: '/update-stop',
+    buttonId: 'update-stop-daemon',
+    message: 'Mise à jour + arrêt en cours…',
   });
 }
 
@@ -3977,7 +3977,7 @@ function setupEventListeners() {
   document.getElementById('refresh-status').addEventListener('click', loadStatus);
   document.getElementById('stop-daemon').addEventListener('click', stopDaemon);
   document.getElementById('restart-daemon').addEventListener('click', restartDaemon);
-  document.getElementById('restart-daemon-update').addEventListener('click', restartDaemonWithUpdate);
+  document.getElementById('update-stop-daemon').addEventListener('click', updateCodeAndStop);
   document.getElementById('refresh-logs').addEventListener('click', loadLogs);
   const refreshSchedulerTasks = document.getElementById('refresh-scheduler-tasks');
   if (refreshSchedulerTasks) {

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -118,7 +118,7 @@
               <div class="actions">
                 <button id="stop-daemon" type="button" class="danger">Arrêter</button>
                 <button id="restart-daemon" type="button" class="danger">Redémarrer</button>
-                <button id="restart-daemon-update" type="button" class="danger">Redémarrer + mise à jour</button>
+                <button id="update-stop-daemon" type="button" class="danger">Mise à jour du code + stop</button>
                 <button id="refresh-status" type="button">Actualiser</button>
               </div>
             </div>


### PR DESCRIPTION
### Motivation
- Replace the existing “Redémarrer + mise à jour” control with a clearer action to update code then stop the daemon. 
- Use the existing daemon control helper to keep the UI logic lean and simple. 
- Wire the frontend to a new API endpoint (`/update-stop`) that implements update-and-stop behavior. 

### Description
- Updated `app/web/index.html` to replace the button `restart-daemon-update` with `update-stop-daemon` and label it `Mise à jour du code + stop`.
- Removed the `restartDaemonWithUpdate()` function from `app/web/app.js` and its old binding. 
- Added a compact `updateCodeAndStop()` function that calls `controlDaemon` with `path: '/update-stop'`, `buttonId: 'update-stop-daemon'`, and the user message `Mise à jour + arrêt en cours…`.
- Wired the new handler by binding `document.getElementById('update-stop-daemon').addEventListener('click', updateCodeAndStop);`.

### Testing
- Started a local static server with `python -m http.server` and verified the updated page loads successfully.
- Ran a Playwright script that opened `http://127.0.0.1:8000/index.html` and captured a screenshot showing the new `update-stop-daemon` button, which succeeded. 
- No unit tests were changed or run as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695540d218b48327a7c706866e98490f)