### PR TITLE
Prefer mkvmerge track id for mkvpropedit audio track selection

### DIFF
--- a/lib/video_utils.rb
+++ b/lib/video_utils.rb
@@ -109,13 +109,13 @@ class VideoUtils
     tracks.filter_map do |track|
       next unless track['type'] == 'audio'
       properties = track.fetch('properties', {})
-      edit_id = properties['number'] || properties['track_number'] || track['id']
-      id_source = if properties.key?('number')
-                    "properties['number']"
-                  elsif properties.key?('track_number')
-                    "properties['track_number']"
-                  else
+      edit_id = track['id'] || properties['number'] || properties['track_number']
+      id_source = if track.key?('id')
                     "track['id']"
+                  elsif properties.key?('number')
+                    "properties['number']"
+                  else
+                    "properties['track_number']"
                   end
       MediaLibrarian.app.speaker.speak_up("mkv audio edit id from #{id_source}: #{edit_id}", 0) if Env.debug?
       next if edit_id.nil?


### PR DESCRIPTION
### Motivation

- mkvpropedit was sometimes targeting the wrong audio track because property numbers were used before the mkvmerge track identifier.
- Files with audio tracks where `properties['number']` or `properties['track_number']` differ from the mkvmerge `track['id']` caused incorrect default audio selection.
- Using the mkvmerge-provided `track['id']` is the most reliable identifier for later `mkvpropedit` operations.
- Debug logging should report the actual identifier source used to aid troubleshooting.

### Description

- Change the edit id selection order to prefer `track['id']` before `properties['number']` and `properties['track_number']`.
- Update the `id_source` debug message to reflect the chosen identifier (`track['id']`, `properties['number']`, or `properties['track_number']`).
- No other functional behavior was changed; the JSON parse rescue and returned track hash remain the same.
- Keep the `mkvmerge` presence check and parsing flow intact.

### Testing

- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960d277d0448327bee67ba38fb4b7dd)