### PR TITLE
Add test for daemon child notification merging

### DIFF
--- a/test/daemon_child_notifications_test.rb
+++ b/test/daemon_child_notifications_test.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require_relative '../app/daemon'
+require_relative '../librarian'
+
+class DaemonChildNotificationsTest < Minitest::Test
+  class FakeSpeaker
+    attr_reader :daemon_lines, :speak_calls
+
+    def initialize
+      @daemon_lines = []
+      @speak_calls = []
+      @new_line = "\n"
+    end
+
+    def daemon_send(str, thread: Thread.current, **_args)
+      line = str.to_s
+      @daemon_lines << { line: line, thread: thread }
+      buffer = thread[:captured_output]
+      buffer&.<<(line.end_with?(@new_line) ? line : "#{line}#{@new_line}")
+    end
+
+    def speak_up(str, in_mail = 1, thread = Thread.current, immediate = 0)
+      @speak_calls << { message: str, in_mail: in_mail, thread: thread, immediate: immediate }
+      if thread[:log_msg] && immediate.to_i <= 0
+        thread[:log_msg] << str.to_s + @new_line
+      end
+      if immediate.to_i > 0 || thread[:log_msg].nil?
+        str.to_s.each_line { |line| daemon_send(line, thread: thread) }
+      end
+      return unless in_mail.to_i >= 0
+
+      buffer = thread[:email_msg]
+      return unless buffer
+
+      prefix = in_mail.to_i > 0 ? "[*] " : ''
+      buffer << prefix + str.to_s + @new_line
+    end
+  end
+
+  def setup
+    reset_librarian_state!
+    @speaker = FakeSpeaker.new
+    @environment = build_stubbed_environment(speaker: @speaker)
+    @old_application = MediaLibrarian.application
+    MediaLibrarian.application = @environment.application
+    Librarian.configure(app: @environment.application)
+    Daemon.configure(app: @environment.application)
+  end
+
+  def teardown
+    @environment&.cleanup
+    MediaLibrarian.application = @old_application
+  end
+
+  def test_merge_notifications_promotes_child_log_and_email
+    parent = Thread.new {}
+    child = Thread.new {}
+
+    Librarian.reset_notifications(parent)
+    parent[:log_msg] = nil
+    child[:log_msg] = String.new
+    child[:parent] = parent
+    child[:email_msg] = String.new
+
+    @speaker.speak_up('child line', 0, child)
+
+    Daemon.merge_notifications(child, parent)
+
+    assert @speaker.daemon_lines.any? { |entry| entry[:thread] == parent && entry[:line].include?('child line') },
+           'expected child log line to be sent to parent'
+    assert_includes parent[:email_msg], 'child line'
+  ensure
+    parent.join
+    child.join
+  end
+end


### PR DESCRIPTION
### Motivation

- Ensure `Daemon.merge_notifications` correctly promotes a child's log lines to the parent daemon output and merges email buffers.
- Protect against regressions in notification propagation between child and parent threads when using `speak_up`/`daemon_send`.

### Description

- Add a new Minitest file `test/daemon_child_notifications_test.rb` that targets `Daemon.merge_notifications` behavior.
- Introduce a lightweight `FakeSpeaker` that captures calls to `daemon_send` and `speak_up` for assertion.
- The test sets up a parent and child thread, initializes `child[:log_msg]` and `child[:email_msg]`, invokes `@speaker.speak_up` on the child, calls `Daemon.merge_notifications(child, parent)`, and asserts the log line reached the parent and the parent's `:email_msg` was enriched.

### Testing

- Ran `bundle exec ruby -Itest test/daemon_child_notifications_test.rb` which failed due to missing project gems and a required `bundle install` (dependency `archive-zip` not checked out).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962c288b95c8327baedf448eb3276d7)