### PR TITLE
Allow multiple unmatched local media rows

### DIFF
--- a/lib/db/migrations/018_adjust_local_media_imdb_uniqueness.rb
+++ b/lib/db/migrations/018_adjust_local_media_imdb_uniqueness.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    break unless table_exists?(:local_media)
+
+    alter_table(:local_media) do
+      set_column_allow_null :imdb_id
+      set_column_default :imdb_id, nil
+    end
+
+    self[:local_media].where(imdb_id: '').update(imdb_id: nil)
+  end
+
+  down do
+    break unless table_exists?(:local_media)
+
+    self[:local_media].where(imdb_id: nil).update(imdb_id: '')
+
+    alter_table(:local_media) do
+      set_column_allow_null :imdb_id, false
+      set_column_default :imdb_id, ''
+    end
+  end
+end

--- a/lib/storage/db.rb
+++ b/lib/storage/db.rb
@@ -223,6 +223,10 @@ module Storage
         normalized[:media_type] = Utils.canonical_media_type(normalized[:media_type])
       end
 
+      if normalized_table == :local_media && normalized.key?(:imdb_id)
+        normalized[:imdb_id] = nil if normalized[:imdb_id].to_s.strip.empty?
+      end
+
       normalized
     end
 


### PR DESCRIPTION
### Motivation
- Allow persisting multiple `local_media` rows that are unmatched (no IMDb id) without violating uniqueness constraints.
- Use the lean approach of permitting `imdb_id` to be NULL so NULLs won’t collide in most DBs.
- Ensure blank/empty `imdb_id` values are normalized to `NULL` before persistence to avoid index collisions.
- Make the change minimal and focused to avoid broad schema or code churn.

### Description
- Add migration `lib/db/migrations/018_adjust_local_media_imdb_uniqueness.rb` to set `imdb_id` nullable and normalize existing blank values to `NULL`.
- Update `lib/storage/db.rb` in `normalize_values` to convert blank `imdb_id` values to `nil` when writing `:local_media` rows.
- The migration preserves a reversible `down` path that restores the previous non-null default and converts `NULL` back to empty string.
- Changes are intentionally small and localized to the DB normalization and migration.

### Testing
- Attempted to run the test suite with `bundle exec rake test`, but it failed due to missing dependencies and requiring `bundle install` (error: `archive-zip` not checked out).
- No automated tests were changed as part of this PR and no tests completed successfully in this environment.
- Migration is idempotent and includes a safe `down` to revert the nullability change.
- Manual verification: normalization logic added to `normalize_values` will convert `''` to `nil` for `:local_media` entries prior to insert/update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bdd4bc3ac8327990de3e24a7b8a30)