### PR TITLE
Remove REMOVEME debug lines

### DIFF
--- a/app/library.rb
+++ b/app/library.rb
@@ -462,7 +462,6 @@ class Library
     when 'filesystem', 'trakt', 'lists'
       existing_files, search_list = get_search_list(source_type, category, source, no_prompt)
       search_list.keys.each do |id|
-        app.speaker.speak_up(id) #REMOVEME
         next if id.is_a?(Symbol)
         case category
         when 'movies'

--- a/app/movies_set.rb
+++ b/app/movies_set.rb
@@ -44,7 +44,6 @@ class MoviesSet
       app.speaker.speak_up("Checking movies set '#{collec_title}' for missing part") if Env.debug?
       collections << collec_title
       collection.movies.each do |m|
-        begin ##REMOVEME
           app.speaker.speak_up "Checking movie '#{m.name}', released '#{m.release_date}', in collection" if Env.debug?
           next if (m.release_date.to_s == '' && m.year > Time.now.year.to_i) || m.release_date > Time.now - delta.to_i.days
           next if Metadata.media_exist?(qualifying_files, Movie.identifier(m.name, m.year))
@@ -62,9 +61,6 @@ class MoviesSet
               identifiers,
               info
           )
-        rescue => e ##REMOVEME
-          app.speaker.tell_error(e, "Block in MovieSet.list_missing_movie() m='#{Cache.object_pack(m,1)}'") ##REMOVEME
-        end ##REMOVEME
       end
     end
     missing_movies

--- a/lib/quality.rb
+++ b/lib/quality.rb
@@ -178,14 +178,12 @@ class Quality
   end
 
   def self.qualities_merge(oq, aq, lang = '', category = '')
-    MediaLibrarian.app.speaker.speak_up Utils.arguments_dump(binding) if Env.debug? #REMOVEME
     quality = ''
     Q_SORT.each do |t|
       cq = parse_qualities(oq.to_s, eval(t), lang, category).join('.')
       cq = parse_qualities((aq.to_s), eval(t), lang, category).join('.') if cq.to_s == ''
       quality += ".#{cq}"
     end
-    MediaLibrarian.app.speaker.speak_up "Qualities_merge = #{quality}" #REMOVEME
     quality
   end
 


### PR DESCRIPTION
### Motivation
- Remove temporary debug lines and leftover exception-handling marked with `#REMOVEME` to clean up noisy logging.
- Eliminate unnecessary `app.speaker` debug calls that are only useful during development.
- Remove a flagged `begin`/`rescue` block that was intended for removal to avoid hiding errors.

### Description
- Deleted `#REMOVEME` debug speaker calls from `lib/quality.rb` and `app/library.rb`.
- Removed the flagged `begin` / `rescue` / `end` block and its debug error reporting from `app/movies_set.rb`.
- Kept code behavior intact aside from removing the debug and exception-swallowing lines.
- Modified files: `lib/quality.rb`, `app/library.rb`, and `app/movies_set.rb`.

### Testing
- Ran `bundle exec rake test`, which failed because dependencies are not installed and `bundle install` must be run first.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956ba48aa0483278253eb3dff4bfae6)