### PR TITLE
Preserve DB lock holder when opening lock file

### DIFF
--- a/lib/storage/db.rb
+++ b/lib/storage/db.rb
@@ -199,7 +199,7 @@ module Storage
       return if @forward_only || ENV['ALLOW_DB_SHARED'] == '1'
 
       lock_path = "#{@db_path}.lock"
-      @lock_file = File.open(lock_path, 'w')
+      @lock_file = File.open(lock_path, 'a+')
       locked = @lock_file.flock(File::LOCK_EX | File::LOCK_NB)
       return write_lock_info if locked
 


### PR DESCRIPTION
### Motivation

- Prevent the lock file from being truncated when opening it to acquire an exclusive lock so existing holder information is preserved.
- Ensure the process reports the original lock holder when the lock cannot be obtained.
- Keep truncation and write of the process identity strictly after the lock is successfully acquired.

### Description

- Open the DB lock file with `File.open(lock_path, 'a+')` instead of `'w'` to avoid clearing contents on open.
- Leave truncation and writing of the PID/host string in `write_lock_info` so it only occurs after the lock is held.
- Continue to read the holder via `File.read(lock_path).strip` when lock acquisition fails to report the original holder.

### Testing

- Attempted to run the storage DB unit test with `bundle exec ruby -Itest test/lib/storage_db_test.rb`, which failed due to an unmet dependency (`archive-zip` not checked out).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962785595808327a166c21321e58275)