### PR TITLE
Canonicalize media_type to 'movie'/'show' and add migration

### DIFF
--- a/app/local_media_repository.rb
+++ b/app/local_media_repository.rb
@@ -23,7 +23,7 @@ class LocalMediaRepository
   private
 
   def normalize_type(type)
-    { 'movies' => 'movie', 'shows' => 'show' }.fetch(type.to_s, type.to_s)
+    Utils.canonical_media_type(type)
   end
 
   def build_identifiers(row)

--- a/app/media_librarian/services/file_system_scan_service.rb
+++ b/app/media_librarian/services/file_system_scan_service.rb
@@ -28,7 +28,7 @@ module MediaLibrarian
       def persist_media_entries(library, type)
         return [] unless library.is_a?(Hash)
 
-        normalized_type = normalize_media_type(type)
+        normalized_type = Utils.canonical_media_type(type)
 
         existing_calendar_ids = calendar_imdb_ids
         cached_calendar = {}
@@ -130,14 +130,6 @@ module MediaLibrarian
           release_date: release_date,
           ids: { 'imdb' => imdb_id }
         }
-      end
-
-      def normalize_media_type(type)
-        normalized = type.to_s.strip.downcase
-        return 'movie' if normalized.start_with?('movie')
-        return 'show' if normalized.start_with?('show') || normalized.start_with?('tv') || normalized.start_with?('series')
-
-        normalized
       end
 
       def upsert_calendar_entry(entry)

--- a/lib/db/migrations/015_normalize_media_types.rb
+++ b/lib/db/migrations/015_normalize_media_types.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    %i[local_media calendar_entries].each do |table|
+      next unless table_exists?(table)
+
+      dataset = self[table]
+      dataset.where(Sequel.function(:lower, :media_type) => %w[movies movie]).update(media_type: 'movie')
+      dataset.where(Sequel.function(:lower, :media_type) => %w[shows show tv series]).update(media_type: 'show')
+    end
+  end
+
+  down do
+    # no-op
+  end
+end

--- a/lib/utils.rb
+++ b/lib/utils.rb
@@ -230,6 +230,14 @@ class Utils
     type
   end
 
+  def self.canonical_media_type(type)
+    normalized = type.to_s.strip.downcase
+    return 'movie' if normalized.start_with?('movie')
+    return 'show' if normalized.start_with?('show') || normalized.start_with?('tv') || normalized.start_with?('series')
+
+    normalized
+  end
+
   def self.timeperiod_to_sec(argument)
     return argument if argument.class < Integer
     if argument.class == String


### PR DESCRIPTION
### Motivation
- Ensure a single canonical value for `media_type` (e.g. `movie` / `show`) across the app and DB to avoid duplicated logic and mismatches.
- Migrate existing inconsistent values in `local_media.media_type` and `calendar_entries.media_type` to the canonical forms.
- Centralize normalization logic to reduce duplicated normalizers living in multiple services and repositories.
- Prevent reintroduction of non-normalized values by reusing a shared helper.

### Description
- Added `Utils.canonical_media_type(type)` which normalizes inputs like `movies`/`shows`/`tv`/`series` to `movie`/`show`.
- Replaced the ad-hoc normalizer in `app/media_librarian/services/file_system_scan_service.rb` with `Utils.canonical_media_type`.
- Replaced the ad-hoc normalizer in `app/local_media_repository.rb` with `Utils.canonical_media_type`.
- Added a migration `lib/db/migrations/015_normalize_media_types.rb` that updates `local_media` and `calendar_entries` rows to use `movie` or `show`.

### Testing
- Attempted to run the test suite with `bundle exec rake test`, but it failed due to missing gem checkout and requires running `bundle install` first (dependency: `archive-zip`).
- No other automated tests were executed in this environment after the change due to dependency setup required by the project.
- Static inspection and local execution of the modified code paths were performed manually (finder/grep and file checks) to validate replacements succeeded.
- The migration file was created and included with the changes to be applied by normal migration tooling.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a3ce97b0c8327904e9b33b32a0b31)