### PR TITLE
Toggle error log details from summary clicks

### DIFF
--- a/app/web/app.js
+++ b/app/web/app.js
@@ -1744,6 +1744,11 @@ function renderErrorBlocks(logEntry, text) {
     actions.appendChild(copyButton);
     summary.appendChild(summaryText);
     summary.appendChild(actions);
+    summary.addEventListener('click', (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      details.open = !details.open;
+    });
     const body = document.createElement('pre');
     body.textContent = block.slice(1).join('\n');
     details.appendChild(summary);


### PR DESCRIPTION
### Motivation
- Make clicking an error title explicitly toggle its block open/closed to avoid relying on browser defaults and to simplify event flow.
- Ensure the existing "Copier" button behavior (`preventDefault`/`stopPropagation`) remains intact so copy actions aren't interfered with.
- Keep the change minimal and lean to avoid UI bloat or side effects.

### Description
- Add a lightweight click handler on the `summary` element via `summary.addEventListener('click', ...)` that runs `details.open = !details.open` and stops propagation.
- Preserve the existing `copyButton` click handler and its `event.preventDefault()`/`event.stopPropagation()` behavior.
- No other logic around `toggle`/`updateRefreshLabel` or auto-refresh handling was modified.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b96a7a9748327b1500745f3178b32)