### PR TITLE
Lazy-initialize container database connection

### DIFF
--- a/lib/media_librarian/container.rb
+++ b/lib/media_librarian/container.rb
@@ -47,7 +47,7 @@ module MediaLibrarian
     end
 
     def db
-      services.fetch(:db)
+      services[:db] ||= Storage::Db.new(File.join(application.config_dir, 'librarian.db'))
     end
 
     def db=(value)
@@ -136,8 +136,6 @@ module MediaLibrarian
       log_path, error_log_path = Logger.log_paths(log_dir)
       store(:speaker, SimpleSpeaker::Speaker.new(log_path, error_log_path), freeze: false)
       store(:args_dispatch, SimpleArgsDispatch::Agent.new(speaker, application.env_flags), freeze: false)
-
-      store(:db, Storage::Db.new(File.join(application.config_dir, 'librarian.db')), freeze: false)
 
       store(:trackers, build_trackers)
 


### PR DESCRIPTION
### Motivation
- Avoid eager DB creation during container boot which holds a lock in CLI-only dispatch paths.
- Defer creation of the DB until it is actually needed to eliminate the startup lock while preserving behavior for daemon/worker processes.
- Keep changes minimal and straightforward, with no extra indirection.

### Description
- Change `Container#db` to lazily initialize and cache the DB with `services[:db] ||= Storage::Db.new(File.join(application.config_dir, 'librarian.db'))`.
- Remove the eager `store(:db, Storage::Db.new(...))` call from `bootstrap!` so the DB is not created at boot.
- Leave the existing `db=` setter and other service wiring untouched to minimize impact.

### Testing
- Ran `bundle exec rake test`, which failed due to missing dependency checkout (`archive-zip` needs `bundle install`).
- No automated tests were added or modified for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696240eb0f5083279d20b3ee4df5ebaa)