### PR TITLE
Append child output to parent captured_output in Daemon.merge_notifications

### DIFF
--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -515,6 +515,11 @@ class Daemon
           app.speaker.speak_up(thread[:log_msg].to_s, -1, parent, 1)
         end
       end
+
+      if parent[:captured_output]
+        captured = thread[:log_msg] || thread[:captured_output]
+        parent[:captured_output] << captured.to_s if captured
+      end
       return unless parent[:email_msg]
 
       parent[:email_msg] << thread[:email_msg].to_s


### PR DESCRIPTION
### Motivation
- Ensure child job output is included in the parent job's captured output so the HTTP `/jobs` response contains child output.
- Preserve existing daemon streaming behavior while also aggregating child buffered output into the parent capture.

### Description
- In `Daemon#merge_notifications` add a check for `parent[:captured_output]` and append child output when present.
- Choose the appended content as `thread[:log_msg]` when available, otherwise `thread[:captured_output]`.
- Append using `to_s` to preserve line breaks and avoid changing existing speaker behavior.

### Testing
- Ran `bundle exec rake test` which failed due to missing gems and requires running `bundle install` first (test run did not complete).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696377069fc08327a1088629f0eca5ca)