### PR TITLE
Skip DB initialization for client-only commands

### DIFF
--- a/init/db.rb
+++ b/init/db.rb
@@ -1,8 +1,10 @@
 require_relative '../boot/librarian'
 
-# Set up and open app DB
-container = MediaLibrarian::Boot.container
-app = container.application
+unless ENV['MEDIA_LIBRARIAN_CLIENT_MODE'] == '1'
+  # Set up and open app DB
+  container = MediaLibrarian::Boot.container
+  app = container.application
 
-# Accessing through the container eagerly materializes the shared services.
-app.db
+  # Accessing through the container eagerly materializes the shared services.
+  app.db
+end


### PR DESCRIPTION
### Motivation
- Prevent client-only commands from initializing or locking the application DB during bootstrap.
- Avoid `daemon status`/`daemon stop` touching the DB when invoked in client mode to prevent lock/conflict scenarios.

### Description
- Guarded DB initialization in `init/db.rb` with `unless ENV['MEDIA_LIBRARIAN_CLIENT_MODE'] == '1'` so `app.db` is not called when client mode is active.
- Change is minimal and localized to `init/db.rb` to keep the bootstrap lean.

### Testing
- Ran `bundle exec ruby -c init/db.rb` to verify the file syntax, which returned `Syntax OK`.
- No other automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962778cf1a48327bb828ea3922873b3)