### PR TITLE
Return job acceptance immediately and poll for completion

### DIFF
--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -1389,7 +1389,6 @@ class Daemon
 
         payload = parse_payload(req)
         args = Array(payload['command'])
-        wait = payload.fetch('wait', true)
         internal = payload['internal'] || 0
         queue = payload['queue']
         task = payload['task']
@@ -1407,12 +1406,7 @@ class Daemon
           wait_for_capacity: wait_for_capacity
         )
 
-        if wait && job&.future
-          job.future.wait
-          job.future.value!
-        end
-
-        json_response(res, body: { 'job' => job&.to_h })
+        json_response(res, body: { 'job' => job&.to_h, 'accepted' => !job.nil? })
       when 'GET'
         return handle_job_not_found(res) unless req.path.start_with?('/jobs/')
 


### PR DESCRIPTION
### Motivation
- Ensure job enqueue requests return an immediate acknowledgement so CLI callers do not block the daemon.
- Let CLI clients optionally wait for completion by polling status rather than relying on the daemon to block/stream.

### Description
- Update `handle_jobs_request` in `app/daemon.rb` to stop blocking and respond with `{'job': job.to_h, 'accepted': !job.nil?}` immediately after enqueue.
- Change `Client#enqueue` in `app/client.rb` to default `wait: false`, always send `'wait': false` to the daemon, and return the acceptance response immediately. 
- Add `FINISHED_STATUSES` and a lightweight `wait_for_job_completion(job_id)` that polls `GET /jobs/:id` using existing `job_status` to produce the final job result when `wait: true` is requested. 
- Keep the implementation lean by reusing the existing job status endpoint and avoiding new streaming endpoints.

### Testing
- Attempted to run the integration test suite with `bundle exec ruby -Itest test/daemon_integration_test.rb`, but it failed due to missing bundle checkout and dependency installation (message: "Run `bundle install` first").
- No other automated tests were executed in this environment.
- Code changes were committed locally after verification of the modified files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69661975563c8327a1460dadc0493908)