### PR TITLE
Require sqlite3 before Storage::Db error handling

### DIFF
--- a/lib/storage/db.rb
+++ b/lib/storage/db.rb
@@ -2,6 +2,7 @@
 
 require 'json'
 require 'sequel'
+require 'sqlite3'
 require 'time'
 require 'date'
 require 'socket'


### PR DESCRIPTION
### Motivation

- Ensure the `SQLite3` constant is defined before any `rescue` clauses reference `SQLite3::CorruptException` to avoid NameError during error handling.  
- The change targets the minimal point of failure surface where `Storage::Db` rescues SQLite-specific exceptions across multiple methods.  
- Keep the code lean by adding a single explicit require rather than introducing extra boot files or refactors.  

### Description

- Added a single `require 'sqlite3'` near the top of `lib/storage/db.rb` so the constant is available when the class is defined.  
- This is a minimal, in-place fix and does not change runtime logic or behavior besides ensuring exception classes are resolvable.  
- The file change was committed with the message `Require sqlite3 before using Storage::Db`.  

### Testing

- Ran `bundle exec rake test` to exercise the test suite and it failed due to missing dependencies requiring `bundle install`.  
- No automated tests passed in this environment because a dependency (`archive-zip` git checkout) was not yet checked out, so test execution was aborted.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69623fa1cf948327af002eb9c842ffd4)