### PR TITLE
Flush logs even when email not initialized in `merge_notifications`

### DIFF
--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -504,7 +504,6 @@ class Daemon
 
     def merge_notifications(thread, parent = Thread.current)
       Utils.lock_time_merge(thread, parent)
-      return if parent[:email_msg].nil?
 
       if thread[:log_msg]
         parent_daemon = thread[:parent_daemon]
@@ -516,6 +515,8 @@ class Daemon
           app.speaker.speak_up(thread[:log_msg].to_s, -1, parent, 1)
         end
       end
+      return unless parent[:email_msg]
+
       parent[:email_msg] << thread[:email_msg].to_s
       parent[:send_email] = thread[:send_email].to_i if thread[:send_email].to_i.positive?
     end


### PR DESCRIPTION
### Motivation
- Ensure thread log output (`thread[:log_msg]`) is always flushed to stdout/daemon even when email aggregation is not initialized.
- Avoid skipping log merging due to a broad guard that returned early when `parent[:email_msg]` was nil.
- Keep email-related merging protected to prevent nil access errors while not blocking other notifications.

### Description
- Modified `merge_notifications` to remove the early `return` and instead place a targeted `return unless parent[:email_msg]` after log handling. 
- This preserves always-running log flush logic and only skips the email append when `parent[:email_msg]` is missing. 
- Change is minimal (2 insertions, 1 deletion) in `app/daemon.rb` inside `merge_notifications`.

### Testing
- Ran `bundle exec rake test`, which could not run due to missing dependencies and reported `archive-zip` not checked out, so tests did not complete. 
- No other automated tests were executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962aedce0188327ba6506faab8631b6)