### PR TITLE
Prefer mkvmerge track number for mkvpropedit track selection

### DIFF
--- a/lib/video_utils.rb
+++ b/lib/video_utils.rb
@@ -109,8 +109,9 @@ class VideoUtils
     tracks.filter_map do |track|
       next unless track['type'] == 'audio'
       properties = track.fetch('properties', {})
+      edit_id = properties['number'] || properties['track_number'] || track['id']
       {
-        id: track['id'],
+        id: edit_id,
         lang: properties['language'].to_s.downcase,
         name: properties['track_name'].to_s,
         commentary: properties['flag_commentary'],


### PR DESCRIPTION
### Motivation
- `mkvpropedit` was failing to find the right audio track when the `id` from `mkvmerge -J` did not match the edit index `mkvpropedit` expects.
- `mkvmerge` exposes numeric fields like `number` or `track_number` in `tracks[].properties` which correspond to the edit IDs used by `mkvpropedit`.
- The intent is to avoid mismatched track identifiers and reduce `mkvpropedit` failures by selecting the appropriate edit ID.

### Description
- Update `mkv_audio_track_map` to prefer `properties['number']` or `properties['track_number']` when present, falling back to `track['id']` otherwise.
- Return the chosen `edit_id` as the `:id` for each audio track so callers use the correct identifier for `mkvpropedit` edits.
- Change is minimal and localized to `lib/video_utils.rb` (the JSON parsing/track mapping logic).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69600a0f8fa883279d2ffc43168d3f78)