### PR TITLE
Fix collection sorting with calendar join

### DIFF
--- a/app/collection_repository.rb
+++ b/app/collection_repository.rb
@@ -50,13 +50,16 @@ class CollectionRepository
   end
 
   def apply_sort(dataset, sort)
+    created_at = Sequel[:local_media][:created_at]
+    local_path = Sequel[:local_media][:local_path]
+
     case sort
     when 'title'
-      dataset.order(Sequel.asc(:local_path))
+      dataset.order(Sequel.asc(local_path))
     when 'released_at', 'year'
-      dataset.order(Sequel.desc(:created_at), Sequel.asc(:local_path))
+      dataset.order(Sequel.desc(created_at), Sequel.asc(local_path))
     else
-      dataset.order(Sequel.desc(:created_at))
+      dataset.order(Sequel.desc(created_at))
     end
   end
 
@@ -83,7 +86,7 @@ class CollectionRepository
     return dataset unless dataset
     return dataset if type.to_s.strip.empty? || type == 'all'
 
-    %w[movie show].include?(type) ? dataset.where(media_type: type) : dataset
+    %w[movie show].include?(type) ? dataset.where(Sequel[:local_media][:media_type] => type) : dataset
   end
 
   def collection_dataset


### PR DESCRIPTION
### Motivation

- Avoid ambiguous column references when `local_media` is joined with `calendar_entries` which breaks sorting and filtering.
- Ensure collection ordering and type filters always use the `local_media` columns so results remain deterministic after joins.

### Description

- Qualify `created_at` and `local_path` with `Sequel[:local_media]` and use those in `apply_sort` (`title`, `released_at`/`year`, default). 
- Qualify `media_type` with `Sequel[:local_media]` in `apply_type_filter` so type filtering is unambiguous.
- Keep existing `collection_dataset` join against `calendar_entries` and leave other selection logic unchanged.

### Testing

- Attempted to run `bundle exec rake test`, but it failed due to missing dependencies (`bundle install` required).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a8380e33c832790e5d9a5f1fa403a)