### PR TITLE
Sync template arg values with nested defaults

### DIFF
--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -1526,6 +1526,7 @@ class Daemon
       return unless template_params.is_a?(Hash)
 
       template_name = template_params['template_name'] || template_params[:template_name]
+      template_args = template_params['args'] || template_params[:args]
       template_values = {}
       if template_name
         resolved_dir = resolve_template_dir(template_name, template_dir)
@@ -1544,9 +1545,17 @@ class Daemon
       end
 
       template_params.each do |key, value|
-        next if key.to_s == 'template_name' || value.nil?
+        next if key.to_s == 'template_name' || key.to_s == 'args' || value.nil?
 
         merged[key.to_s] = value.is_a?(String) ? value : value.to_s
+      end
+
+      if template_args.is_a?(Hash)
+        template_args.each do |key, value|
+          next if key.to_s == 'template_name' || value.nil?
+
+          merged[key.to_s] = value.is_a?(String) ? value : value.to_s
+        end
       end
 
       merged


### PR DESCRIPTION
### Motivation
- `template_command_arg_keys` unwraps nested `args`, but `template_command_arg_values` only merged top-level keys, causing nested defaults to be missing in the UI.
- The UI relies on `arg_values` to prefill inputs, so nested defaults must be exposed in the values map to avoid dropped parameters when launching tasks.

### Description
- Read nested `args` from `template_params` into `template_args` via `template_params['args'] || template_params[:args]`.
- Skip merging the top-level `args` entry when folding `template_params` into the result by checking `key.to_s == 'args'`.
- Merge entries from `template_args` into the final `merged` values so nested defaults are included and stringified consistently.
- Keep existing template-loading and default-resolution logic unchanged (`load_template`, `parse_template_args`, and string conversion behavior).

### Testing
- Ran `ruby -c app/daemon.rb` to validate syntax and it completed successfully.
- No other automated tests were modified or executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c20840fbc8327ad3beb8af1253c6b)