### PR TITLE
Render medialibrarian_errors.log as structured error blocks, preserve truncation for other logs

### DIFF
--- a/app/web/app.js
+++ b/app/web/app.js
@@ -1825,15 +1825,27 @@ function renderLogs(logs = {}) {
     }
 
     const fullLogText = content || '';
-    const { text: displayContent, truncated } = getLogTail(fullLogText);
+    const isErrorLog = name === 'medialibrarian_errors.log';
+    const { text: displayContent, truncated } = isErrorLog
+      ? { text: fullLogText, truncated: false }
+      : getLogTail(fullLogText);
     logEntry.dataset.fullLogText = fullLogText;
     logEntry.dataset.logText = displayContent || '';
     logEntry.dataset.logTruncated = truncated ? 'true' : 'false';
-    updateLogFilter(logEntry);
+    if (isErrorLog) {
+      const query = logEntry.querySelector('.log-filter')?.value.trim();
+      if (query) {
+        updateLogFilter(logEntry);
+      } else {
+        renderErrorBlocks(logEntry, fullLogText);
+      }
+    } else {
+      updateLogFilter(logEntry);
+    }
     const logContent = logEntry.querySelector('.log-content');
 
     let hint = logEntry.querySelector('.log-hint');
-    if (truncated) {
+    if (!isErrorLog && truncated) {
       if (!hint) {
         hint = document.createElement('p');
         hint.className = 'log-hint';


### PR DESCRIPTION
### Motivation

- Render `medialibrarian_errors.log` as structured error blocks so error groups can be expanded/collapsed and copied instead of showing raw tail text. 
- Preserve tailing/truncation behavior for non-error logs to avoid dumping thousands of lines into the DOM. 
- Ensure filtering still searches the full log for both error and non-error logs. 
- Keep the `log-hint` truncation message consistent for non-error logs.

### Description

- Detect error logs in `renderLogs` via `isErrorLog = name === 'medialibrarian_errors.log'`. 
- Bypass `getLogTail` for error logs by assigning `displayContent = fullLogText` and `truncated = false`, while using `getLogTail` for other logs. 
- For error logs call `renderErrorBlocks(logEntry, fullLogText)` when there is no active filter, and call `updateLogFilter(logEntry)` when a filter is present. 
- Only create/show the `log-hint` message when the entry is not an error log and `truncated` is true.

### Testing

- Ran `bundle exec rake test`, which failed due to missing dependencies and requiring `bundle install` (no test suite run succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bb4b7b7208327b428abda85d2e33a)