### PR TITLE
Show routed command when dispatching to daemon and acknowledge job without waiting

### DIFF
--- a/librarian.rb
+++ b/librarian.rb
@@ -203,14 +203,15 @@ class Librarian
       elsif app.librarian.pid_status(app.pidfile) == :running && proxy_internal.to_i.zero?
         return if args.nil? || args.empty?
 
-        app.speaker.speak_up('A daemon is already running, sending execution there and waiting to get an execution slot')
+        app.speaker.speak_up('A daemon is already running, sending execution there and waiting for acknowledgement')
+        app.speaker.speak_up("Routing command to daemon: #{Array(args).join(' ')}")
         response = Client.new.enqueue(
           args,
-          wait: true,
+          wait: false,
           queue: queue,
           task: task,
           internal: proxy_internal,
-          capture_output: true
+          capture_output: false
         )
         status_code = response['status_code'].to_i
         body = response['body']
@@ -226,13 +227,9 @@ class Librarian
           app.speaker.speak_up("Daemon rejected the job: #{message}")
         elsif body && body['job']
           job = body['job']
-          output = job['output'].to_s
-          app.speaker.speak_up(output, 0) unless output.empty?
-          if job['error']
-            app.speaker.speak_up("Job #{job['id']} failed: #{job['error']}")
-          else
-            app.speaker.speak_up("Job #{job['id']} completed")
-          end
+          status = job['status'].to_s
+          status = 'queued' if status.empty?
+          app.speaker.speak_up("Job #{job['id']} acknowledged (status: #{status})")
         else
           app.speaker.speak_up('Command dispatched to daemon')
         end


### PR DESCRIPTION
### Motivation

- Avoid blocking the CLI while the daemon executes long-running jobs so commands return as soon as the daemon acknowledges them.
- Ensure the user still sees the routed command in the terminal even when execution is dispatched to a running daemon.

### Description

- Echo the routed command via `app.speaker.speak_up("Routing command to daemon: #{Array(args).join(' ')}")` in `librarian.rb` when dispatching to a running daemon.
- Preserve the non-blocking dispatch behavior by calling `Client.new.enqueue` with `wait: false` and `capture_output: false`.
- Update user-facing text to indicate the CLI is "waiting for acknowledgement" and report job acknowledgement with its `status` instead of streaming job output.

### Testing

- Ran `bundle exec rake test`, which failed due to missing bundle dependencies (`is not yet checked out; run `bundle install` first`).
- No other automated test suite was executed after the dependency issue prevented running the tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69615c8989ec8327a8e937d8aa8f168b)