### PR TITLE
Guard DB access in client mode and remove eager DB require from Container

### DIFF
--- a/lib/media_librarian/container.rb
+++ b/lib/media_librarian/container.rb
@@ -9,7 +9,6 @@ require_relative '../simple_speaker'
 require_relative '../simple_args_dispatch' unless defined?(SimpleArgsDispatch)
 require_relative '../logger'
 
-require_relative '../storage/db' unless defined?(Storage::Db)
 require_relative '../torznab_tracker' unless defined?(TorznabTracker)
 require_relative '../utils' unless defined?(Utils)
 
@@ -47,6 +46,10 @@ module MediaLibrarian
     end
 
     def db
+      if ENV['MEDIA_LIBRARIAN_CLIENT_MODE'] == '1'
+        raise 'Database access is disabled in client mode. Run the command through the daemon.'
+      end
+
       services[:db] ||= Storage::Db.new(File.join(application.config_dir, 'librarian.db'))
     end
 


### PR DESCRIPTION
### Motivation
- Prevent the CLI running in client mode from loading or using the database connection to avoid concurrent local DB writes when dispatching to a daemon.
- Defer DB loading to daemon-only boot so the client binary remains lightweight and only interacts with the daemon over IPC/HTTP.
- Keep the container lean by removing the eager `Storage::Db` require and centralizing DB access control.

### Description
- Removed the eager `require_relative '../storage/db'` from `lib/media_librarian/container.rb` so the DB implementation is not loaded at container bootstrap.
- Added a guard in `MediaLibrarian::Container#db` that raises an explicit error when `ENV['MEDIA_LIBRARIAN_CLIENT_MODE']=='1'` to block DB access from client mode.
- Primary change file: `lib/media_librarian/container.rb` (updated `#db` accessor).

### Testing
- Attempted to run `bundle exec rake test TEST=test/librarian_cli_test.rb`, but the run failed due to missing bundle setup (`bundle install` required).
- No other automated tests were run in this environment after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964d7edefa483279162bb3bbe898d3e)