### PR TITLE
Serialize SQLite writes with a shared mutex

### DIFF
--- a/lib/storage/db.rb
+++ b/lib/storage/db.rb
@@ -284,7 +284,7 @@ module Storage
       return speaker&.speak_up("Would #{sql}") if Env.pretend?
       raise 'ReadOnly Db' if readonly
 
-      Utils.lock_block("db_#{table}") { yield }
+      Utils.lock_block('db_write') { yield }
     end
 
     def skip_write?(sql)


### PR DESCRIPTION
### Motivation
- Serialize all SQLite write operations to avoid concurrent write conflicts across tables.
- Prefer a minimal, lean change that centralizes write locking at the DB level.
- Leave the read path unchanged so `get_rows` still uses its per-table lock to allow reads to proceed.

### Description
- Replace the per-table lock in `run_write` with a shared lock by calling `Utils.lock_block('db_write')` in `lib/storage/db.rb`.
- This one-line change serializes all writes while keeping existing read locking intact.
- No other public interfaces or behaviors were modified.

### Testing
- Ran `bundle exec rake test`, which failed due to missing dependency checkout / needing `bundle install` so tests could not run successfully in this environment.
- No automated tests completed successfully here due to the environment dependency issue.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ba7e6f2f48327a08c180cd3143e69)