### PR TITLE
Restore current-thread daemon send while keeping capture on explicit thread

### DIFF
--- a/lib/simple_speaker.rb
+++ b/lib/simple_speaker.rb
@@ -35,13 +35,12 @@ module SimpleSpeaker
 
     def daemon_send(str, thread: Thread.current, stdout: $stdout, stderr: $stderr)
       line = str.to_s
-      target_thread = thread || Thread.current
-      if target_thread[:current_daemon]
-        target_thread[:current_daemon].send_data "#{line}\n"
+      if Thread.current[:current_daemon]
+        Thread.current[:current_daemon].send_data "#{line}\n"
       else
         (stdout || $stdout).puts(line)
       end
-      buffer = target_thread[:captured_output]
+      buffer = thread[:captured_output]
       buffer&.<<(line.end_with?("\n") ? line : "#{line}\n")
     end
 


### PR DESCRIPTION
### Motivation
- Separate the "thread used to send daemon output" from the "thread used to capture output" to match prior behavior.
- Ensure `send_data` always uses the actual current thread's daemon context rather than the provided thread parameter.
- Keep stdout fallback independent of the parent thread so output still prints when no daemon is present.
- Preserve captured output writing on the explicit `thread` parameter so captures go into the intended buffer.

### Description
- Updated `daemon_send` to call `Thread.current[:current_daemon].send_data` when present so sending uses the current thread's daemon context.
- Fall back to `(stdout || $stdout).puts(line)` when no daemon is attached to the current thread.
- Write captured content into the explicit `thread[:captured_output]` buffer instead of the sending-thread buffer.
- Kept method signature and behavior otherwise unchanged for minimal, focused change.

### Testing
- Ran `bundle exec ruby -c lib/simple_speaker.rb` to verify syntax, which returned `Syntax OK`.
- No other automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69628c71c4b883278d833b6fb6a189f7)