### PR TITLE
Adjust mkvpropedit error detection to use combined stdout/stderr

### DIFF
--- a/lib/video_utils.rb
+++ b/lib/video_utils.rb
@@ -71,26 +71,26 @@ class VideoUtils
     return MediaLibrarian.app.speaker.speak_up("Would run the following command: '#{args.join(' ')}'") if Env.pretend?
 
     stdout, stderr, status = Open3.capture3(*args)
-    stderr_text = stderr.to_s
-    if stderr_text.match?(/Tracks/i) && stderr_text.match?(/failed|échoué/i) && stderr_text.match?(/unknown error|erreur inconnue/i)
+    combined_text = "#{stderr} #{stdout}".to_s
+    if combined_text.match?(/Tracks/i) && combined_text.match?(/failed|échoué/i) && combined_text.match?(/unknown error|erreur inconnue/i)
       dir = File.dirname(path)
       tmp_path = File.join(dir, ".#{File.basename(path, '.*')}.remux#{File.extname(path)}")
       remux_out, remux_err, remux_status = Open3.capture3('mkvmerge', '-o', tmp_path, path)
       unless remux_status.success?
-        MediaLibrarian.app.speaker.speak_up("mkvmerge remux failed: #{remux_err.to_s.strip} stdout: #{remux_out.to_s.strip}")
+        MediaLibrarian.app.speaker.speak_up("mkvmerge remux failed: #{remux_err.to_s.strip} stdout: #{remux_out.to_s.strip} (mkvpropedit: #{combined_text.strip})")
         return false
       end
       tmp_args = args.dup
       tmp_args[1] = tmp_path
       tmp_out, tmp_err, tmp_status = Open3.capture3(*tmp_args)
       unless tmp_status.success?
-        MediaLibrarian.app.speaker.speak_up("mkvpropedit failed on remuxed file: #{tmp_err.to_s.strip} stdout: #{tmp_out.to_s.strip}")
+        MediaLibrarian.app.speaker.speak_up("mkvpropedit failed on remuxed file: #{tmp_err.to_s.strip} stdout: #{tmp_out.to_s.strip} (mkvpropedit: #{combined_text.strip})")
         return false
       end
       FileUtils.mv(path, "#{path}.bak")
       FileUtils.mv(tmp_path, path)
     elsif !status.success?
-      message = "mkvpropedit failed: #{stderr_text.strip}"
+      message = "mkvpropedit failed: #{stderr.to_s.strip}"
       stdout_line = stdout.to_s.strip
       message += " stdout: #{stdout_line}" unless stdout_line.empty?
       MediaLibrarian.app.speaker.speak_up("#{message}. Run: #{args.join(' ')}")


### PR DESCRIPTION
### Motivation
- Ensure the error detection for `mkvpropedit` catches messages that may appear in either `stdout` or `stderr` when deciding to run the remux fallback. 
- Preserve the original `mkvpropedit` error context in logs when the remux fallback (`mkvmerge`) or a subsequent `mkvpropedit` run fails. 
- Keep the change compact and avoid duplicating error-handling code. 

### Description
- In `VideoUtils.set_default_original_audio!` (in `lib/video_utils.rb`) capture `stdout` and `stderr` and build a `combined_text = "#{stderr} #{stdout}"` for matching the error pattern instead of inspecting `stderr` alone. 
- Use `combined_text` to decide whether to run the remux fallback with `mkvmerge`. 
- Include the trimmed `combined_text` in diagnostic messages when `mkvmerge` or the remuxed `mkvpropedit` invocation fails, and streamline the fallback logging logic. 

### Testing
- No automated tests were executed for this change. 
- The repository and modified file were saved and committed as `lib/video_utils.rb` but no unit or integration test run was performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960fe33532c83278a5a2999e48642f0)