### PR TITLE
Preserve parent bus ID for inline jobs

### DIFF
--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -956,6 +956,10 @@ class Daemon
         thread[:current_daemon] = job.client || snapshot[:current_daemon]
         thread[:parent] = job.parent_thread unless job.parent_thread.equal?(thread)
         thread[:parent_daemon] = job.parent_daemon
+        if inline_child
+          parent_jid = thread[:jid]
+          thread[:bus_parent_jid] = parent_jid if parent_jid
+        end
         thread[:jid] = job.id
         thread[:queue_name] = job.queue
         if job.child.to_i.positive?

--- a/lib/library_bus.rb
+++ b/lib/library_bus.rb
@@ -11,7 +11,9 @@ class LibraryBus
   end
 
   def self.bus_id(thread = Thread.current)
-    bus_get(thread)[:jid].to_s == '' ? 'nodaemon' : bus_get(thread)[:jid]
+    bus_thread = bus_get(thread)
+    jid = bus_thread[:bus_parent_jid] || bus_thread[:jid]
+    jid.to_s == '' ? 'nodaemon' : jid
   end
 
   def self.bus_variable_get(vname, thread = Thread.current)


### PR DESCRIPTION
### Motivation
- Ensure messages/notifications produced by inline child jobs are enqueued on the parent job's bus rather than the child bus.
- Avoid losing parent bus context when `thread[:jid]` is overwritten for inline execution.
- Keep the fix minimal and localized to thread bookkeeping and bus id resolution.

### Description
- In `app/daemon.rb` within `execute_job`, capture the existing `thread[:jid]` for inline children and stash it as `thread[:bus_parent_jid]` before overwriting `thread[:jid]`.
- In `lib/library_bus.rb` `bus_id`, prefer `thread[:bus_parent_jid]` when present and fall back to `:jid` otherwise.
- Changes are limited to `app/daemon.rb` and `lib/library_bus.rb` with no broader API changes.

### Testing
- Ran `bundle exec ruby -Itest test/librarian_terminate_command_test.rb` which failed due to a missing `bundle install` step required for dependencies.
- No other automated test suites were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963d515477c8327ab064679be3f633a)