### PR TITLE
Set `max_connections: 1` for daemon SQLite DB access

### DIFF
--- a/lib/storage/db.rb
+++ b/lib/storage/db.rb
@@ -16,7 +16,9 @@ module Storage
       @db_path = db_path
       @forward_only = ENV['MEDIA_LIBRARIAN_CLIENT_MODE'] == '1'
       @readonly = readonly.to_i.positive? || @forward_only
-      @database = Sequel.connect(adapter: 'sqlite', database: db_path, readonly: @readonly, timeout: 5000)
+      options = { adapter: 'sqlite', database: db_path, readonly: @readonly, timeout: 5000 }
+      options[:max_connections] = 1 unless @forward_only
+      @database = Sequel.connect(options)
       if @database.database_type == :sqlite
         configure_sqlite
         verify_sqlite


### PR DESCRIPTION
### Motivation
- Limit concurrent SQLite connections when the daemon opens the DB to avoid connection-related issues under the long-running process.
- Keep existing SQLite pragmas such as `journal_mode = WAL` and `busy_timeout = 5000` intact in `configure_sqlite`.
- Ensure the client/CLI path (client mode) continues to behave differently and does not get the daemon-only connection limit.

### Description
- Build an `options` hash passed to `Sequel.connect` and set `:max_connections` to `1` when not in forward-only/CLIENT mode by checking `ENV['MEDIA_LIBRARIAN_CLIENT_MODE']`.
- Preserve existing `readonly` and `timeout` options and leave `configure_sqlite` untouched so `journal_mode` and `busy_timeout` remain as before.
- Use the existing `@forward_only` flag (derived from `ENV['MEDIA_LIBRARIAN_CLIENT_MODE']`) to gate the connection limit.
- No other behavioral changes to migration or corruption handling logic were made.

### Testing
- Ran `bundle exec rake test` to exercise the test suite, but it failed due to missing dependency checkout (`archive-zip`) and needs `bundle install` in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964f499fce08327ac9a9895aec8ab57)