### PR TITLE
Add template command list to scheduler tab

### DIFF
--- a/app/web/index.html
+++ b/app/web/index.html
@@ -185,6 +185,15 @@
               <p class="hint">Aucune commande CLI détectée.</p>
             </div>
           </section>
+
+          <section class="panel" id="template-commands-panel">
+            <div class="panel-header">
+              <h2>Templates de commandes</h2>
+            </div>
+            <div id="template-command-list" class="scheduler-tasks">
+              <p class="hint">Aucun template de commande détecté.</p>
+            </div>
+          </section>
         </section>
 
         <section


### PR DESCRIPTION
### Motivation

- Exposer les templates qui encapsulent une commande CLI dans l'onglet Scheduler pour pouvoir les lancer depuis l'interface.  
- Réutiliser la logique existante d'affichage d'une commande et d'édition d'arguments afin de rester LEAN et cohérent avec les sections existantes.  
- Charger les entrées templates depuis l'endpoint `/template_commands` et ne présenter que celles déclarant un argument `command`.

### Description

- Ajout d'un nouveau panneau HTML `#template-commands-panel` avec le container `#template-command-list` dans `app/web/index.html`.  
- Ajout de `filterTemplateCommands()` et `renderTemplateCommands()` dans `app/web/app.js` qui réutilisent `renderCommandList()` et la logique d'édition/lancement (`runSchedulerTask`).  
- Modification de `loadSchedulerTasks()` pour effectuer un `fetch` vers `/template_commands`, normaliser les entrées avec `normalizeCommandEntries()`, filtrer celles contenant un argument `command`, et appeler `renderTemplateCommands()`.  
- Aucune nouvelle CSS spécifique ajoutée ; les classes existantes (`scheduler-tasks`, `task-body`, `task-actions`, etc.) sont réutilisées pour l'alignement.

### Testing

- Démarré un serveur statique (`python -m http.server`) et capturé une capture d'écran via un script Playwright pour valider le rendu du panneau Scheduler, et la capture a été générée avec succès.  
- Le flux de récupération `/template_commands` a été exercé dans le code via `fetchJson` (manipulé lors du test navigateur).  
- Aucun test unitaire/CI automatique supplémentaire n'a été exécuté dans cette PR.  
- Les changements ont été commités localement et sont prêts pour revue.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bfa9714988327b58fb832d05d6113)