### PR TITLE
Set default original audio for downloaded MKVs

### DIFF
--- a/app/library.rb
+++ b/app/library.rb
@@ -170,6 +170,14 @@ class Library
       type = otype.downcase
       ttype = handling[type] && handling[type]['media_type'] ? handling[type]['media_type'] : type
       extension = FileUtils.get_extension(torrent_name)
+      if torrent_name.match(Regexp.new(VALID_VIDEO_EXT)) &&
+         %w[movies shows].include?(ttype) &&
+         File.extname(full_p).downcase == '.mkv' &&
+         system('command -v mkvpropedit >/dev/null 2>&1')
+        _, _, info = Metadata.parse_media_filename(full_p, ttype, nil, '', 1, folder_hierarchy, completed_folder + '/' + otype, { :name => full_p })
+        original_lang = info[:language].to_s
+        VideoUtils.set_default_original_audio!(path: full_p, original_lang: original_lang) if original_lang != ''
+      end
       if ['rar', 'zip'].include?(extension)
         FileUtils.rm_r(torrent_path + '/extfls') if File.exist?(torrent_path + '/extfls')
         FileUtils.extract_archive(extension, full_p, torrent_path + '/extfls')


### PR DESCRIPTION
### Motivation
- Ensure downloaded video files have their original audio track flagged as default when possible. 
- Use the original language inferred from the filename metadata rather than prompting or re-parsing full metadata flows. 
- Limit the behavior to MKV containers and only when `mkvpropedit` is available to avoid unsafe operations. 
- Keep the change minimal and lean to avoid duplicating existing parsing work.

### Description
- Added a guarded block in `handle_completed_download` (`app/library.rb`) that runs only when the download matches `VALID_VIDEO_EXT`, the resolved media type is `movies` or `shows`, the file extension is `.mkv`, and `mkvpropedit` is available. 
- The code performs a lightweight call to `Metadata.parse_media_filename` to extract `info[:language]` from the filename and then calls `VideoUtils.set_default_original_audio!(path: full_p, original_lang: original_lang)` when a language is found. 
- The change is scoped to avoid double parsing and only triggers for MKV files to match the expectations of `VideoUtils.set_default_original_audio!`.

### Testing
- Ran `bundle exec rake test`, which failed because a dependency is not installed: `https://github.com/raphyduck/archive-zip.git is not yet checked out` and instructs to run `bundle install` first. 
- No other automated tests were executed in this environment due to the missing gem; code compiles and the patch was applied to `app/library.rb` successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d6a887ce883278f8cfedea816a6af)