### PR TITLE
Remove unscheduled template commands panel and related code

### DIFF
--- a/app/web/index.html
+++ b/app/web/index.html
@@ -177,15 +177,6 @@
             </div>
           </section>
 
-          <section class="panel" id="unscheduled-templates-panel">
-            <div class="panel-header">
-              <h2>Commandes de template non planifiées</h2>
-            </div>
-            <div id="unscheduled-template-list" class="scheduler-tasks">
-              <p class="hint">Aucune commande de template détectée.</p>
-            </div>
-          </section>
-
           <section class="panel" id="available-commands-panel">
             <div class="panel-header">
               <h2>Commandes disponibles</h2>


### PR DESCRIPTION
### Motivation
- Remove the "Commandes de template non planifiées" panel from the Scheduler UI and drop the associated client-side handling to simplify the scheduler interface.
- Reduce unused code and complexity by trimming template-command-specific helpers and filtering.

### Description
- Deleted the unscheduled templates panel from `app/web/index.html` and its placeholder content.
- Removed `renderUnscheduledTemplateCommands` and the `addBaseCommandKey` helper from `app/web/app.js` and updated `renderAvailableCommands` to no longer accept `templateKeys`.
- Simplified `loadSchedulerTasks` by removing the fetch/processing of `/template_commands` and the `templateKeys` set, and adjusted calls to `renderAvailableCommands` accordingly.

### Testing
- Ran `bundle exec rake test`, which failed due to missing dependencies and requiring `bundle install` (tests did not complete).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956474db8148327867551b37acac327)