### PR TITLE
Remove legacy update-restart handling and suppress legacy UI errors

### DIFF
--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -2258,7 +2258,6 @@ class Daemon
         return error_response(res, status: 500, message: 'update_failed')
       end
 
-      update_stop_requested_flag.make_true
       json_response(res, status: 202, body: { 'status' => 'update_stopping' })
       Thread.new { stop }
     end
@@ -2280,10 +2279,6 @@ class Daemon
 
     def restart_requested_flag
       @restart_requested_flag ||= Concurrent::AtomicBoolean.new(false)
-    end
-
-    def update_stop_requested_flag
-      @update_stop_requested_flag ||= Concurrent::AtomicBoolean.new(false)
     end
 
     def update_root
@@ -3114,12 +3109,12 @@ class Daemon
       return @executor.wait_for_termination if timeout.nil?
       return if @executor.wait_for_termination(timeout)
 
-      app.speaker.speak_up("Restart/update shutdown timed out after #{timeout}s; forcing executor shutdown")
+      app.speaker.speak_up("Restart shutdown timed out after #{timeout}s; forcing executor shutdown")
       @executor.kill if @executor.respond_to?(:kill)
     end
 
     def restart_shutdown?
-      restart_requested_flag.true? || update_stop_requested_flag.true?
+      restart_requested_flag.true?
     end
 
     def restart_shutdown_timeout

--- a/app/web/app.js
+++ b/app/web/app.js
@@ -703,7 +703,11 @@ async function parseErrorMessage(response) {
   try {
     const parsed = JSON.parse(text);
     if (parsed && typeof parsed === 'object') {
-      return parsed.error || parsed.message || JSON.stringify(parsed);
+      const message = parsed.error || parsed.message;
+      if (message === 'update_restarting' || message === 'restart_only') {
+        return '';
+      }
+      return message || JSON.stringify(parsed);
     }
   } catch (error) {
     // ignore JSON errors, fall back to text


### PR DESCRIPTION
### Motivation
- Clean up obsolete `update+restart` handling and flags after migrating to `update+stop` flow to keep the daemon code lean.
- Prevent legacy error codes like `update_restarting` and `restart_only` from surfacing in the web UI.

### Description
- Removed the `update_stop_requested_flag` usage and its factory method from `app/daemon.rb` and stopped setting it when handling `/update-stop` requests.
- Simplified the shutdown message to remove the combined "Restart/update" wording in `app/daemon.rb` and limited `restart_shutdown?` to only check `restart_requested_flag`.
- Updated `app/web/app.js` `parseErrorMessage` to suppress legacy error messages `update_restarting` and `restart_only` so they do not show notifications.
- Changes touch `app/daemon.rb` and `app/web/app.js` to remove legacy behavior and reduce code bloat.

### Testing
- Ran `bundle exec rake test` to exercise the test suite, but it failed early due to missing dependency (`archive-zip` not checked out) so tests could not complete.
- Verified repository modifications apply cleanly and no additional references to `update_stop_requested_flag` remain via code search.
- Manual quick smoke checks on the modified JavaScript parsing branch confirmed suppression logic for the two legacy messages.
- No automated test failures attributable to the changes were observed (test run was blocked by dependency installation issue).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69554406dd588327bb016ae997a5eb7b)