### PR TITLE
Simplify librarian path resolution

### DIFF
--- a/librarian
+++ b/librarian
@@ -1,11 +1,13 @@
 #!/bin/bash
 
-cd `dirname $0`
-if [[ `pwd` == *media_librarian ]]
-then
-    cd_path=`pwd`
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+if [ -f "$SCRIPT_DIR/librarian.rb" ]; then
+  cd "$SCRIPT_DIR"
+elif [ -f "$SCRIPT_DIR/media_librarian/librarian.rb" ]; then
+  cd "$SCRIPT_DIR/media_librarian"
 else
-    cd_path=`pwd`/media_librarian
+  echo "librarian.rb not found." >&2
+  exit 1
 fi
-cd $cd_path
-ruby `pwd`/librarian.rb "$@"
+
+ruby "$PWD/librarian.rb" "$@"


### PR DESCRIPTION
### Motivation
- Replace brittle string-matching logic with a simple existence check for `librarian.rb`.
- Make the script deterministic and minimal when resolving its working directory.
- Fail fast with a concise error when the target script cannot be located.

### Description
- Compute the script directory with `SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"`.
- If `"$SCRIPT_DIR/librarian.rb"` exists `cd "$SCRIPT_DIR"`, else if `"$SCRIPT_DIR/media_librarian/librarian.rb"` exists `cd "$SCRIPT_DIR/media_librarian"`.
- Print `librarian.rb not found.` to stderr and `exit 1` when neither file exists.
- Invoke `ruby "$PWD/librarian.rb" "$@"` after changing directory.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963d50b244c8327b3dbffe447d303c8)