### PR TITLE
Respect pretend flag for original audio defaulting

### DIFF
--- a/lib/video_utils.rb
+++ b/lib/video_utils.rb
@@ -22,6 +22,8 @@ class VideoUtils
   end
 
   def self.set_default_original_audio!(path:)
+    return MediaLibrarian.app.speaker.speak_up("Would set default original audio for #{path}") if Env.pretend?
+
     file_info = FileInfo.new(path)
     audio_tracks = file_info.getaudiochannels
     return false if audio_tracks.empty?


### PR DESCRIPTION
### Motivation
- Avoid performing real changes when the application is running in pretend mode by short-circuiting original-audio defaulting logic.  
- Prevent running external tools (like `mkvpropedit`) or inspecting files when the run is intended to be a dry-run.  
- Make behavior consistent with other file operations that already check `Env.pretend?`.  

### Description
- Added an early return at the start of `VideoUtils.set_default_original_audio!` to speak up and exit when `Env.pretend?` is true.  
- Change is implemented in `lib/video_utils.rb` and produces a descriptive `Would set default original audio for <path>` message via `MediaLibrarian.app.speaker.speak_up`.  
- No other functional logic was modified; the rest of the audio-selection and `mkvpropedit` invocation remain unchanged.  

### Testing
- Ran `bundle exec rake test`, which could not run because dependencies are not installed and `bundle install` is required (test run failed).  
- Verified the file change was applied to `lib/video_utils.rb` and inspected the updated function to confirm the pretend short-circuit.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695df015a42883279b3ac04f2849de02)