### PR TITLE
Adjust child output flush without email buffer touch

### DIFF
--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -537,10 +537,6 @@ class Daemon
         captured = thread[:log_msg] || thread[:captured_output]
         parent[:captured_output] << captured.to_s if captured
       end
-      return unless parent[:email_msg]
-
-      parent[:email_msg] << thread[:email_msg].to_s
-      parent[:send_email] = thread[:send_email].to_i if thread[:send_email].to_i.positive?
     end
 
     def clear_waiting_worker(worker_thread, thread_value = nil, object = nil, _clear_current = 0)
@@ -1004,6 +1000,10 @@ class Daemon
           if job.child.to_i.positive?
             if thread[:parent]
               merge_notifications(thread, thread[:parent])
+              if thread[:parent][:email_msg]
+                thread[:parent][:email_msg] << thread[:email_msg].to_s
+                thread[:parent][:send_email] = thread[:send_email].to_i if thread[:send_email].to_i.positive?
+              end
             elsif thread[:log_msg]
               parent_daemon = thread[:parent_daemon]
               if parent_daemon


### PR DESCRIPTION
### Motivation
- Ensure child stdout/log output is emitted immediately via the daemon/speaker paths instead of invoking email buffering during the early flush.
- Keep email aggregation logic reserved for final aggregation rather than during interim child-output emission.
- Avoid adding new buffering constructs and keep the change lean by reusing existing speaker methods.

### Description
- Removed early email buffer merging from `merge_notifications` so it no longer touches `thread[:email_msg]`.
- After calling `merge_notifications` in `execute_job`, explicitly append the child's `:email_msg` into the parent thread only at the final flush point.
- Continued to emit child logs through `app.speaker.daemon_send` or `app.speaker.speak_up(..., immediate: 1)` as before, reusing existing speaker paths.
- Changes are localized to `app/daemon.rb` and kept minimal (few lines modified).

### Testing
- Ran a Ruby syntax check with `ruby -c app/daemon.rb` which succeeded.
- No additional automated test suite was present or executed as part of this change.
- The patch was kept small to minimize risk and facilitate easy review.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696619d09f5c8327b124d272f8b47344)