### PR TITLE
Ensure daemon child logs flush immediately

### DIFF
--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -505,7 +505,7 @@ class Daemon
       Utils.lock_time_merge(thread, parent)
       return if parent[:email_msg].nil?
 
-      app.speaker.speak_up(thread[:log_msg].to_s, -1, parent) if thread[:log_msg]
+      app.speaker.speak_up(thread[:log_msg].to_s, -1, parent, 1) if thread[:log_msg]
       parent[:email_msg] << thread[:email_msg].to_s
       parent[:send_email] = thread[:send_email].to_i if thread[:send_email].to_i.positive?
     end

--- a/lib/simple_speaker.rb
+++ b/lib/simple_speaker.rb
@@ -56,7 +56,7 @@ module SimpleSpeaker
     end
 
     def speak_up(str, in_mail = 1, thread = Thread.current, immediate = 0)
-      thread[:log_msg] << str.to_s + @new_line if thread[:log_msg]
+      thread[:log_msg] << str.to_s + @new_line if thread[:log_msg] && immediate.to_i <= 0
       if immediate.to_i > 0 || thread[:log_msg].nil?
         str.to_s.each_line do |l|
           daemon_send(l)


### PR DESCRIPTION
### Motivation
- Daemon-run commands (e.g. `process_folder`) were missing lines in the log because child-job output was being buffered instead of flushed to the parent/daemon stream.
- Child job logs need to be written immediately so the daemon control client receives complete output and the log file contains all lines.

### Description
- Update `SimpleSpeaker::Speaker#speak_up` to only append to `thread[:log_msg]` when `immediate` is not requested, avoiding double-buffering when immediate flush is required (`lib/simple_speaker.rb`).
- Call `speak_up` with the `immediate` flag when merging child notifications in `Daemon.merge_notifications` so child log buffers are flushed into the parent immediately (`app/daemon.rb`).

### Testing
- Attempted to run the daemon job control unit tests with `bundle exec ruby -Itest test/daemon_job_control_test.rb` but the run failed due to missing bundle setup: `bundle install` required (dependency `https://github.com/raphyduck/archive-zip.git` not checked out), so tests were not executed.
- Ran quick static verification of changed files and committed the patch successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696253476324832796e72847a13107a7)