### PR TITLE
Handle localized mkvpropedit error

### DIFF
--- a/lib/video_utils.rb
+++ b/lib/video_utils.rb
@@ -72,7 +72,7 @@ class VideoUtils
 
     stdout, stderr, status = Open3.capture3(*args)
     stderr_text = stderr.to_s
-    if stderr_text.match?(/Tracks/i) && stderr_text.match?(/failed|échoué/i) && stderr_text.match?(/unknown error/i)
+    if stderr_text.match?(/Tracks/i) && stderr_text.match?(/failed|échoué/i) && stderr_text.match?(/unknown error|erreur inconnue/i)
       dir = File.dirname(path)
       tmp_path = File.join(dir, ".#{File.basename(path, '.*')}.remux#{File.extname(path)}")
       remux_out, remux_err, remux_status = Open3.capture3('mkvmerge', '-o', tmp_path, path)


### PR DESCRIPTION
### Motivation
- `mkvpropedit` can emit localized messages (e.g., French) which prevented the existing remux fallback from triggering when a known "Tracks update failed" condition occurred.
- Broaden the stderr detection to catch the same failure across locales while keeping the remux path narrowly targeted.
- Keep the change minimal and focused to avoid bloating the logic.

### Description
- Updated the condition in `VideoUtils.set_default_original_audio!` (`lib/video_utils.rb`) to match `stderr` against `/unknown error|erreur inconnue/i` in addition to the existing checks.
- The remux fallback using `mkvmerge` and the retry of `mkvpropedit` remain unchanged and only run when the localized error pattern matches.
- No other functional changes were made.

### Testing
- Attempted to run `bundle exec rake test`, which failed due to a missing dependency requiring `bundle install` (archive-zip not checked out).
- No automated tests were executed successfully due to the dependency issue.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960fc5b6198832799bf8a0c9b2013fe)