### PR TITLE
Use config dir for daemon lock file

### DIFF
--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -186,7 +186,7 @@ class Daemon
     end
 
     def acquire_daemon_lock
-      lock_path = '/home/raph/.medialibrarian/librarian.flock'
+      lock_path = File.join(app.config_dir, 'librarian.flock')
       FileUtils.mkdir_p(File.dirname(lock_path))
       @daemon_lock = File.open(lock_path, 'a')
       locked = @daemon_lock.flock(File::LOCK_EX | File::LOCK_NB)


### PR DESCRIPTION
### Motivation
- The daemon lock path was hard-coded to `/home/raph/.medialibrarian/librarian.flock`, which fails when the process runs under a different user or environment where that path is missing or not writable. 
- The application already exposes `app.config_dir` for other runtime files, so the lock file should live in that directory for consistency and correct permissions.

### Description
- Replace the hard-coded path with `File.join(app.config_dir, 'librarian.flock')` in `app/daemon.rb` to derive the lock location from the app config directory. 
- Preserve existing behavior of creating the parent directory (`FileUtils.mkdir_p`) and obtaining an exclusive non-blocking flock on the file. 

### Testing
- Ran `bundle exec rake test`, which could not run due to a missing dependency: `archive-zip` needs to be installed via `bundle install` (test run failed). 
- Verified the modified code path via quick inspection and ensured no other references to the old hard-coded lock path remain in `app/daemon.rb`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964d2ece4808327aae8cff9e4e0a66d)