### PR TITLE
Rescan when media_list cache is empty in process_folder

### DIFF
--- a/app/library.rb
+++ b/app/library.rb
@@ -509,7 +509,7 @@ class Library
     raw_filtered += FileUtils.search_folder(folder, filter_criteria.merge(file_criteria)) if filter_criteria && !filter_criteria.empty?
     Utils.lock_block(__method__.to_s + cache_name) {
       media_list = BusVariable.new('media_list', Vash)
-      if media_list[cache_name].nil? || remove_duplicates.to_i > 0 || (rename && !rename.empty?)
+      if media_list[cache_name].nil? || media_list[cache_name].empty? || remove_duplicates.to_i > 0 || (rename && !rename.empty?)
         limit = max_results.to_i if max_results
         count = 0
         FileUtils.search_folder(folder, file_criteria.deep_merge(DEFAULT_FILTER_PROCESSFOLDER[type]) { |_, x1, x2| x1 + x2 }).each do |f|


### PR DESCRIPTION
### Motivation
- The cache check in `Library.process_folder` did not trigger a rescan when `media_list[cache_name]` existed but was empty, which could return a stale `{}` result.
- The change ensures an empty cache is treated like a missing cache so the folder is rescanned and media entries are populated.

### Description
- Modified the predicate in `app/library.rb` inside `process_folder` to also check `media_list[cache_name].empty?`.
- The new condition is `if media_list[cache_name].nil? || media_list[cache_name].empty? || remove_duplicates.to_i > 0 || (rename && !rename.empty?)` to force rescans for empty caches.
- No other logic or behavior was changed.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e1970a1648327b67dfd12c79cfbe4)