### PR TITLE
Add 'Copier' button to error log blocks

### DIFF
--- a/app/web/app.css
+++ b/app/web/app.css
@@ -659,13 +659,37 @@ button.danger:hover {
 }
 
 .log-error summary {
-  display: block;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
   padding: 0.35rem 0.5rem;
   border-radius: 0.5rem;
   border: 1px solid rgba(248, 113, 113, 0.6);
   cursor: pointer;
   list-style: none;
   color: #fecaca;
+}
+
+.log-error-title {
+  flex: 1;
+  min-width: 0;
+}
+
+.log-error .log-actions {
+  flex-shrink: 0;
+}
+
+.log-error .copy-error {
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  background: rgba(248, 113, 113, 0.12);
+  border-color: rgba(248, 113, 113, 0.4);
+}
+
+.log-error .copy-error:hover {
+  background: rgba(248, 113, 113, 0.2);
 }
 
 .log-error summary:hover {

--- a/app/web/app.js
+++ b/app/web/app.js
@@ -1703,7 +1703,28 @@ function renderErrorBlocks(logEntry, text) {
     const details = document.createElement('details');
     details.className = 'log-error';
     const summary = document.createElement('summary');
-    summary.textContent = block[0];
+    const summaryText = document.createElement('span');
+    summaryText.className = 'log-error-title';
+    summaryText.textContent = block[0];
+    const actions = document.createElement('span');
+    actions.className = 'log-actions';
+    const copyButton = document.createElement('button');
+    copyButton.type = 'button';
+    copyButton.className = 'copy-error';
+    copyButton.textContent = 'Copier';
+    copyButton.addEventListener('click', async (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      try {
+        await navigator.clipboard.writeText(block.join('\n'));
+        showNotification("Bloc d'erreur copié dans le presse-papiers.");
+      } catch (error) {
+        showNotification("Impossible de copier ce bloc d'erreur.", 'error');
+      }
+    });
+    actions.appendChild(copyButton);
+    summary.appendChild(summaryText);
+    summary.appendChild(actions);
     const body = document.createElement('pre');
     body.textContent = block.slice(1).join('\n');
     details.appendChild(summary);


### PR DESCRIPTION
### Motivation
- Permettre de copier facilement le bloc complet d'une erreur (résumé + stack trace) depuis l'affichage des logs d'erreur.
- Utiliser l'API native du navigateur pour coller proprement le contenu dans le presse‑papiers et informer l'utilisateur.
- Préserver l'UI légère en ajoutant un petit bouton d'action inline dans chaque bloc d'erreur.

### Description
- Mise à jour de `renderErrorBlocks` dans `app/web/app.js` pour insérer un bouton `Copier` par bloc qui appelle `navigator.clipboard.writeText(block.join('\n'))` et affiche une confirmation via `showNotification` en cas de succès/échec.
- Construction de la chaîne copiée avec `block.join('\n')` pour inclure le résumé et la trace complète.
- Ajustements CSS dans `app/web/app.css` pour transformer ` .log-error summary` en `flex`, ajouter `.log-error-title` et styles compacts pour `.copy-error` afin de garder l'interface compacte.

### Testing
- Démarrage d'un serveur statique avec `python -m http.server` dans `app/web` pour tester l'UI localement, ce qui a bien démarré.
- Tentatives d'exécution d'un script Playwright pour injecter des blocs d'erreur et prendre une capture d'écran ont été effectuées mais ont échoué en raison d'un plantage/timeout du navigateur (Chromium SIGSEGV / timeouts).
- Aucune suite de tests automatisés unitaires n'a été lancée pour ces changements.
- Les modifications ont été commitées localement (`Add copy buttons to error blocks`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b931b797883278d317813373a25e8)