### PR TITLE
Normalize media_type on DB writes and add migration

### DIFF
--- a/lib/db/migrations/016_normalize_media_types.rb
+++ b/lib/db/migrations/016_normalize_media_types.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    %i[local_media calendar_entries].each do |table|
+      next unless table_exists?(table)
+
+      dataset = self[table]
+      dataset.where(Sequel.function(:lower, :media_type) => %w[movies movie]).update(media_type: 'movie')
+      dataset.where(Sequel.function(:lower, :media_type) => %w[shows show tv series]).update(media_type: 'show')
+    end
+  end
+
+  down do
+    # no-op
+  end
+end

--- a/lib/storage/db.rb
+++ b/lib/storage/db.rb
@@ -205,17 +205,24 @@ module Storage
     end
 
     def normalize_values(table, values)
-      case values
-      when Hash
-        values.each_with_object({}) do |(key, value), memo|
-          memo[key.to_sym] = value
-        end
-      when Array
-        columns = schema_info(table).keys
-        Hash[columns.zip(values)].compact
-      else
-        {}
+      normalized_table = table.to_sym
+      normalized = case values
+                   when Hash
+                     values.each_with_object({}) do |(key, value), memo|
+                       memo[key.to_sym] = value
+                     end
+                   when Array
+                     columns = schema_info(table).keys
+                     Hash[columns.zip(values)].compact
+                   else
+                     {}
+                   end
+
+      if normalized[:media_type] && %i[local_media calendar_entries].include?(normalized_table)
+        normalized[:media_type] = Utils.canonical_media_type(normalized[:media_type])
       end
+
+      normalized
     end
 
     def serialize_value(value)


### PR DESCRIPTION
### Motivation
- Ensure existing rows use canonical `media_type` values (`movie` / `show`) and prevent new writes from inserting non-normalized values.
- Avoid schema changes by normalizing data and application-level writes so indexes and constraints remain valid.

### Description
- Add a Sequel migration `lib/db/migrations/016_normalize_media_types.rb` that updates `local_media` and `calendar_entries` to map `movies` → `movie` and `shows/tv/series` → `show`.
- Normalize `media_type` on all DB writes by updating `lib/storage/db.rb` `normalize_values` to run `Utils.canonical_media_type` for `:media_type` when writing to `local_media` and `calendar_entries`.
- Keep changes minimal and limited to data normalization without touching indexes or constraints.

### Testing
- Attempted to run the test suite with `bundle exec rake test`, which failed because project dependencies are not installed and `bundle install` must be run first.
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a3dc90ae48327bc48cc116a5e8bb2)