### PR TITLE
Fix template args key extraction

### DIFF
--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -1563,7 +1563,8 @@ class Daemon
                  key if key && !key.empty?
                end
              when Hash
-               template_params.keys.map(&:to_s)
+               template_args = template_params['args'] || template_params[:args]
+               (template_args.is_a?(Hash) ? template_args : template_params).keys.map(&:to_s)
              else
                []
              end
@@ -1574,7 +1575,10 @@ class Daemon
         if resolved_dir
           template = app.args_dispatch.load_template(template_name, resolved_dir)
           template = app.args_dispatch.parse_template_args(template, resolved_dir)
-          keys.concat(template.keys.map(&:to_s)) if template.is_a?(Hash)
+          if template.is_a?(Hash)
+            template_args = template['args'] || template[:args]
+            keys.concat((template_args.is_a?(Hash) ? template_args : template).keys.map(&:to_s))
+          end
         end
       end
 


### PR DESCRIPTION
### Motivation
- Templates that nest their params under an `args:` hash produced only the top-level key `"args"` instead of the actual argument names, causing required args with nil defaults to be hidden by UI filtering.
- The intent is to ensure `template_command_arg_keys` reports the real argument names when templates use nested `args` structures.

### Description
- Update `template_command_arg_keys` in `app/daemon.rb` to inspect a nested `args` hash when `data['args']` or parsed templates wrap arguments under `args`.
- When `template_params` or a loaded/parsed `template` is a Hash, the code now prefers the inner `['args']`/`[:args]` Hash and falls back to the parent Hash otherwise before extracting keys.
- Preserve previous behavior for Array-style arg lists and continue rejecting the `template_name` key and returning unique keys.

### Testing
- Attempted to run `bundle exec rake test` but it failed due to missing dependency checkout (`archive-zip`), so test suite did not execute.
- No other automated tests were run in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c02d04a2483279ed9b4b9c2417ffd)