### PR TITLE
Guard Daemon autoload, tighten email init, and register `library test_children` CLI

### DIFF
--- a/init/email.rb
+++ b/init/email.rb
@@ -9,6 +9,10 @@ FileUtils.mkdir_p(app.email_templates) unless File.exist?(app.email_templates)
 app.email = app.config['email']
 
 if app.email
+  host = app.email['host'].to_s.strip
+  app.email = nil if host.empty? || host == 'host'
+  return unless app.email
+
   module Mail
     class SMTP
       module VerifyCallback

--- a/lib/media_librarian/command_registry.rb
+++ b/lib/media_librarian/command_registry.rb
@@ -32,7 +32,8 @@ module MediaLibrarian
           handle_completed_download: ['Library', 'handle_completed_download', 4, 'handle_completed_download', 1],
           scan_file_system: ['FileSystemScan', 'scan'],
           import_csv: ['Library', 'import_list_csv'],
-          process_folder: ['Library', 'process_folder']
+          process_folder: ['Library', 'process_folder'],
+          test_children: ['Library', 'test_children']
         },
         torrent: {
           check_all_download: ['TorrentSearch', 'check_all_download', 1, 'torrenting'],

--- a/lib/simple_speaker.rb
+++ b/lib/simple_speaker.rb
@@ -16,7 +16,7 @@ module SimpleSpeaker
       ask_if_needed = default
       if no_prompt.to_i == 0
         speak_up(question, 0, thread, 1)
-        if Daemon.is_daemon?
+        if defined?(Daemon) && Daemon.is_daemon?
           wtime = 0
           while @user_input.nil?
             sleep 1


### PR DESCRIPTION
### Motivation

- Avoid triggering autoloading of `Daemon` (and possible Zeitwerk conflicts) while prompting for input.
- Prevent Hanami/Mail SMTP setup when the email configuration is missing or still uses the placeholder host to avoid connection errors at boot.
- Ensure the `library test_children` command is recognized and dispatched by the CLI.

### Description

- Check `defined?(Daemon)` in `SimpleSpeaker#ask_if_needed` before calling `Daemon.is_daemon?` to avoid autoloading `Daemon` during prompts.
- Simplify `init/email.rb` by trimming a redundant guard and returning early when `app.email['host']` is empty or equals the placeholder `"host"`, preventing Nil/NoMethodError and skipping mailer configuration.
- Register `test_children` under the `library` action map in `CommandRegistry` so `library test_children` is dispatched to `Library.test_children`.

### Testing

- Executed `./librarian library test_children --nb=10`, which ran successfully and printed the expected child messages.
- Attempting `/librarian library test_children --nb=10` failed due to `/librarian` not being present in PATH, which is expected in this environment.
- No automated unit test suite was changed or executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696371f878e08327afe2d06c49a25286)