### PR TITLE
Trim process_folder to max_results only and enforce it in search_folder

### DIFF
--- a/app/library.rb
+++ b/app/library.rb
@@ -502,10 +502,11 @@ class Library
     return search_list, existing_files
   end
 
-  def self.process_folder(type:, folder:, item_name: '', remove_duplicates: 0, rename: {}, filter_criteria: {}, no_prompt: 0, folder_hierarchy: {}, cache_expiration: CACHING_TTL, set_original_audio_default: 0)
+  def self.process_folder(type:, folder:, item_name: '', remove_duplicates: 0, rename: {}, filter_criteria: {}, no_prompt: 0, folder_hierarchy: {}, cache_expiration: CACHING_TTL, set_original_audio_default: 0, max_results: nil)
     app.speaker.speak_up("Processing folder #{folder}...#{' for ' + item_name.to_s if item_name.to_s != ''}#{'(type: ' + type.to_s + ', folder: ' + folder.to_s + ', item_name: ' + item_name.to_s + ', remove_duplicates: ' + remove_duplicates.to_s + ', rename: ' + rename.to_s + ', filter_criteria: ' + filter_criteria.to_s + ', no_prompt: ' + no_prompt.to_s + ', folder_hierarchy: ' + folder_hierarchy.to_s + ')' if Env.debug?}", 0)
     files, raw_filtered, cache_name, media_list = nil, [], folder.to_s + type.to_s, {}
     file_criteria = { 'regex' => '.*' + item_name.to_s.gsub(/(\w*)\(\d+\)/, '\1').strip.gsub(/ /, '.') + '.*' }
+    file_criteria['max_results'] = max_results if max_results
     raw_filtered += FileUtils.search_folder(folder, filter_criteria.merge(file_criteria)) if filter_criteria && !filter_criteria.empty?
     Utils.lock_block(__method__.to_s + cache_name) {
       media_list = BusVariable.new('media_list', Vash)

--- a/lib/file_utils.rb
+++ b/lib/file_utils.rb
@@ -243,6 +243,7 @@ module FileUtils
       filter_criteria = {} if filter_criteria.nil?
       return [] unless folder && File.directory?(folder)
       search_folder = []
+      max_results = filter_criteria['max_results'].to_i
       Find.find(folder).each do |path|
         path = File.absolute_path(path)
         next if path == File.absolute_path(folder)
@@ -264,6 +265,7 @@ module FileUtils
             MediaLibrarian.app.str_closeness.getDistance(File.basename(path), filter_criteria['str_closeness_comp']) < filter_criteria['str_closeness'].to_i &&
             MediaLibrarian.app.str_closeness.getDistance(parent, filter_criteria['str_closeness_comp']) < filter_criteria['str_closeness'].to_i
         search_folder << [path, parent] if breakflag == 0
+        break if max_results > 0 && search_folder.length >= max_results
         if filter_criteria['maxdepth'].to_i > 0 && depth >= filter_criteria['maxdepth'].to_i
           Find.prune if FileTest.directory?(path)
         end


### PR DESCRIPTION
### Motivation
- Simplify the API by removing the `limit` alias and use a single `max_results` parameter for folder processing.
- Ensure the `max_results` cap is passed through to folder searches to avoid unnecessary scanning and work.
- Keep changes minimal and LEAN by only touching the callsites that propagate the limit and the search implementation.

### Description
- Updated `Library.process_folder` signature to remove `limit` and accept only `max_results` in `app/library.rb`.
- Injected `file_criteria['max_results'] = max_results` so the value is merged into folder search criteria before scans.
- Updated `FileUtils.search_folder` in `lib/file_utils.rb` to read `filter_criteria['max_results']` and `break` out of the `Find.find` loop once the collected results reach the cap.
- Changes are minimal and limited to `app/library.rb` and `lib/file_utils.rb`.

### Testing
- Ran `rake test`, which aborted because `bundle install` is required for the `archive-zip` dependency, so automated tests did not complete.
- No other automated test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695dee0a63488327acebbc73dd4f8c96)