### PR TITLE
Pass target thread to daemon output

### DIFF
--- a/test/daemon_job_control_test.rb
+++ b/test/daemon_job_control_test.rb
@@ -261,7 +261,7 @@ class DaemonJobControlTest < Minitest::Test
     @environment.application.speaker = SimpleSpeaker::Speaker.new
     speaker = @environment.application.speaker
     captured_output = []
-    speaker.define_singleton_method(:daemon_send) do |str|
+    speaker.define_singleton_method(:daemon_send) do |str, **_kwargs|
       captured_output << str.to_s
     end
 


### PR DESCRIPTION
### Motivation
- Ensure daemon output is written to an explicit target thread buffer instead of implicitly using `Thread.current` so parent capture works correctly.
- Make `daemon_send` accept an explicit thread so `speak_up` can route output into the parent thread's `:captured_output`.
- Preserve existing behavior of sending to an attached daemon socket or `stdout` while directing captured buffers to the provided thread.
- Confirm aggregation in `Daemon.merge_notifications` will write into the parent thread buffer when invoked.

### Description
- Change `daemon_send` signature to `def daemon_send(str, thread: Thread.current, stdout: $stdout, stderr: $stderr)` and use `target_thread = thread || Thread.current` for lookups and writes.
- Send data via `target_thread[:current_daemon]` when present and append output into `target_thread[:captured_output]`.
- Have `speak_up` pass the `thread` through to `daemon_send` via `daemon_send(l, thread: thread)` so flushing goes to the intended buffer.
- Update the test stub in `test/daemon_job_control_test.rb` to accept the new keyword args for `daemon_send` (`|str, **_kwargs|`).

### Testing
- Updated unit test stub to match the new `daemon_send` keyword signature.
- Attempted to run `bundle exec ruby -Itest test/daemon_job_control_test.rb` but it failed due to missing dependencies and an unmet `bundle install` requirement.
- No automated tests completed successfully in this environment because `bundle install` is required to run the test suite.
- Changes were committed after adjustments and verified by inspecting `app/daemon.rb` to ensure the parent thread is used in merges.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962892b2db883279f0ab68c47a71160)