### PR TITLE
Avoid mutating lock process names

### DIFF
--- a/lib/utils.rb
+++ b/lib/utils.rb
@@ -127,7 +127,7 @@ class Utils
   end
 
   def self.lock_block(process_name, nonex = 0, &block)
-    process_name.gsub!(/[\{\}\(\)]/, '')
+    process_name = process_name.to_s.gsub(/[\{\}\(\)]/, '')
     lock_name = "lock_#{process_name}_on"
     if Thread.current[lock_name] == 1
       r = block.call


### PR DESCRIPTION
### Motivation
- Prevent in-place mutation of `process_name` passed to `Utils.lock_block` so callers can safely pass string literals like `'db_write'`.
- Ensure `lock_name` and other internals use a sanitized copy without altering the original argument.

### Description
- In `lib/utils.rb` update `Utils.lock_block` to use `process_name = process_name.to_s.gsub(/[\{\}\(\)]/, '')` instead of `gsub!`.
- This creates a sanitized string copy and also safely handles `nil` by calling `to_s`.

### Testing
- Ran `bundle exec rake test`, which failed due to missing dependency checkout (`archive-zip` not checked out), so the test suite could not be executed successfully.
- No other automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bfae1859c8327a52ee88323b2d3f5)