### PR TITLE
Unify original language detection for default audio

### DIFF
--- a/app/library.rb
+++ b/app/library.rb
@@ -174,7 +174,7 @@ class Library
          %w[movies shows].include?(ttype) &&
          File.extname(full_p).downcase == '.mkv' &&
          system('command -v mkvpropedit >/dev/null 2>&1')
-        VideoUtils.set_default_original_audio!(path: full_p)
+        VideoUtils.set_default_original_audio!(path: full_p, type: ttype)
       end
       if ['rar', 'zip'].include?(extension)
         FileUtils.rm_r(torrent_path + '/extfls') if File.exist?(torrent_path + '/extfls')
@@ -371,7 +371,15 @@ class Library
     return files if identifiers.empty? || full_name == ''
     return files if file[:type].to_s == 'file' && !File.exist?(file[:name])
     if set_original_audio_default.to_i > 0 && file[:type].to_s == 'file'
-      VideoUtils.set_default_original_audio!(path: file[:name])
+      VideoUtils.set_default_original_audio!(
+        path: file[:name],
+        type: type,
+        item_name: item_name,
+        item: item,
+        no_prompt: no_prompt,
+        folder_hierarchy: folder_hierarchy,
+        base_folder: base_folder
+      )
     end
     app.speaker.speak_up("Adding #{file[:type]} '#{full_name}' (filename '#{File.basename(file[:name])}', ids '#{identifiers}') to list", 0) if Env.debug?
     if file[:type].to_s == 'file'

--- a/lib/metadata.rb
+++ b/lib/metadata.rb
@@ -84,6 +84,15 @@ class Metadata
     metadata
   end
 
+  def self.original_language_for(path:, type:, item_name: '', item: nil, no_prompt: 1, folder_hierarchy: {}, base_folder: Dir.home)
+    return '' if type.to_s == ''
+    _, _, info = parse_media_filename(path, type, item, item_name, no_prompt, folder_hierarchy, base_folder, {})
+    language = info[:language].to_s
+    return '' if language == ''
+    normalized = Languages.get_code(language.split('-').first)
+    normalized.to_s == '' ? language : normalized
+  end
+
   def self.identify_title(filename, type, no_prompt = 0, folder_level = 2, base_folder = Dir.home, ids = {})
     ids = {} if ids.nil?
     title, item, original_filename = nil, nil, nil

--- a/lib/video_utils.rb
+++ b/lib/video_utils.rb
@@ -24,7 +24,7 @@ class VideoUtils
     skipping
   end
 
-  def self.set_default_original_audio!(path:)
+  def self.set_default_original_audio!(path:, type: nil, item_name: '', item: nil, no_prompt: 1, folder_hierarchy: {}, base_folder: Dir.home)
     return MediaLibrarian.app.speaker.speak_up("Would set default original audio for #{path}") if Env.pretend?
 
     return false unless File.extname(path).downcase == '.mkv'
@@ -44,7 +44,18 @@ class VideoUtils
       commentary = audio[:commentary].to_s.downcase
       !%w[yes true 1].include?(commentary)
     end
-    target_lang = Languages.get_code(track_map.find(&valid_audio)&.dig(:lang).to_s.split('-').first)
+    target_lang = Metadata.original_language_for(
+      path: path,
+      type: type,
+      item_name: item_name,
+      item: item,
+      no_prompt: no_prompt,
+      folder_hierarchy: folder_hierarchy,
+      base_folder: base_folder
+    )
+    if target_lang.to_s == ''
+      target_lang = Languages.get_code(track_map.find(&valid_audio)&.dig(:lang).to_s.split('-').first)
+    end
     MediaLibrarian.app.speaker.speak_up("Default audio language target: #{target_lang}", 0) if Env.debug?
     return false if target_lang.to_s == ''
 


### PR DESCRIPTION
### Motivation
- Ensure default-audio selection uses the same filename/folder metadata parsing as other metadata flows to avoid duplicated logic.
- Keep the change minimal and lean by adding a small helper that reuses `parse_media_filename` instead of reimplementing parsing.
- Preserve existing guardrails (non-`.mkv`, missing `mkvpropedit`, empty track map) and fall back to current track-based detection when metadata yields no language.

### Description
- Add `Metadata.original_language_for(path:, type:, item_name: '', item: nil, no_prompt: 1, folder_hierarchy: {}, base_folder: Dir.home)` which calls `parse_media_filename` and returns a normalized code via `Languages.get_code` (or raw language if normalization is empty).
- Change `VideoUtils.set_default_original_audio!` signature to accept optional media context and use `Metadata.original_language_for` first, falling back to the previous `Languages.get_code(track_lang)` logic when blank.
- Update call sites in `app/library.rb` to pass `type` and available media context into `VideoUtils.set_default_original_audio!` while keeping the surface area small.

### Testing
- Ran `bundle exec rake test`, which failed because dependencies are not installed and `bundle install` is required, so automated tests could not be completed.
- Basic repository sanity checks (`git status`) and local commits were performed and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696114d6f04883278e1a1ef8a8aae915)