### PR TITLE
Remove stray debug speak_up call in library parsing

### DIFF
--- a/app/library.rb
+++ b/app/library.rb
@@ -373,7 +373,6 @@ class Library
           Utils.lock_block("file_handling_found_#{i}") do
             ok = false
             fs.uniq.each do |f|
-              app.speaker.speak_up "Found a '#{f[:type]}'#{' (' + f[:name].to_s + ')' if [:type] == 'file'} to remove for file '#{File.basename(file[:name])}' (identifier '#{i}'), removing now..." # if Env.debug?
               ok = !File.exist?(f[:name]) || FileUtils.rm(f[:name]) if f[:type] == 'file'
               if f[:type] == 'lists'
                 imdb_id = (f[:imdb_id] || f[:external_id] || f[:obj_imdb]).to_s.strip


### PR DESCRIPTION
### Motivation
- Remove an unguarded debug output that was printing during file-handling cleanup in the library parsing flow.
- Ensure the migration to `local_files` did not leave stray `#REMOVEME` markers or unguarded debug blocks in the same parsing path.

### Description
- Deleted the unguarded `app.speaker.speak_up` call inside the file-handling cleanup loop in `app/library.rb`.
- Left existing debug messages that are properly gated by `if Env.debug?` and verified no `#REMOVEME` markers remain in the parsing flow.

### Testing
- Ran a code search with `rg` for `REMOVEME` and debug patterns and found no remaining `#REMOVEME` occurrences in the parsing path. 
- Attempted to run the test suite with `bundle exec rake test`, which failed due to missing gems (notably `sqlite3`) so the test suite did not complete. 
- Started `bundle install` to provision dependencies but the install was interrupted and did not finish, preventing full automated test execution.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956bf5e92f883279f0c3e529f49b427)