### PR TITLE
Add collapsible error log entries with per-error copy

### DIFF
--- a/app/web/app.css
+++ b/app/web/app.css
@@ -647,6 +647,46 @@ button.danger:hover {
   overflow-wrap: anywhere;
 }
 
+.log-error {
+  border: 1px solid rgba(248, 113, 113, 0.5);
+  border-radius: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  background: rgba(127, 29, 29, 0.2);
+}
+
+.log-error + .log-error {
+  margin-top: 0.5rem;
+}
+
+.log-error summary {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+  cursor: pointer;
+  list-style: none;
+  color: #fecaca;
+}
+
+.log-error summary::-webkit-details-marker {
+  display: none;
+}
+
+.log-error pre {
+  margin: 0.5rem 0 0;
+  white-space: pre-wrap;
+}
+
+.log-error-copy {
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  background: rgba(15, 23, 42, 0.6);
+  color: inherit;
+  border-radius: 0.6rem;
+  padding: 0.2rem 0.5rem;
+  font-size: 0.75rem;
+  cursor: pointer;
+}
+
 .log-hint {
   margin: 0.75rem 0 0;
   color: var(--muted);

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -575,7 +575,7 @@
             <button type="button" class="copy-log">Copier</button>
           </div>
         </header>
-        <pre class="log-content"></pre>
+        <div class="log-content"></div>
       </article>
     </template>
 


### PR DESCRIPTION
### Motivation
- Improve readability of error logs by grouping stack traces into collapsible blocks. 
- Provide a quick way to copy an individual error and its trace to the clipboard. 
- Avoid cluttering the main log view while keeping full traces accessible. 

### Description
- Replace the `pre` log container with a `div` in `app/web/index.html` to host structured error blocks and regular text via `log-entry-template` and `log-content`. 
- Add CSS rules in `app/web/app.css` for `.log-error`, `.log-error summary`, and `.log-error-copy` to style collapsible error blocks and copy buttons. 
- Implement `renderErrorBlocks(text)` in `app/web/app.js` and call it from `updateLogFilter` for `medialibrarian_errors.log`, splitting logs on lines starting with `E, [` and rendering each error as a `<details>` with a `Copier` button that uses the clipboard API. 

### Testing
- No automated tests were run for this change. 
- Basic static checks (file updates and commit) completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b8ae93cac8327ab7ab69eb5e6f7fa)