### PR TITLE
Revert daemon client stdout streaming

### DIFF
--- a/app/client.rb
+++ b/app/client.rb
@@ -7,12 +7,10 @@ require 'httparty'
 class Client
   include MediaLibrarian::AppContainerSupport
 
-  def initialize(control_token: nil, stdout: $stdout)
+  def initialize(control_token: nil)
     options = app.api_option || {}
     @api_options = options
     @control_token = resolve_control_token(control_token, options)
-    @stdout = stdout || $stdout
-    @output_buffer = String.new
   end
 
   def enqueue(command, wait: true, queue: nil, task: nil, internal: 0, capture_output: wait)
@@ -47,16 +45,6 @@ class Client
     perform(:post, '/stop')
   end
 
-  def send_data(payload)
-    receive_data(payload)
-  end
-
-  def receive_data(payload)
-    text = payload.to_s
-    @output_buffer << text
-    @stdout.print(text)
-  end
-
   private
 
   def perform(method, path, options = {})
@@ -72,8 +60,6 @@ class Client
   end
 
   attr_reader :control_token
-
-  attr_reader :output_buffer
 
   def resolve_control_token(explicit_token, options)
     select_token(


### PR DESCRIPTION
### Motivation
- Simplify the daemon `Client` by removing direct stdout streaming and an internal output buffer to keep the code lean.
- Avoid side effects where the client printed job output directly, which increased coupling and made testing harder.
- Restore the simpler control-token-only initialization surface for the `Client`.
- Reduce potential race conditions and state held on the client instance.

### Description
- Remove the `stdout` parameter and `@output_buffer` initialization from `Client#initialize`.
- Remove the `send_data` and `receive_data` helper methods and the `output_buffer` reader.
- Keep the HTTP/API methods such as `enqueue`, `status`, `job_status`, `kill_job`, and `stop` intact and unchanged.
- Retain existing response parsing and connection error handling logic.

### Testing
- Ran `bundle exec rake test` which failed because the `archive-zip` dependency is not checked out, so the test suite did not execute.
- No other automated tests were run due to the missing dependency preventing the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69639dfe689883279b0a9b6f110e6868)