### PR TITLE
Normalize collection types to movie/show

### DIFF
--- a/app/collection_repository.rb
+++ b/app/collection_repository.rb
@@ -83,7 +83,7 @@ class CollectionRepository
     return dataset unless dataset
     return dataset if type.to_s.strip.empty? || type == 'all'
 
-    %w[movie tv].include?(type) ? dataset.where(media_type: type) : dataset
+    %w[movie show].include?(type) ? dataset.where(media_type: type) : dataset
   end
 
   def collection_dataset
@@ -142,7 +142,7 @@ class CollectionRepository
       files: rows.map { |row| fetch(row, :local_path) }.compact
     }.compact
 
-    entry[:seasons] = build_seasons(rows) if entry[:media_type] == 'tv'
+    entry[:seasons] = build_seasons(rows) if entry[:media_type] == 'show'
     entry
   end
 

--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -1918,7 +1918,10 @@ class Daemon
 
     def normalize_collection_type(value)
       type = value.to_s.strip.downcase
-      %w[movie tv all].include?(type) ? type : nil
+      return 'movie' if %w[movie movies].include?(type)
+      return 'show' if %w[show shows tv series].include?(type)
+
+      type == 'all' ? 'all' : nil
     end
 
     def normalize_collection_sort(value)

--- a/app/web/app.js
+++ b/app/web/app.js
@@ -2571,7 +2571,7 @@ function resolveCollectionSortOption(sort) {
 
 function resolveCollectionType(value) {
   const type = value?.toString().trim();
-  return ['movie', 'tv', 'all'].includes(type) ? type : '';
+  return ['movie', 'show', 'all'].includes(type) ? type : '';
 }
 
 function normalizeFileEntries(files) {
@@ -2746,7 +2746,7 @@ function renderCollectionCard(entry) {
     body.appendChild(files);
   }
 
-  if (entry.media_type === 'tv') {
+  if (entry.media_type === 'show') {
     const seasons = Array.isArray(entry.seasons) ? entry.seasons : [];
     const seasonButton = document.createElement('button');
     seasonButton.type = 'button';

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -339,7 +339,7 @@
                 <select id="collection-type" name="type">
                   <option value="">Type</option>
                   <option value="movie">Films</option>
-                  <option value="tv">Shows</option>
+                  <option value="show">Séries</option>
                   <option value="all">Tous</option>
                 </select>
                 <div class="actions">


### PR DESCRIPTION
### Motivation
- Canonicalize collection type inputs so both backend and frontend use a single set of values (`movie` / `show`) instead of mixing `tv`/`shows`/`movies` variants.
- Ensure collection filtering and season detection behave consistently across API, repository and UI.
- Align the collection UI options with the canonical values to avoid mismatch when filtering.

### Description
- Update `normalize_collection_type` in `app/daemon.rb` to map variants (`movies`, `shows`, `tv`, `series`) to canonical `movie`/`show` (and preserve `all`).
- Change `apply_type_filter` and season detection in `app/collection_repository.rb` to compare against `show` instead of `tv` and filter by `movie`/`show`.
- Adjust the collection selector in `app/web/index.html` (`tv` → `show`) and update `resolveCollectionType` and card rendering in `app/web/app.js` to accept/use `show`.

### Testing
- Ran `bundle exec rake test` which failed due to missing gems, so unit test suite was not executed successfully.
- Attempted `bundle install` to fetch dependencies, which started installing many gems but was long-running and was interrupted before completing.
- Executed an automated browser script that loaded `app/web/index.html` and captured a screenshot to verify the UI option now shows `Séries` with value `show`, and the script completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a37069fbc83279cbe6bc8345dd16f)