### PR TITLE
Document process_folder audio default CLI flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ This program is made to answer my various needs for automation in the management
   bundle exec ruby librarian.rb --config ~/.medialibrarian/conf.yml
   ```
 
+* Example: process a folder and force the original audio track as default when parsing media files:
+
+  ```bash
+  bundle exec ruby librarian.rb library process_folder --type=shows --folder=/path/to/folder --set_original_audio_default=1
+  ```
+
 The daemon logs to `~/.medialibrarian/logs/` by default, and jobs are queued according to the values configured in `conf.yml`.
 Finished job history is capped per queue (defaults to `finished_jobs_per_queue: 100` in `~/.medialibrarian/conf.yml`) to keep the
 in-memory registry bounded; raise or lower the limit to tune how many completed entries remain visible via `/status`.


### PR DESCRIPTION
### Motivation

- The change aims to surface the `set_original_audio_default` option for the `library process_folder` command so users can force the original audio track to be set as default when media files are parsed.
- The codebase already accepts `set_original_audio_default` in `Library.process_folder` and forwards it to `parse_media`, so documenting the CLI usage was needed for discoverability.

### Description

- Added a CLI usage example to `README.md` showing how to call `library process_folder` with `--set_original_audio_default=1`.
- The example demonstrates invoking the command via `bundle exec ruby librarian.rb library process_folder --type=shows --folder=/path/to/folder --set_original_audio_default=1`.

### Testing

- No automated tests were added or executed since this is a documentation-only change.
- Manual verification consisted of inspecting the updated `README.md` to confirm the example was added successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f84a453048327a27ee9f0f08470b8)