### PR TITLE
Skip DB writes in read-only mode and handle missing PID file

### DIFF
--- a/init/trakt.rb
+++ b/init/trakt.rb
@@ -38,7 +38,7 @@ if trakt_config.is_a?(Hash)
     begin
       app.trakt.account.access_token
       token = app.trakt.token
-      app.db.insert_row('trakt_auth', token.merge({ account: app.trakt_account }), 1) if token
+      app.db.insert_row('trakt_auth', token.merge({ account: app.trakt_account }), 1) if token && !app.db.readonly?
     rescue StandardError => e
       app.speaker.tell_error(e, 'Trakt token initialization')
     end

--- a/lib/storage/db.rb
+++ b/lib/storage/db.rb
@@ -152,6 +152,10 @@ module Storage
       database.table_exists?(table.to_sym)
     end
 
+    def readonly?
+      readonly
+    end
+
     private
 
     attr_reader :readonly

--- a/librarian.rb
+++ b/librarian.rb
@@ -86,6 +86,8 @@ class Librarian
 
     Process.kill(0, pid)
     :running
+  rescue Errno::ENOENT
+    :exited
   rescue Errno::ESRCH
     :dead
   rescue Errno::EPERM


### PR DESCRIPTION
### Motivation

- Prevent runtime errors when the application attempts to write Trakt tokens while the SQLite database is opened read-only (e.g. client/daemon stop flow).  
- Allow callers to check the DB write capability programmatically.  
- Avoid spurious errors when the daemon `stop`/status flow encounters a missing pidfile.  

### Description

- Added `Storage::Db#readonly?` to expose the instance read-only state to callers.  
- Guard Trakt token persistence in `init/trakt.rb` so `insert_row` is only called when `!app.db.readonly?`.  
- Updated `Librarian#pid_status` to also rescue `Errno::ENOENT` and return `:exited` when the pidfile disappears.  

### Testing

- Ran `ruby -c librarian.rb` to validate syntax, which succeeded.  
- Ran `ruby -c init/trakt.rb` to validate syntax, which succeeded.  
- Ran `ruby -c lib/storage/db.rb` to validate syntax, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69627cec4784832781577880e9bb54ae)