### PR TITLE
Guard Cache stub when real cache is loaded

### DIFF
--- a/test/support/dependency_stubs.rb
+++ b/test/support/dependency_stubs.rb
@@ -275,26 +275,28 @@ module FuzzyStringMatch
   end
 end
 
-module Cache
-  class << self
-    def queue_state_add_or_update(*)
-      # no-op in tests
-    end
+unless defined?(Cache)
+  module Cache
+    class << self
+      def queue_state_add_or_update(*)
+        # no-op in tests
+      end
 
-    def queue_state_remove(*)
-      # no-op in tests
-    end
+      def queue_state_remove(*)
+        # no-op in tests
+      end
 
-    def queue_state_get(*)
-      []
-    end
+      def queue_state_get(*)
+        []
+      end
 
-    def object_pack(value, *_args)
-      value
-    end
+      def object_pack(value, *_args)
+        value
+      end
 
-    def object_unpack(value, *_args)
-      value
+      def object_unpack(value, *_args)
+        value
+      end
     end
   end
 end


### PR DESCRIPTION
### Motivation
- Prevent the test stub from unconditionally defining `Cache` and clobbering the real implementation from `lib/cache.rb`.
- Make tests safe to run when the real `Cache` constant is loaded by other parts of the codebase.

### Description
- Wrap the `Cache` stub in `test/support/dependency_stubs.rb` with `unless defined?(Cache)` so it only defines the stub when `Cache` is not already present.
- No functional change to the stubbed methods; behavior remains a no-op in tests when the stub is used.

### Testing
- Ran `bundle exec rake test` to exercise the test suite, which failed due to missing dependency checkout and requires `bundle install` (error: `archive-zip` not yet checked out).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69636689d4f0832789ea70a713d4664f)