### PR TITLE
Show all template commands

### DIFF
--- a/app/web/app.js
+++ b/app/web/app.js
@@ -3589,9 +3589,7 @@ function renderAvailableCommands(commands = [], scheduledKeys = new Set()) {
 }
 
 function filterTemplateCommands(commands = []) {
-  return Array.isArray(commands)
-    ? commands.filter((command) => Array.isArray(command?.command) ? command.command.length : Boolean(command?.command))
-    : [];
+  return Array.isArray(commands) ? commands.filter((command) => command != null) : [];
 }
 
 function renderTemplateCommands(commands = [], { message } = {}) {


### PR DESCRIPTION
### Motivation

- The UI was filtering out template entries that did not include a `command` argument, hiding valid templates returned by `/template_commands` such as `movies_watchlist`.
- The intent is to display all entries returned by the API (or only ignore null entries), so templates are visible even if they don't have a `command` field.

### Description

- Simplified `filterTemplateCommands` to return all non-null entries instead of requiring a `command` value. 
- `renderTemplateCommands` continues to call `filterTemplateCommands`, so templates returned from `/template_commands` are now rendered (including entries without a `command`).

### Testing

- Ran `bundle exec rake test`, which failed due to missing dependencies and requires running `bundle install` first.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69627e96539883279aa8f82698f3e134)