### PR TITLE
Skip DB locking for forwarded CLI jobs

### DIFF
--- a/librarian.rb
+++ b/librarian.rb
@@ -204,6 +204,7 @@ class Librarian
         return if args.nil? || args.empty?
 
         app.speaker.speak_up('A daemon is already running, sending execution there and waiting for acknowledgement')
+        ENV['MEDIA_LIBRARIAN_CLIENT_MODE'] = '1'
         response = Client.new.enqueue(
           args,
           wait: true,


### PR DESCRIPTION
### Motivation
- Prevent CLI processes that merely forward commands to the daemon from acquiring the SQLite DB lock and creating `.lock` files to avoid contention.
- Treat forwarded CLI executions as client/forward-only so they use readonly DB connections rather than competing for the daemon's exclusive lock.
- Provide a clear, minimal signal to indicate client/forward-only mode using an environment flag so the signal can be propagated to `Storage::Db`.
- Keep daemon behavior unchanged so the daemon retains exclusive locking responsibility.

### Description
- When dispatching to the daemon, set the client-only flag by assigning `ENV['MEDIA_LIBRARIAN_CLIENT_MODE'] = '1'` in `librarian.rb` before calling the `Client` API.
- In `Storage::Db#initialize`, read the flag into `@forward_only` and mark the DB connection as readonly by setting `@readonly` when `@forward_only` is true.
- Modify `acquire_db_lock` to return early (skip locking) when `@forward_only` is true or when `ENV['ALLOW_DB_SHARED'] == '1'`.
- Changes are minimal and local to `librarian.rb` and `lib/storage/db.rb`, with no changes to daemon lock-handling logic.

### Testing
- Attempted to run `bundle exec ruby -Itest test/daemon_cli_stop_test.rb`, but it failed because `bundle install` has not been run in this environment (dependency checkout required).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962743573c48327bab2be101472b6b6)