### PR TITLE
Add SQLite lock file to enforce single instance

### DIFF
--- a/lib/storage/db.rb
+++ b/lib/storage/db.rb
@@ -4,6 +4,7 @@ require 'json'
 require 'sequel'
 require 'time'
 require 'date'
+require 'socket'
 
 Sequel.extension :migration
 
@@ -14,6 +15,7 @@ module Storage
     def initialize(db_path, readonly = 0, migrations_path: default_migrations_path)
       @db_path = db_path
       @readonly = readonly.to_i.positive?
+      acquire_db_lock
       @database = Sequel.connect(adapter: 'sqlite', database: db_path, readonly: @readonly, timeout: 5000)
       if @database.database_type == :sqlite
         configure_sqlite
@@ -185,6 +187,29 @@ module Storage
 
     def default_migrations_path
       File.expand_path('../db/migrations', __dir__)
+    end
+
+    def acquire_db_lock
+      return if ENV['ALLOW_DB_SHARED'] == '1'
+
+      lock_path = "#{@db_path}.lock"
+      @lock_file = File.open(lock_path, 'w')
+      locked = @lock_file.flock(File::LOCK_EX | File::LOCK_NB)
+      return write_lock_info if locked
+
+      holder = File.read(lock_path).strip
+      holder = 'unknown' if holder.empty?
+      message = "Database lock already held by #{holder} for #{@db_path}"
+      speaker&.speak_up(message)
+      warn(message)
+      exit(1)
+    end
+
+    def write_lock_info
+      @lock_file.rewind
+      @lock_file.truncate(0)
+      @lock_file.write("#{Process.pid}@#{Socket.gethostname}")
+      @lock_file.flush
     end
 
     def deserialize_row(row)


### PR DESCRIPTION
### Motivation

- Prevent multiple processes from opening the same SQLite database concurrently to avoid corruption.
- Fail fast when another process holds the DB lock and provide owner info (PID@hostname).
- Allow an escape hatch for advanced setups via an environment variable.

### Description

- Added a `require 'socket'` and call to `acquire_db_lock` in `initialize` of `lib/storage/db.rb`.
- Implemented `acquire_db_lock` which opens `#{@db_path}.lock`, calls `flock(LOCK_EX | LOCK_NB)`, and keeps the descriptor in `@lock_file` for the process lifetime.
- When locked, `write_lock_info` writes `Process.pid@Socket.gethostname` into the lock file, and if the lock cannot be obtained the code logs the holder and exits unless `ALLOW_DB_SHARED=1` is set.
- Logging uses the existing `speaker` where available and also issues a `warn` before exiting.

### Testing

- Ran `bundle exec rake test`, which failed to run because `bundle install` is required to checkout dependencies (archive-zip), so tests did not complete.
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696235431c488327b7c88e6073b982f0)