### PR TITLE
Expose `template_args` for template commands and use it in the UI

### DIFF
--- a/app/web/app.js
+++ b/app/web/app.js
@@ -3502,9 +3502,12 @@ function renderCommandList(container, commands = [], emptyMessage, options = {})
 
     const inputs = [];
     const argValues = command.arg_values || command.argValues || {};
-    const argList = Array.isArray(command.args) && command.args.length
-      ? command.args.filter((arg) => arg?.name)
-      : Object.keys(argValues).map((name) => ({ name, required: false }));
+    const templateArgs = command.template_args || command.templateArgs || [];
+    const argList = Array.isArray(templateArgs) && templateArgs.length
+      ? templateArgs.map((name) => ({ name, required: false }))
+      : Array.isArray(command.args) && command.args.length
+        ? command.args.filter((arg) => arg?.name)
+        : Object.keys(argValues).map((name) => ({ name, required: false }));
     if (argList.length) {
       argList.forEach((arg) => {
         const wrapper = document.createElement('label');
@@ -3586,10 +3589,18 @@ function renderAvailableCommands(commands = [], scheduledKeys = new Set()) {
 }
 
 function filterTemplateCommands(commands = []) {
+  const commandArgs = (command) => {
+    const templateArgs = command?.template_args || command?.templateArgs;
+    if (Array.isArray(templateArgs)) {
+      return templateArgs;
+    }
+    if (Array.isArray(command?.args)) {
+      return command.args.map((arg) => arg?.name).filter(Boolean);
+    }
+    return [];
+  };
   return Array.isArray(commands)
-    ? commands.filter((command) =>
-        Array.isArray(command.args) && command.args.some((arg) => arg?.name === 'command')
-      )
+    ? commands.filter((command) => commandArgs(command).includes('command'))
     : [];
 }
 


### PR DESCRIPTION
### Motivation
- Ensure template command metadata exposes the declared argument keys so the front-end can detect templates that accept a `command` argument even if defaults are absent.
- Provide the UI a stable source of template parameter names separate from initial `arg_values` so editing and filtering behave correctly.

### Description
- Add `template_command_arg_keys(data, template_dir)` to collect argument keys from template `args` (array or hash) and recursively from referenced templates via `template_name`.
- Populate a new `template_args` field in `build_template_command_entry` (in `app/daemon.rb`) and merge with any computed `arg_values` keys.
- Update front-end `app/web/app.js` to use `template_args` for filtering templates (so templates exposing a `command` arg are selectable) and to drive the displayed/editable argument list while keeping `arg_values` as initial values.
- Changes touch `app/daemon.rb` and `app/web/app.js` and keep behavior lean by reusing existing parsing/loading functions.

### Testing
- Attempted to run the test suite with `bundle exec rake test`, which failed because `bundle install` is required for the `archive-zip` dependency; no other automated tests were executed.
- No additional automated tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bfbb4bf548327855a141378016520)