### PR TITLE
Persist unmatched local media entries

### DIFF
--- a/lib/db/migrations/017_allow_null_imdb_id_local_media.rb
+++ b/lib/db/migrations/017_allow_null_imdb_id_local_media.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    break unless table_exists?(:local_media)
+
+    alter_table(:local_media) do
+      set_column_allow_null :imdb_id
+    end
+
+    self[:local_media].where(imdb_id: '').update(imdb_id: nil)
+  end
+
+  down do
+    break unless table_exists?(:local_media)
+
+    self[:local_media].where(imdb_id: nil).update(imdb_id: '')
+
+    alter_table(:local_media) do
+      set_column_allow_null :imdb_id, false
+    end
+  end
+end


### PR DESCRIPTION
### Motivation

- Allow files discovered on disk that have no resolved IMDb ID to be recorded in `local_media` so they can be managed later.
- Mark unmatched items with a distinguishable value (`imdb_id` = `NULL`) instead of skipping them during persistence.
- Ensure duplicate detection still works for unmatched rows by falling back to `media_type` + `local_path` comparison.
- Keep the change minimal and storage-light by only relaxing the `imdb_id` nullability and lookup logic.

### Description

- In `persist_media_entries` set `imdb_id = nil` when the normalized ID is empty and stop skipping files that lack an IMDb ID so metadata containing `imdb_id: nil` is persisted.
- Guard calendar upsert to only run when `imdb_id` is present so unmatched entries are not seeded into the calendar logic (`cached_calendar` check adjusted accordingly).
- Update `existing_local_media` to fall back to `app.db.get_rows(:local_media, { media_type: ..., local_path: ... })` when `imdb_id` is empty so duplicates are detected by `media_type + local_path` for unmatched rows.
- Add migration `lib/db/migrations/017_allow_null_imdb_id_local_media.rb` that makes the `imdb_id` column nullable and converts empty-string IDs to `NULL` (and reverses on down).

### Testing

- Ran `bundle exec rake test`, which failed to run because `bundle install` is required and a dependency (`archive-zip`) was not checked out.
- No other automated test suites were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bd859843c83278e8550d6c5e32b7d)