### PR TITLE
Assert child log output in inline job test

### DIFF
--- a/test/daemon_job_control_test.rb
+++ b/test/daemon_job_control_test.rb
@@ -315,6 +315,7 @@ class DaemonJobControlTest < Minitest::Test
     assert_nil parent_log_states[:after_child], 'expected inline child to preserve nil parent log buffer'
     assert_nil parent_log_states[:after_log], 'expected parent log buffer to remain nil after logging'
     assert_includes captured_output, 'parent message', 'expected parent log message to flush immediately'
+    assert_includes captured_output, 'child message', 'expected child log message to flush immediately'
   end
 
   def test_consolidate_children_runs_child_inline_with_single_worker


### PR DESCRIPTION
### Motivation
- Ensure inline child logging flushes its output to the application's speaker so that child log messages are observed when a child runs inline. 
- Prevent regressions where child output would not be captured or immediately flushed during inline execution. 

### Description
- Add an assertion to `test/daemon_job_control_test.rb` in `test_inline_child_logging_restores_parent_immediate_flush` that verifies the `captured_output` contains the `'child message'`. 
- The change relies on the existing `SimpleSpeaker` override in the test that captures `daemon_send` into `captured_output` and makes no other behavioral changes. 

### Testing
- Attempted to run the test with `bundle exec ruby -Itest test/daemon_job_control_test.rb`, but the run failed due to missing gems and requires `bundle install` to proceed. 
- No other automated test runs were executed in this environment after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963aaa3568c8327909cccb274f3e99a)