### PR TITLE
Remove upgrade/get_missing_set handling from filter sources

### DIFF
--- a/app/library.rb
+++ b/app/library.rb
@@ -459,7 +459,7 @@ class Library
             :move_completed => (destination[category] || File.dirname(DEFAULT_MEDIA_DESTINATION[category])) }
         )
       end
-    when 'filesystem', 'trakt', 'lists'
+    when 'local_files', 'trakt', 'lists'
       existing_files, search_list = get_search_list(source_type, category, source, no_prompt)
       search_list.keys.each do |id|
         app.speaker.speak_up(id) #REMOVEME
@@ -467,17 +467,12 @@ class Library
         case category
         when 'movies'
           search_list[id][:files] = [] unless search_list[id][:files].is_a?(Array)
-          if (source['upgrade'].to_i > 0 && Quality.qualities_file_filter(existing_files[category][id], qualities)) ||
-            source['get_missing_set'].to_i > 0
-            search_list.delete(id)
-          else
-            already_exists = get_duplicates(existing_files[category][id], 1)
-            already_exists.each do |ae|
-              if app.speaker.ask_if_needed("Replace already existing file #{ae[:name]}? (y/n)", [no_prompt.to_i, source['upgrade'].to_i].max, source_type == 'trakt' ? 'n' : 'y').to_s == 'y'
-                search_list[id][:files] << ae unless source_type == 'filesystem'
-              elsif app.speaker.ask_if_needed("Remove #{search_list[id][:name]} from the search list? (y/n)", no_prompt.to_i, 'y').to_s == 'y'
-                search_list.delete(id)
-              end
+          already_exists = get_duplicates(existing_files[category][id], 1)
+          already_exists.each do |ae|
+            if app.speaker.ask_if_needed("Replace already existing file #{ae[:name]}? (y/n)", no_prompt.to_i, source_type == 'trakt' ? 'n' : 'y').to_s == 'y'
+              search_list[id][:files] << ae unless source_type == 'local_files'
+            elsif app.speaker.ask_if_needed("Remove #{search_list[id][:name]} from the search list? (y/n)", no_prompt.to_i, 'y').to_s == 'y'
+              search_list.delete(id)
             end
           end
         when 'shows'
@@ -490,8 +485,8 @@ class Library
         no_prompt,
         (source['delta'] || 10),
         source['include_specials'],
-        source['upgrade'].to_i > 0 ? qualities : {}
-      ) unless (category == 'movies' && source['get_missing_set'].to_i == 0)
+        {}
+      )
       ['movies', 'shows'].each { |t| search_list.merge!(missing[t]) if missing[t] }
       search_list.keep_if { |_, f| !f.is_a?(Hash) || f[:type] != 'movies' || (!f[:release_date].nil? && f[:release_date] < Time.now) }
     end

--- a/app/media_librarian/services/list_management_service.rb
+++ b/app/media_librarian/services/list_management_service.rb
@@ -34,7 +34,7 @@ module MediaLibrarian
 
       def get_search_list(request)
         existing_files_from_db = media_repository.library_index(type: request.category)
-        if request.source_type == 'filesystem' && existing_files_from_db.empty?
+        if request.source_type == 'local_files' && existing_files_from_db.empty?
           speaker.speak_up("get_search_list: no existing media in DB for category=#{request.category}, returning empty", 0) if speaker
           return [{ request.category => {} }, {}]
         end
@@ -54,7 +54,7 @@ module MediaLibrarian
         search_list = {}
         existing_files = {}
         case request.source_type
-        when 'filesystem'
+        when 'local_files'
           search_list[cache_name] = existing_files_from_db
           existing_files[request.category] = search_list[cache_name].dup
         when 'watchlist', 'download_list', 'lists'

--- a/app/torrent_search.rb
+++ b/app/torrent_search.rb
@@ -243,7 +243,7 @@ class TorrentSearch
   def self.search_from_torrents(torrent_sources:, filter_sources:, category:, destination: {}, no_prompt: 0, qualities: {}, download_criteria: {}, search_category: nil, no_waiting: 0, grab_all: 0)
     search_list, existing_files = {}, {}
     filter_sources.each do |t, s|
-      unless %w[search filesystem trakt lists watchlist download_list].include?(t.to_s)
+      unless %w[search local_files trakt lists watchlist download_list].include?(t.to_s)
         app.speaker.speak_up "Unknown filter source '#{t}', skipping"
         next
       end

--- a/config/templates/search_from_torrents.yml.example
+++ b/config/templates/search_from_torrents.yml.example
@@ -8,15 +8,9 @@ torrent_sources:
       - https://feed.second:
           timeframe: 3 hours
 filter_sources:
-  filesystem:
+  local_files:
     include_specials: 1 #For tv shows
-    filter_criteria:
-      days_newer:
-      days_older:
-    item_name: '' #If set, will only look for files containing this string
     delta: 10
-    upgrade: 1 #if '1', will try to download episodes of better qualities if available
-    get_missing_set: 1 #If '1', will look for missing movies from a given set
   search:
     keywords:
       - 'keyword'
@@ -25,14 +19,10 @@ filter_sources:
     list_name: 'watchlist'
     include_specials: 1 #For tv shows
     delta: 10
-    upgrade: 1 #if '1', will try to download episodes of better qualities if available
-    get_missing_set: 1 #If '1', will look for missing movies from a given set
   lists:
     list_name: 'watchlist'
     include_specials: 1 #For tv shows
     delta: 10
-    upgrade: 1 #if '1', will try to download episodes of better qualities if available
-    get_missing_set: 1 #If '1', will look for missing movies from a given set
   watchlist:
     # Loads entries from the Watchlist filled from the calendrier / intérêt pane.
 category: shows

--- a/test/services/list_management_service_test.rb
+++ b/test/services/list_management_service_test.rb
@@ -39,7 +39,7 @@ class ListManagementServiceTest < Minitest::Test
 
   def test_get_search_list_returns_empty_when_source_invalid
     request = MediaLibrarian::Services::SearchListRequest.new(
-      source_type: 'filesystem',
+      source_type: 'local_files',
       category: 'movies',
       source: {}
     )
@@ -53,14 +53,14 @@ class ListManagementServiceTest < Minitest::Test
 
   def test_get_search_list_uses_cached_results_when_source_valid
     request = MediaLibrarian::Services::SearchListRequest.new(
-      source_type: 'filesystem',
+      source_type: 'local_files',
       category: 'movies',
       source: {
         'list_name' => 'watchlist'
       }
     )
 
-    cache_name = 'filesystemmovies'
+    cache_name = 'local_filesmovies'
     existing_files = { cache_name => ['file.mkv'] }
     search_results = { cache_name => { 'file.mkv' => { size: 123 } } }
     repository = Class.new do
@@ -136,9 +136,9 @@ class ListManagementServiceTest < Minitest::Test
     end
   end
 
-  def test_filesystem_source_reads_existing_media_from_db_only
+  def test_local_files_source_reads_existing_media_from_db_only
     request = MediaLibrarian::Services::SearchListRequest.new(
-      source_type: 'filesystem',
+      source_type: 'local_files',
       category: 'movies',
       source: {
         'list_name' => 'library'


### PR DESCRIPTION
### Motivation

- Prevent treating `local_files` as if it should trigger remote-oriented `upgrade`/`get_missing_set` behavior.  
- Remove the `upgrade`/`get_missing_set` knobs and associated branching to keep the filter processing lean.  
- Normalize source type naming to `local_files` to reflect intended semantics.  

### Description

- Removed checks and uses of `source['upgrade']` and `source['get_missing_set']` from `Library.process_filter_sources` so those options no longer affect filtering.  
- Replaced `filesystem` with `local_files` in `app/media_librarian/services/list_management_service.rb` and in filter validation in `app/torrent_search.rb`.  
- Removed `upgrade`/`get_missing_set` keys from `config/templates/search_from_torrents.yml.example` and updated unit tests in `test/services/list_management_service_test.rb` to use `local_files` and the updated cache-name.  

### Testing

- Ran `bundle exec ruby -Itest test/services/list_management_service_test.rb`, which failed due to a missing dependency (`https://github.com/raphyduck/archive-zip.git is not yet checked out`) and requires running `bundle install` first (test did not complete).  
- No other automated tests were executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956b8b77e2883279d09fa979d3174a8)