### PR TITLE
Fix mkvpropedit track id selection

### DIFF
--- a/lib/video_utils.rb
+++ b/lib/video_utils.rb
@@ -109,7 +109,7 @@ class VideoUtils
     tracks.filter_map do |track|
       next unless track['type'] == 'audio'
       properties = track.fetch('properties', {})
-      edit_id = properties['number'] || properties['track_number'] || track['id']
+      edit_id = track['id'] || properties['number'] || properties['track_number']
       {
         id: edit_id,
         lang: properties['language'].to_s.downcase,


### PR DESCRIPTION
### Motivation

- mkvpropedit was likely being invoked with the wrong track identifier leading to failures when updating track flags. 
- The mkvmerge JSON output includes a top-level `id` which is the correct edit ID to use for `mkvpropedit` edits. 

### Description

- Update `mkv_audio_track_map` in `lib/video_utils.rb` to prefer `track['id']` when computing the edit id. 
- This ensures the `--edit track:@<id>` arguments built for `mkvpropedit` use the mkvmerge-provided track IDs. 

### Testing

- Attempted to run `bundle exec rake test`, but it initially refused because `bundle install` had not been run. (failed)
- Ran `bundle install` which began fetching and installing gems but the process was interrupted, leaving the environment incomplete. (interrupted)
- Re-running `bundle exec rake test` afterwards failed due to a missing `sqlite3` gem, so test suite could not be executed successfully. (failed)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69600c1400308327896d74186455d4cb)