### PR TITLE
Use `job.child` for child merge guard in `execute_job`

### DIFF
--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -968,7 +968,7 @@ class Daemon
           Librarian.run_command(job.args.dup, job.internal, job.task, &job.block)
         ensure
           job.output = captured_output.dup if captured_output
-          merge_notifications(thread, thread[:parent]) if thread[:child_job].to_i.positive? && thread[:parent]
+          merge_notifications(thread, thread[:parent]) if job.child.to_i.positive? && thread[:parent]
         end
       end
     ensure


### PR DESCRIPTION
### Motivation

- Prevent `merge_notifications` from being incorrectly gated by a thread-local value that can be overwritten by `Librarian.init_thread`.
- Use a stable job-level flag so the merge decision reflects the real job relationship.
- Keep the existing `thread[:parent]` check to avoid merging when there is no parent.

### Description

- Replace the conditional in `execute_job` from `thread[:child_job].to_i.positive?` to `job.child.to_i.positive?` when calling `merge_notifications`.
- The change is a single-line, lean modification in `app/daemon.rb` inside the `ensure` block after `Librarian.run_command`.

### Testing

- No automated tests were executed for this change.
- Static inspection and quick local load of `app/daemon.rb` confirm the edit is syntactically correct and minimal.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962c736da50832786a824624273c6be)