### PR TITLE
Render all template commands in scheduler UI

### DIFF
--- a/app/web/app.js
+++ b/app/web/app.js
@@ -3588,33 +3588,15 @@ function renderAvailableCommands(commands = [], scheduledKeys = new Set()) {
   renderCommandList(container, available, 'Aucune commande CLI disponible.');
 }
 
-function filterTemplateCommands(commands = []) {
-  const commandArgs = (command) => {
-    const templateArgs = command?.template_args || command?.templateArgs;
-    if (Array.isArray(templateArgs)) {
-      return templateArgs;
-    }
-    if (Array.isArray(command?.args)) {
-      return command.args.map((arg) => arg?.name).filter(Boolean);
-    }
-    return [];
-  };
-  return Array.isArray(commands)
-    ? commands.filter((command) => commandArgs(command).includes('command'))
-    : [];
-}
-
 function renderTemplateCommands(commands = [], { message } = {}) {
   const container = document.getElementById('template-command-list');
   if (!container) {
     return;
   }
 
-  const filtered = filterTemplateCommands(commands);
-
   renderCommandList(
     container,
-    filtered,
+    commands,
     message || 'Aucun template de commande disponible.',
     { titleFormat: 'commandWithTemplate' }
   );
@@ -3686,8 +3668,7 @@ async function loadSchedulerTasks() {
   try {
     const templateData = await fetchJson('/template_commands');
     const templates = normalizeCommandEntries(templateData?.commands);
-    const filteredTemplates = filterTemplateCommands(templates);
-    renderTemplateCommands(filteredTemplates);
+    renderTemplateCommands(templates);
   } catch (error) {
     renderTemplateCommands([], { message: error.message });
     if (state.authenticated) {


### PR DESCRIPTION
### Motivation
- Scheduler UI previously filtered templates to only those whose args included a `command` parameter, which hid valid templates returned by `/template_commands`.
- The intent is to show all templates from the server in the scheduler tab so users can schedule any available template.

### Description
- Removed use of the `filterTemplateCommands` filter and its invocation so templates are no longer excluded based on their args.
- `renderTemplateCommands` now receives the full `commands` array and passes it to `renderCommandList` unchanged.
- `loadSchedulerTasks` was updated to call `renderTemplateCommands(templates)` instead of rendering a filtered list.

### Testing
- No automated tests were run for this change as it is a UI-only modification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696279f9d8cc8327951bbdf7d9292a75)