### PR TITLE
Normalize local media types and preserve full local_files listings

### DIFF
--- a/app/library.rb
+++ b/app/library.rb
@@ -459,7 +459,9 @@ class Library
             :move_completed => (destination[category] || File.dirname(DEFAULT_MEDIA_DESTINATION[category])) }
         )
       end
-    when 'local_files', 'trakt', 'lists'
+    when 'local_files'
+      existing_files, search_list = get_search_list(source_type, category, source, no_prompt)
+    when 'trakt', 'lists'
       existing_files, search_list = get_search_list(source_type, category, source, no_prompt)
       search_list.keys.each do |id|
         next if id.is_a?(Symbol)
@@ -469,7 +471,7 @@ class Library
           already_exists = get_duplicates(existing_files[category][id], 1)
           already_exists.each do |ae|
             if app.speaker.ask_if_needed("Replace already existing file #{ae[:name]}? (y/n)", no_prompt.to_i, source_type == 'trakt' ? 'n' : 'y').to_s == 'y'
-              search_list[id][:files] << ae unless source_type == 'local_files'
+              search_list[id][:files] << ae
             elsif app.speaker.ask_if_needed("Remove #{search_list[id][:name]} from the search list? (y/n)", no_prompt.to_i, 'y').to_s == 'y'
               search_list.delete(id)
             end

--- a/app/local_media_repository.rb
+++ b/app/local_media_repository.rb
@@ -8,7 +8,8 @@ class LocalMediaRepository
   end
 
   def library_index(type:, folder: nil)
-    rows = fetch_rows(type, folder)
+    normalized_type = normalize_type(type)
+    rows = fetch_rows(normalized_type, folder)
     rows.each_with_object({}) do |row, memo|
       identifiers = build_identifiers(row)
       next if identifiers.empty?
@@ -20,6 +21,10 @@ class LocalMediaRepository
   end
 
   private
+
+  def normalize_type(type)
+    { 'movies' => 'movie', 'shows' => 'show' }.fetch(type.to_s, type.to_s)
+  end
 
   def build_identifiers(row)
     id = (row[:imdb_id] || row['imdb_id'] || row[:external_id] || row['external_id']).to_s

--- a/app/media_librarian/services/list_management_service.rb
+++ b/app/media_librarian/services/list_management_service.rb
@@ -33,16 +33,16 @@ module MediaLibrarian
       end
 
       def get_search_list(request)
-        existing_files_from_db = media_repository.library_index(type: request.category)
-        if request.source_type == 'local_files' && existing_files_from_db.empty?
-          speaker.speak_up("get_search_list: no existing media in DB for category=#{request.category}, returning empty", 0) if speaker
-          return [{ request.category => {} }, {}]
-        end
+        existing_files_from_db = request.source_type == 'local_files' ? {} : media_repository.library_index(type: request.category)
         search_list = {}
         existing_files = {}
         cache_name = "#{request.source_type}#{request.category}"
         Utils.lock_block(__method__.to_s + cache_name) do
           search_list, existing_files = build_search_list(request, cache_name, existing_files_from_db)
+        end
+        if request.source_type == 'local_files' && existing_files[request.category].to_h.empty?
+          speaker.speak_up("get_search_list: no existing media in DB for category=#{request.category}, returning empty", 0) if speaker
+          return [{ request.category => {} }, {}]
         end
         result_list = (search_list[cache_name] || {}).deep_dup
         result_list[:calendar_entries] = search_list[:calendar_entries].deep_dup if search_list[:calendar_entries]
@@ -55,6 +55,7 @@ module MediaLibrarian
         existing_files = {}
         case request.source_type
         when 'local_files'
+          existing_files_from_db = media_repository.library_index(type: request.category)
           search_list[cache_name] = existing_files_from_db
           existing_files[request.category] = search_list[cache_name].dup
         when 'watchlist', 'download_list', 'lists'


### PR DESCRIPTION
### Motivation

- Ensure `local_files` lookups match the `local_media` table by normalizing requested media types (`movies`→`movie`, `shows`→`show`).
- For `local_files` sources, load the complete set of existing files from the DB without applying folder/path filters so the search list contains full entries with associated `files`.
- Avoid removing `shows` entries or stripping entries based on `item_name` / `filter_criteria` when handling `local_files` so both movies and shows return full lists with their files.
- Keep the code lean and minimal while making local-file behavior consistent with expectations (all movies and all shows with associated files).

### Description

- Added `normalize_type` to `LocalMediaRepository` and call it in `library_index` to map `movies`→`movie` and `shows`→`show` before fetching rows.
- Changed `MediaLibrarian::Services::ListManagementService#get_search_list` to avoid pre-fetching DB rows for `local_files` and to defer calling `library_index` inside `build_search_list` so it can load unfiltered local listings.
- In `build_search_list`, explicitly call `media_repository.library_index(type: request.category)` for the `local_files` branch so local DB rows are loaded without folder filters.
- Modified `Library.process_filter_sources` to add a dedicated `when 'local_files'` branch that simply assigns `existing_files, search_list = get_search_list(...)` and removed the earlier logic that deleted `shows` and skipped attaching files for local sources, and ensured duplicate-file handling for `movies` always appends candidates.

### Testing

- Ran `ruby -c` syntax checks on `app/local_media_repository.rb`, `app/media_librarian/services/list_management_service.rb`, and `app/library.rb` which all returned `Syntax OK`.
- Attempted `bundle exec rake test` but it failed due to missing bundle setup (`bundle install` required), so the full test suite was not executed.
- Static checks/sanity edits only; no automated test failures were introduced by the syntax checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956bdecb08883278939abfb017a9745)