### PR TITLE
Handle array-root template commands

### DIFF
--- a/test/daemon_integration_test.rb
+++ b/test/daemon_integration_test.rb
@@ -323,6 +323,26 @@ class DaemonIntegrationTest < Minitest::Test
     assert_equal 'torrenting', beta['queue']
   end
 
+  def test_template_commands_endpoint_supports_array_root_templates
+    boot_daemon_environment do
+      create_yaml_file(
+        @environment.application.template_dir,
+        'array_root.yml',
+        [
+          { 'command' => 'torrent.search' }
+        ]
+      )
+    end
+
+    response = control_get('/template_commands')
+    assert_equal 200, response[:status_code]
+
+    commands = response.fetch(:body).fetch('commands')
+    entry = commands.find { |item| item['name'] == 'array_root' }
+    refute_nil entry
+    assert_equal %w[torrent search], entry.fetch('command')
+  end
+
   def test_tracker_endpoint_updates_registry_after_save
     boot_daemon_environment do
       create_yaml_file(@environment.application.tracker_dir,


### PR DESCRIPTION
### Motivation
- Support discovery of command templates when a template YAML file is rooted as an `Array` instead of a `Hash` so commands like `torrent.search` are picked up correctly.
- The previous implementation skipped array-root templates and therefore missed valid command entries in user templates.
- Make a minimal, focused change to extend parsing behavior without introducing extra complexity.

### Description
- Update `template_file_commands` in `app/daemon.rb` to accept both `Hash` and `Array` roots and to iterate array items through `template_command_nodes` when present.
- Consolidate nodes into a `nodes` collection and call `build_template_command_entry` via `filter_map` unchanged from existing flow.
- Add integration test `test_template_commands_endpoint_supports_array_root_templates` in `test/daemon_integration_test.rb` to cover array-root template command files.

### Testing
- Attempted to run `bundle exec ruby -Itest test/daemon_integration_test.rb -n "/template_commands_endpoint/"`, but it failed because the bundle was not installed.
- Ran `bundle install` to install dependencies, but the install was interrupted and tests were not executed to completion.
- No automated tests were run to completion in this environment after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69624e8874248327875a263bcd758d8f)