### PR TITLE
Remove existing_folder dependency for local media checks

### DIFF
--- a/app/library.rb
+++ b/app/library.rb
@@ -442,7 +442,7 @@ class Library
           ids
         )
       end
-      existing_files[category] = existing_media_from_db(category, source.dig('existing_folder', category))
+      existing_files[category] = existing_media_from_db(category)
     when 'search'
       keywords = source['keywords']
       keywords = [keywords] if keywords.is_a?(String)
@@ -533,9 +533,7 @@ class Library
     {}
   end
 
-  def self.existing_media_from_db(category, folder)
-    return {} if folder.to_s.empty?
-
+  def self.existing_media_from_db(category, folder = nil)
     LocalMediaRepository.new(app: app).library_index(type: category, folder: folder) || {}
   end
 


### PR DESCRIPTION
### Motivation
- Stop relying on `request.source['existing_folder']` for determining already-present local media and instead use the DB as the source of truth. 
- Allow loading existing media from `local_media` without imposing a folder filter so search/list flows work even when no filesystem-folder is provided. 
- Simplify existing-media lookup signature to make folder optional. 
- Ensure torrent search flows get `existing_files` from the repository (not from sources) so processing can decide based on DB state.

### Description
- Updated `app/media_librarian/services/list_management_service.rb` to stop validating `existing_folder`, build cache names without folder, and load DB media via `LocalMediaRepository#library_index(type:)` once and pass it into `build_search_list` instead of reading `request.source['existing_folder']` repeatedly. 
- Adjusted the filesystem branch in `build_search_list` to use the preloaded DB index for `search_list` and `existing_files`. 
- Modified `app/library.rb` to call `existing_media_from_db(category)` without requiring a folder and changed `existing_media_from_db` signature to `existing_media_from_db(category, folder = nil)` which delegates to `LocalMediaRepository#library_index`. 
- Conservatively return an empty result early from `get_search_list` when the request is a `filesystem` type and no existing media are present in the DB to avoid unnecessary filesystem-dependent processing.

### Testing
- Ran `bundle exec rake test` to exercise the test suite; it failed to run because dependencies need to be checked out (`bundle install` required).  
- Performed code inspections and greps to verify references to `existing_folder` were removed and updated call sites now use the optional-folder API.  
- No automated tests executed against the modified code due to the above dependency issue.  
- Manual smoke inspection confirmed modified methods compile/parse (no Ruby syntax errors during static inspection).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956b4cb66948327a64272d6a86821f3)