### PR TITLE
Use Open3.capture3 for mkvpropedit and report stderr

### DIFF
--- a/lib/video_utils.rb
+++ b/lib/video_utils.rb
@@ -81,7 +81,12 @@ class VideoUtils
     end
     return MediaLibrarian.app.speaker.speak_up("Would run the following command: '#{args.join(' ')}'") if Env.pretend?
 
-    system(*args)
+    _stdout, stderr, status = Open3.capture3(*args)
+    return true if status.success?
+
+    err_line = stderr.to_s.split("\n").first.to_s.strip
+    MediaLibrarian.app.speaker.speak_up("mkvpropedit failed: #{err_line}. Run: #{args.join(' ')}")
+    false
   end
 
   def self.mkv_audio_track_map(path)


### PR DESCRIPTION
### Motivation
- Replace `system(*args)` for `mkvpropedit` with a capture-based call so failures can be detected and surfaced.
- Provide a concise, actionable error message (stderr line + a hint) instead of silent failure.
- Keep the change minimal and LEAN to avoid bloat.

### Description
- Switch `mkvpropedit` invocation to `Open3.capture3(*args)` and ignore stdout via `_stdout`.
- Return `true` when the command succeeds and `false` on failure.
- On failure, extract the first stderr line and call `MediaLibrarian.app.speaker.speak_up` with the short error plus a hint to run the command manually.
- Preserve existing `Env.pretend?` and debug behaviors and leave `mkv_audio_track_map` unchanged.

### Testing
- Ran `bundle exec rake test`, which failed because bundler dependencies were not installed.
- Started `bundle install` to fetch gems but the process was interrupted before completion.
- No automated test run completed successfully due to the interrupted dependency installation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ffeea57908327b5975940babd752b)