### PR TITLE
Select default audio from audio track codes and avoid 'vo' normalization

### DIFF
--- a/app/library.rb
+++ b/app/library.rb
@@ -174,9 +174,7 @@ class Library
          %w[movies shows].include?(ttype) &&
          File.extname(full_p).downcase == '.mkv' &&
          system('command -v mkvpropedit >/dev/null 2>&1')
-        _, _, info = Metadata.parse_media_filename(full_p, ttype, nil, '', 1, folder_hierarchy, completed_folder + '/' + otype, { :name => full_p })
-        original_lang = info[:language].to_s
-        VideoUtils.set_default_original_audio!(path: full_p, original_lang: original_lang) if original_lang != ''
+        VideoUtils.set_default_original_audio!(path: full_p)
       end
       if ['rar', 'zip'].include?(extension)
         FileUtils.rm_r(torrent_path + '/extfls') if File.exist?(torrent_path + '/extfls')
@@ -375,8 +373,7 @@ class Library
     return files if identifiers.empty? || full_name == ''
     return files if file[:type].to_s == 'file' && !File.exist?(file[:name])
     if set_original_audio_default.to_i > 0 && file[:type].to_s == 'file'
-      original_lang = info[:language].to_s
-      VideoUtils.set_default_original_audio!(path: file[:name], original_lang: original_lang) if original_lang != ''
+      VideoUtils.set_default_original_audio!(path: file[:name])
     end
     app.speaker.speak_up("Adding #{file[:type]} '#{full_name}' (filename '#{File.basename(file[:name])}', ids '#{identifiers}') to list", 0) if Env.debug?
     if file[:type].to_s == 'file'

--- a/lib/video_utils.rb
+++ b/lib/video_utils.rb
@@ -21,12 +21,16 @@ class VideoUtils
     skipping
   end
 
-  def self.set_default_original_audio!(path:, original_lang:)
-    target_lang = Languages.get_code(original_lang.to_s)
-    return false if target_lang.to_s == ''
-
-    audio_tracks = FileInfo.new(path).getaudiochannels
+  def self.set_default_original_audio!(path:)
+    file_info = FileInfo.new(path)
+    audio_tracks = file_info.getaudiochannels
     return false if audio_tracks.empty?
+    target_lang = Languages.get_code(
+      audio_tracks.find do |audio|
+        audio && audio.language.to_s.strip.downcase != '' && !%w[und undefined].include?(audio.language.to_s.strip.downcase)
+      end&.language.to_s.split('-').first
+    )
+    return false if target_lang.to_s == ''
 
     selected_index = nil
     audio_tracks.each_with_index do |audio, index|


### PR DESCRIPTION
### Motivation
- Avoid treating non-language quality tags like `vo` as a real language when choosing a default audio track.
- Prefer deriving the target language from actual audio track language codes rather than `LANGUAGES`/quality tags.
- Keep callers simpler by removing the external `original_lang` parameter from `set_default_original_audio!`.
- Reduce allocations by reusing the fetched audio track list for both detection and selection.

### Description
- Changed `VideoUtils.set_default_original_audio!` signature to `set_default_original_audio!(path:)` and removed the `original_lang` argument.
- Derive `target_lang` from `FileInfo.new(path).getaudiochannels` language codes while skipping blank, `und`, and `undefined` values and splitting language subtags via `split('-').first` before mapping with `Languages.get_code`.
- Reused the `audio_tracks` array when both detecting the target language and iterating to choose the default track, and retained existing filters for commentary/title and `mkvpropedit` flag setting.
- Updated call sites to call `VideoUtils.set_default_original_audio!(path: ...)` without passing `original_lang`.

### Testing
- Ran `bundle exec rake test`, which failed because a `bundle install` is required and the `https://github.com/raphyduck/archive-zip.git` dependency is not checked out.
- No automated tests could complete due to the dependency installation issue.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ddc9f04b483279b39152856b0c5a3)