### PR TITLE
Add 'unmatched' collection filter (backend + frontend)

### DIFF
--- a/app/collection_repository.rb
+++ b/app/collection_repository.rb
@@ -86,7 +86,18 @@ class CollectionRepository
     return dataset unless dataset
     return dataset if type.to_s.strip.empty? || type == 'all'
 
-    %w[movie show].include?(type) ? dataset.where(Sequel[:local_media][:media_type] => type) : dataset
+    if %w[movie show].include?(type)
+      dataset.where(Sequel[:local_media][:media_type] => type)
+    elsif type == 'unmatched'
+      imdb_id = Sequel[:local_media][:imdb_id]
+      conditions = [imdb_id => nil, imdb_id => '']
+      if dataset.columns.include?(:matched)
+        conditions << { Sequel[:local_media][:matched] => false }
+      end
+      dataset.where(Sequel.|(*conditions))
+    else
+      dataset
+    end
   end
 
   def collection_dataset

--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -1920,6 +1920,7 @@ class Daemon
       type = value.to_s.strip.downcase
       return 'movie' if %w[movie movies].include?(type)
       return 'show' if %w[show shows tv series].include?(type)
+      return 'unmatched' if type == 'unmatched'
 
       type == 'all' ? 'all' : nil
     end

--- a/app/web/app.js
+++ b/app/web/app.js
@@ -2709,7 +2709,7 @@ function resolveCollectionSortOption(sort) {
 
 function resolveCollectionType(value) {
   const type = value?.toString().trim();
-  return ['movie', 'show', 'all'].includes(type) ? type : '';
+  return ['movie', 'show', 'all', 'unmatched'].includes(type) ? type : '';
 }
 
 function normalizeFileEntries(files) {

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -340,6 +340,7 @@
                   <option value="">Type</option>
                   <option value="movie">Films</option>
                   <option value="show">Séries</option>
+                  <option value="unmatched">Unmatched</option>
                   <option value="all">Tous</option>
                 </select>
                 <div class="actions">


### PR DESCRIPTION
### Motivation
- Allow users to filter the collection for items that are not matched to calendar entries or external metadata by introducing an `unmatched` collection type.
- Keep the new filter minimal and consistent with existing type filtering semantics used for `movie`/`show`.

### Description
- Accept `unmatched` in `normalize_collection_type` in `app/daemon.rb` so it is recognized in collection query params via `type`.
- Implement `unmatched` handling in `apply_type_filter` in `app/collection_repository.rb` to return rows where `imdb_id` is NULL/empty or where `matched = false` when the column exists.
- Add an `Unmatched` option to the collection type selector in `app/web/index.html` and accept it in `resolveCollectionType` in `app/web/app.js`.

### Testing
- Ran `bundle exec rake test`, which failed due to missing dependencies (needs `bundle install` for `archive-zip`).
- Attempted an automated headless UI check to confirm the new dropdown entry, which failed due to the Chromium headless process crashing in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bdb129dc48327975d111a511f1319)