### PR TITLE
Merge child notifications before thread restore

### DIFF
--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -968,6 +968,7 @@ class Daemon
           Librarian.run_command(job.args.dup, job.internal, job.task, &job.block)
         ensure
           job.output = captured_output.dup if captured_output
+          merge_notifications(thread, thread[:parent]) if thread[:child_job].to_i.positive? && thread[:parent]
         end
       end
     ensure


### PR DESCRIPTION
### Motivation
- Ensure child-thread notification buffers (`thread[:log_msg]` / `thread[:email_msg]`) are flushed to the parent while the child thread still owns them to avoid lost logs or emails. 
- Call `merge_notifications` at the end of a child job so parent receives messages immediately after the child finishes. 
- Preserve existing protection around email merging so logs are flushed even if parent email is uninitialized. 

### Description
- Added a call to `merge_notifications(thread, thread[:parent])` inside `execute_job`'s `ensure` block immediately after setting `job.output`. 
- The call is guarded by `thread[:child_job].to_i.positive? && thread[:parent]` so it only runs for child jobs with a parent. 
- Placement inside the `ThreadState.around` block ensures merging happens before thread state is restored and buffers are lost. 
- Change is a single-line insertion with no other behavioral changes to `merge_notifications` or email protection logic. 

### Testing
- Ran `bundle exec rake test`, which failed due to an external dependency not being checked out (`https://github.com/raphyduck/archive-zip.git`), with the failure advising to run `bundle install` first. 
- No other automated test suites were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962be004ae8832793a2fb2fdddbd8ae)