### PR TITLE
Avoid DB lock for daemon status/stop

### DIFF
--- a/librarian.rb
+++ b/librarian.rb
@@ -184,6 +184,7 @@ class Librarian
           if %w[status stop].any? { |cmd| subcommand.casecmp(cmd).zero? }
             proxy_internal = 1
             direct_flag = 1
+            ENV['MEDIA_LIBRARIAN_CLIENT_MODE'] ||= '1'
           end
         end
       end


### PR DESCRIPTION
### Motivation
- `daemon status` and `daemon stop` should not trigger full app initialization which can open the DB and cause lock contention.
- Some init hooks eagerly materialize services (e.g. `init/db.rb`) and must be bypassed for lightweight client-mode checks.

### Description
- When detecting an in-process `daemon` subcommand of `status` or `stop`, set `ENV['MEDIA_LIBRARIAN_CLIENT_MODE'] ||= '1'` to enable client mode and avoid DB init.
- Change added in `librarian.rb` alongside the logic that sets `proxy_internal` and `direct_flag` for these subcommands.

### Testing
- Ran a Ruby syntax check with `bundle exec ruby -c librarian.rb` which returned `Syntax OK`.
- No other automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69627925c7c48327ab3a22036f0ecc94)