### PR TITLE
Route child job logs to parent daemon

### DIFF
--- a/lib/simple_speaker.rb
+++ b/lib/simple_speaker.rb
@@ -33,10 +33,11 @@ module SimpleSpeaker
       ask_if_needed.nil? ? default : ask_if_needed
     end
 
-    def daemon_send(str, thread: Thread.current, stdout: $stdout, stderr: $stderr)
+    def daemon_send(str, thread: Thread.current, stdout: $stdout, stderr: $stderr, daemon: nil)
       line = str.to_s
-      if Thread.current[:current_daemon]
-        Thread.current[:current_daemon].send_data "#{line}\n"
+      target = daemon || Thread.current[:current_daemon]
+      if target
+        target.send_data "#{line}\n"
       else
         (stdout || $stdout).puts(line)
       end


### PR DESCRIPTION
### Motivation
- Ensure child job log lines are flushed to the parent's daemon socket without modifying `Thread.current` in the parent thread.
- Preserve existing captured output and email aggregation while routing child logs to the correct daemon.
- Provide an explicit path to target a specific daemon when sending output so children can forward logs safely.

### Description
- Added `:parent_daemon` to the `Job` struct and store it from `parent_thread[:current_daemon]` when enqueuing jobs in `app/daemon.rb`.
- Propagate `job.parent_daemon` into the worker thread (`thread[:parent_daemon]`) in `execute_job` so child threads know their parent's daemon.
- In `merge_notifications` send `thread[:log_msg]` lines directly to the parent daemon using `app.speaker.daemon_send(..., daemon: parent_daemon)` when present, otherwise fall back to existing `speak_up` behavior.
- Extended `SimpleSpeaker#daemon_send` to accept an optional `daemon:` parameter and use it as the target for `send_data`, while keeping captured output buffering unchanged (file `lib/simple_speaker.rb`).

### Testing
- Attempted to run `bundle exec rake test`, but it failed due to missing dependencies and reported `bundle install` is required (external dependency `archive-zip` not checked out).
- Changes were exercised locally by running the test command and by basic sanity inspection of `app/daemon.rb` and `lib/simple_speaker.rb` behavior; no automated tests were able to complete successfully due to the dependency issue.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696292c03a188327ba142c99cf4ca69b)