### PR TITLE
Include max_results in process_folder cache key

### DIFF
--- a/app/library.rb
+++ b/app/library.rb
@@ -503,7 +503,7 @@ class Library
 
   def self.process_folder(type:, folder:, item_name: '', remove_duplicates: 0, rename: {}, filter_criteria: {}, no_prompt: 0, folder_hierarchy: {}, cache_expiration: CACHING_TTL, set_original_audio_default: 0, max_results: nil, force_refresh: 0)
     app.speaker.speak_up("Processing folder #{folder}...#{' for ' + item_name.to_s if item_name.to_s != ''}#{'(type: ' + type.to_s + ', folder: ' + folder.to_s + ', item_name: ' + item_name.to_s + ', remove_duplicates: ' + remove_duplicates.to_s + ', rename: ' + rename.to_s + ', filter_criteria: ' + filter_criteria.to_s + ', no_prompt: ' + no_prompt.to_s + ', folder_hierarchy: ' + folder_hierarchy.to_s + ')' if Env.debug?}", 0)
-    files, raw_filtered, cache_name, media_list = nil, [], folder.to_s + type.to_s, {}
+    files, raw_filtered, cache_name, media_list = nil, [], "#{folder}#{type}#{max_results ? "|max_results=#{max_results}" : ''}", {}
     file_criteria = { 'regex' => '.*' + item_name.to_s.gsub(/(\w*)\(\d+\)/, '\1').strip.gsub(/ /, '.') + '.*' }
     raw_filtered += FileUtils.search_folder(folder, filter_criteria.merge(file_criteria)) if filter_criteria && !filter_criteria.empty?
     Utils.lock_block(__method__.to_s + cache_name) {


### PR DESCRIPTION
### Motivation

- Ensure caches created by `process_folder` are distinct when called with different `max_results` so cached results don't leak between requests.
- Keep the cache key format compact and human-readable rather than introducing extra structures or branching logic.
- Avoid unnecessary branches or code bloat while making cache behavior correct for result-limited queries.

### Description

- Updated `process_folder` in `app/library.rb` to include `max_results` in the cache name by changing `cache_name` to `"#{folder}#{type}#{max_results ? "|max_results=#{max_results}" : ''}"`.
- Change is a single-line, lean modification that appends a short `|max_results=...` suffix when a limit is provided, preserving existing behavior when `max_results` is `nil`.

### Testing

- Ran the unit test command `bundle exec ruby -Itest test/app/library_test.rb`, which failed due to missing gem checkout and requires `bundle install` to complete.
- No other automated tests were run in this environment after the change; local test run should succeed once dependencies are installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69628380d3708327856eef69336ca174)