### PR TITLE
Handle local_media normalization duplicates

### DIFF
--- a/lib/db/migrations/015_normalize_media_types.rb
+++ b/lib/db/migrations/015_normalize_media_types.rb
@@ -6,6 +6,17 @@ Sequel.migration do
       next unless table_exists?(table)
 
       dataset = self[table]
+      if table == :local_media
+        normalized_types = %w[movies movie shows show tv series]
+        normalized = Sequel.case(
+          { %w[movies movie] => 'movie', %w[shows show tv series] => 'show' },
+          Sequel.function(:lower, :media_type)
+        )
+        candidates = dataset.where(Sequel.function(:lower, :media_type) => normalized_types)
+        keep_ids = candidates.select { min(:id).as(:id) }.group(:imdb_id, normalized)
+        candidates.exclude(id: keep_ids).delete
+      end
+
       dataset.where(Sequel.function(:lower, :media_type) => %w[movies movie]).update(media_type: 'movie')
       dataset.where(Sequel.function(:lower, :media_type) => %w[shows show tv series]).update(media_type: 'show')
     end

--- a/lib/db/migrations/016_normalize_media_types.rb
+++ b/lib/db/migrations/016_normalize_media_types.rb
@@ -6,6 +6,17 @@ Sequel.migration do
       next unless table_exists?(table)
 
       dataset = self[table]
+      if table == :local_media
+        normalized_types = %w[movies movie shows show tv series]
+        normalized = Sequel.case(
+          { %w[movies movie] => 'movie', %w[shows show tv series] => 'show' },
+          Sequel.function(:lower, :media_type)
+        )
+        candidates = dataset.where(Sequel.function(:lower, :media_type) => normalized_types)
+        keep_ids = candidates.select { min(:id).as(:id) }.group(:imdb_id, normalized)
+        candidates.exclude(id: keep_ids).delete
+      end
+
       dataset.where(Sequel.function(:lower, :media_type) => %w[movies movie]).update(media_type: 'movie')
       dataset.where(Sequel.function(:lower, :media_type) => %w[shows show tv series]).update(media_type: 'show')
     end


### PR DESCRIPTION
### Motivation
- Avoid violating the unique index on `local_media` (`idx_local_media_type_imdb_id`) when normalizing `media_type` values.
- Ensure normalization like `movies/movie` → `movie` and `shows/show/tv series` → `show` does not produce duplicate rows for the same `imdb_id`.
- Keep the migration change minimal and safe by only touching `local_media` duplicates before updating values.

### Description
- Updated `015_normalize_media_types.rb` and `016_normalize_media_types.rb` to add a `local_media`-only cleanup step guarded by `if table == :local_media` and `table_exists?`.
- Built a normalized expression with `Sequel.case` and identified candidate rows via `Sequel.function(:lower, :media_type)` matching normalized types. 
- Kept the earliest row per `imdb_id` + normalized value using `select { min(:id).as(:id) }.group(:imdb_id, normalized)` and deleted the other duplicates with `candidates.exclude(id: keep_ids).delete` before running the existing `UPDATE` statements.
- Left the existing update calls intact and constrained changes to the two migration files to remain lean.

### Testing
- Attempted to run `bundle exec rake test` to exercise the test suite. 
- `bundle exec rake test` failed to run because dependencies are not checked out and require `bundle install`, so automated tests were not executed. 
- No further automated tests were run in this environment due to the missing dependency step (`bundle install`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a41739db483278e329b96c54c0108)