### PR TITLE
Use dataset fetch for SQLite quick_check

### DIFF
--- a/lib/storage/db.rb
+++ b/lib/storage/db.rb
@@ -344,7 +344,7 @@ module Storage
     end
 
     def verify_sqlite
-      result = database.get(Sequel.lit('PRAGMA quick_check'))
+      result = database.fetch('PRAGMA quick_check').single_value
       return if result.to_s == 'ok'
 
       message = "SQLite quick_check failed for #{@db_path}: #{result}"


### PR DESCRIPTION
### Motivation
- Ensure `PRAGMA quick_check` is executed directly so SQLite returns the integrity-check result rather than being treated like a column by Sequel.
- Prefer the Sequel dataset/fetch API for PRAGMA queries to make behavior explicit and reliable.

### Description
- In `lib/storage/db.rb` (`verify_sqlite`) replace `database.get(Sequel.lit('PRAGMA quick_check'))` with `database.fetch('PRAGMA quick_check').single_value` to read the PRAGMA result directly.
- This is a minimal change focused on using Sequel's dataset API for PRAGMA execution and keeps the code lean.

### Testing
- Ran `bundle exec rake test` but it failed because dependencies were not installed and `bundle install` is required, so tests did not run.
- Started `bundle install`; installation progressed but was interrupted before the test suite could be executed to completion.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69623de9c2e48327aec7285cd622a17b)