### PR TITLE
Handle inline child logging output

### DIFF
--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -974,7 +974,9 @@ class Daemon
           Librarian.run_command(job.args.dup, job.internal, job.task, &job.block)
         ensure
           job.output = captured_output.dup if captured_output
-          merge_notifications(thread, thread[:parent]) if job.child.to_i.positive? && thread[:parent]
+          if job.child.to_i.positive? && thread[:parent] && !thread.equal?(thread[:parent])
+            merge_notifications(thread, thread[:parent])
+          end
         end
       end
     ensure

--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -950,14 +950,15 @@ class Daemon
       thread = Thread.current
       job.worker_thread = thread
       captured_output = nil
+      inline_child = job.child.to_i.positive? && job.parent_thread.equal?(thread)
 
       ThreadState.around(thread) do |snapshot|
         thread[:current_daemon] = job.client || snapshot[:current_daemon]
-        thread[:parent] = job.parent_thread unless job.parent_thread.equal?(thread)
+        thread[:parent] = job.parent_thread if job.parent_thread
         thread[:parent_daemon] = job.parent_daemon
         thread[:jid] = job.id
         thread[:queue_name] = job.queue
-        thread[:log_msg] = String.new if job.child.to_i.positive?
+        thread[:log_msg] = String.new if job.child.to_i.positive? && !inline_child
         thread[:child_job] = job.child.to_i.positive? ? 1 : 0
         thread[:child_job_override] = thread[:child_job]
 

--- a/test/daemon_job_control_test.rb
+++ b/test/daemon_job_control_test.rb
@@ -314,6 +314,7 @@ class DaemonJobControlTest < Minitest::Test
     assert_nil parent_log_states[:before_child], 'expected parent log buffer to start nil'
     assert_nil parent_log_states[:after_child], 'expected inline child to preserve nil parent log buffer'
     assert_nil parent_log_states[:after_log], 'expected parent log buffer to remain nil after logging'
+    assert_includes captured_output, 'child message', 'expected child log message to flush immediately'
     assert_includes captured_output, 'parent message', 'expected parent log message to flush immediately'
   end
 


### PR DESCRIPTION
### Motivation

- Inline child jobs executed on the parent worker should not allocate a separate `:log_msg` buffer so that their messages flush immediately to stdout/logs and the parent's `:captured_output`.
- Preserve parent linkage for notification merging even when the parent thread equals the current thread to allow `merge_notifications` to run correctly.
- Add an assertion that verifies inline child messages appear in the captured output when run inline.

### Description

- Detect inline child execution with `inline_child = job.child.to_i.positive? && job.parent_thread.equal?(thread)` in `execute_job`.
- Always set `thread[:parent] = job.parent_thread` when `job.parent_thread` is present so parent linkage is preserved for merging notifications.
- Only allocate a child log buffer with `thread[:log_msg] = String.new` when the job is a child and not an `inline_child`.
- Add a focused test assertion in `test/daemon_job_control_test.rb` to assert `captured_output` includes the child's message when the child runs inline.

### Testing

- Updated `test/daemon_job_control_test.rb` to include the inline child logging assertion and attempted to run `bundle exec ruby -Itest test/daemon_job_control_test.rb` which failed due to missing gems (run `bundle install` required for `archive-zip`).
- No other automated test runs completed in this environment due to the dependency installation issue.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963aa4d279c8327bc74709c38bede4c)