### PR TITLE
Render medialibrarian_errors.log as collapsible error blocks

### DIFF
--- a/app/web/app.css
+++ b/app/web/app.css
@@ -647,6 +647,17 @@ button.danger:hover {
   overflow-wrap: anywhere;
 }
 
+.log-error summary {
+  color: #f87171;
+  border-left: 3px solid #f87171;
+  padding-left: 0.5rem;
+  cursor: pointer;
+}
+
+.log-error summary:hover {
+  color: #fca5a5;
+}
+
 .log-hint {
   margin: 0.75rem 0 0;
   color: var(--muted);

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -575,7 +575,7 @@
             <button type="button" class="copy-log">Copier</button>
           </div>
         </header>
-        <pre class="log-content"></pre>
+        <div class="log-content"></div>
       </article>
     </template>
 


### PR DESCRIPTION
### Motivation
- Improve readability of the `medialibrarian_errors.log` by grouping stack traces/errors into collapsible blocks for easier inspection.
- Preserve existing filter behavior and the copy-to-clipboard functionality to avoid surprising changes.
- Keep the implementation minimal and lean by using native `details/summary` elements and small CSS additions.

### Description
- Detect `medialibrarian_errors.log` in `updateLogFilter` and, when no filter is active, render the log as collapsible error blocks instead of plain text by calling `renderErrorBlocks`.
- Add a small `renderErrorBlocks` helper that splits the log by lines and groups blocks starting with lines that begin `E, [`, emitting a `<details class="log-error">` with a `<summary>` for the first line and a `<pre>` for the rest.
- Switch the log container from a `<pre>` to a `<div>` in `index.html` so it can host HTML elements, and add minimal styles in `app/web/app.css` for `.log-error summary` with red accent and hover cursor.
- Preserve `logEntry.dataset.fullLogText` and existing copy behavior so the "Copier" button and filtered plain-text display remain unchanged.

### Testing
- Ran an automated headless browser rendering test using Playwright which loaded the page, invoked `renderLogs` with sample error text, and produced a screenshot (`artifacts/log-errors.png`) showing the collapsible blocks (succeeds).
- Attempted to run the test suite with `bundle exec rake test` but it failed due to missing dependencies (`bundle install` required).
- Static checks: basic local runtime exercised by the Playwright scenario and verified DOM updates; no unit tests were added or broken by this change.
- Confirmed the copy-to-clipboard path still uses `dataset.fullLogText` and was not modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b9143653c8327902fe2a93b6bfaf8)