### PR TITLE
Prefer mkv property number for edit IDs and fix mkvpropedit track syntax

### DIFF
--- a/lib/video_utils.rb
+++ b/lib/video_utils.rb
@@ -66,7 +66,7 @@ class VideoUtils
     args = ['mkvpropedit', path]
     track_map.each do |track|
       flag = (track[:id] == selected_track_id) ? '1' : '0'
-      args += ['--edit', "track:@#{track[:id]}", '--set', "flag-default=#{flag}"]
+      args += ['--edit', "track:#{track[:id]}", '--set', "flag-default=#{flag}"]
     end
     return MediaLibrarian.app.speaker.speak_up("Would run the following command: '#{args.join(' ')}'") if Env.pretend?
 
@@ -109,7 +109,16 @@ class VideoUtils
     tracks.filter_map do |track|
       next unless track['type'] == 'audio'
       properties = track.fetch('properties', {})
-      edit_id = track['id'] || properties['number'] || properties['track_number']
+      edit_id = properties['number'] || properties['track_number'] || track['id']
+      id_source = if properties.key?('number')
+                    "properties['number']"
+                  elsif properties.key?('track_number')
+                    "properties['track_number']"
+                  else
+                    "track['id']"
+                  end
+      MediaLibrarian.app.speaker.speak_up("mkv audio edit id from #{id_source}: #{edit_id}", 0) if Env.debug?
+      next if edit_id.nil?
       {
         id: edit_id,
         lang: properties['language'].to_s.downcase,


### PR DESCRIPTION
### Motivation
- Use the mkvmerge-provided track edition identifier when available instead of the JSON `track['id']` to ensure `mkvpropedit` addresses the correct edit entry.
- Prevent `mkvpropedit` from using incompatible identifiers like `@0` by constructing `--edit` args with the edit id that mkvmerge exposes.
- Make it easier to diagnose which field was chosen for edit id by emitting a debug message when `Env.debug?`.

### Description
- Change `mkv_audio_track_map` to prefer `properties['number']` then `properties['track_number']` and only fall back to `track['id']`, and skip tracks with no edit id.
- Add a debug log that states which source (`properties['number']`, `properties['track_number']`, or `track['id']`) produced the chosen edit id.
- Update `set_default_original_audio!` to build `mkvpropedit` edits using `--edit 'track:<id>'` (no `@`) so the identifier matches mkvmerge/mkvpropedit expectations.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960c7d734308327afb1adc544608bdf)