### PR TITLE
Adjust template command filtering to include templates with `command` present

### DIFF
--- a/app/web/app.js
+++ b/app/web/app.js
@@ -3589,18 +3589,8 @@ function renderAvailableCommands(commands = [], scheduledKeys = new Set()) {
 }
 
 function filterTemplateCommands(commands = []) {
-  const commandArgs = (command) => {
-    const templateArgs = command?.template_args || command?.templateArgs;
-    if (Array.isArray(templateArgs)) {
-      return templateArgs;
-    }
-    if (Array.isArray(command?.args)) {
-      return command.args.map((arg) => arg?.name).filter(Boolean);
-    }
-    return [];
-  };
   return Array.isArray(commands)
-    ? commands.filter((command) => commandArgs(command).includes('command'))
+    ? commands.filter((command) => Array.isArray(command?.command) ? command.command.length : Boolean(command?.command))
     : [];
 }
 


### PR DESCRIPTION
### Motivation
- Ensure templates from `/template_commands` are detected even if they lack `template_args` so templates like `movies_watchlist.yml` are visible.  
- Rely on the presence of a `command` definition instead of scanning `template_args` or `args`.  
- Simplify and reduce the filtering logic to keep the code lean.  
- Keep `renderTemplateCommands` inclusive so templates without args are still rendered.

### Description
- Updated `filterTemplateCommands` in `app/web/app.js` to include entries when `command` is present by checking `Array.isArray(command?.command) ? command.command.length : Boolean(command?.command)`.  
- Removed the previous inspection of `template_args`, `templateArgs`, and `args` to determine inclusion.  
- Left `renderTemplateCommands` behavior unchanged so it now receives the expanded set of templates and displays them even if `template_args` is empty.  
- Change is a minimal, single-function simplification to keep the codebase small and clear.

### Testing
- Ran `bundle exec rake test`, which failed with the error indicating `https://github.com/raphyduck/archive-zip.git is not yet checked out` and suggesting to run `bundle install`.  
- No other automated tests were executed after the change due to the dependency checkout issue.  
- No failures introduced by application logic were observed locally beyond the test setup problem.  
- Further CI or local testing should be run after running `bundle install` to validate behavior end-to-end.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69627b6222988327ae91d0653df27485)