### PR TITLE
Remove `existing_folder` usage from template and update list management tests

### DIFF
--- a/config/templates/search_from_torrents.yml.example
+++ b/config/templates/search_from_torrents.yml.example
@@ -9,9 +9,6 @@ torrent_sources:
           timeframe: 3 hours
 filter_sources:
   filesystem:
-    existing_folder:
-      movies: '/folder/of/movies'
-      shows: '/folder/of/tvseries'
     include_specials: 1 #For tv shows
     filter_criteria:
       days_newer:
@@ -30,23 +27,14 @@ filter_sources:
     delta: 10
     upgrade: 1 #if '1', will try to download episodes of better qualities if available
     get_missing_set: 1 #If '1', will look for missing movies from a given set
-    existing_folder:
-      movies: '/folder/of/movies'
-      shows: '/folder/of/tvseries'
   lists:
     list_name: 'watchlist'
     include_specials: 1 #For tv shows
     delta: 10
     upgrade: 1 #if '1', will try to download episodes of better qualities if available
     get_missing_set: 1 #If '1', will look for missing movies from a given set
-    existing_folder:
-      movies: '/folder/of/movies'
-      shows: '/folder/of/tvseries'
   watchlist:
     # Loads entries from the Watchlist filled from the calendrier / intérêt pane.
-    existing_folder:
-      movies: '/folder/of/movies'
-      shows: '/folder/of/tvseries'
 category: shows
 search_category: optional_can_be_one_of_movies_shows
 no_prompt: 0


### PR DESCRIPTION
### Motivation
- The configuration previously referenced `existing_folder` blocks that are no longer used by the local-DB based lookup logic.
- Tests referenced `existing_folder` fixtures and expected filesystem paths which no longer match the service behavior. 
- Align template and tests with the simplified repository lookup that relies on `LocalMediaRepository#library_index`.

### Description
- Removed all `existing_folder` blocks from `config/templates/search_from_torrents.yml.example`.
- Updated `test/services/list_management_service_test.rb` to remove `existing_folder` inputs and adapt expectations to the new cache naming and repository responses. 
- Adjusted test fixtures to stub `media_repository` and return DB-style entries and changed expected `repo.calls` to have `folder: nil` where folder parameters are no longer supplied. 
- Simplified the cached key usage in tests to match the production `cache_name` format used by the service (`filesystemmovies`).

### Testing
- Searched the repository for remaining `existing_folder` references using `rg "existing_folder"`, which returned no matches after the change. 
- Attempted to run the modified unit test with `bundle exec ruby -Itest test/services/list_management_service_test.rb`, but the run failed due to missing gem checkout (bundle install required), so full unit test execution was not completed.
- No other automated test failures were observed from the local checks performed during the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956b596a8e08327a32810654ebd9e50)