### PR TITLE
Return job acceptance immediately and surface failures when waiting

### DIFF
--- a/app/client.rb
+++ b/app/client.rb
@@ -9,6 +9,7 @@ class Client
   include MediaLibrarian::AppContainerSupport
 
   SOCKET_PATH = '/home/raph/.medialibrarian/librarian.sock'
+  FINISHED_STATUSES = %w[finished failed cancelled].freeze
 
   def initialize(control_token: nil)
     options = app.api_option || {}
@@ -16,13 +17,13 @@ class Client
     @control_token = resolve_control_token(control_token, options)
   end
 
-  def enqueue(command, wait: true, queue: nil, task: nil, internal: 0, capture_output: wait)
-    perform(
+  def enqueue(command, wait: false, queue: nil, task: nil, internal: 0, capture_output: wait)
+    response = perform(
       :post,
       '/jobs',
       body: JSON.dump(
         'command' => command,
-        'wait' => wait,
+        'wait' => false,
         'queue' => queue,
         'task' => task,
         'internal' => internal,
@@ -30,6 +31,12 @@ class Client
       ),
       headers: json_headers
     )
+    return response unless wait
+
+    job_id = response.dig('body', 'job', 'id')
+    return response unless job_id
+
+    wait_for_job_completion(job_id)
   end
 
   def status
@@ -217,6 +224,24 @@ class Client
   def parse_http_response(response)
     body = response.body.to_s.empty? ? nil : JSON.parse(response.body)
     { 'status_code' => response.code.to_i, 'body' => body }
+  end
+
+  def wait_for_job_completion(job_id)
+    loop do
+      response = job_status(job_id)
+      return response unless response['status_code'] == 200
+
+      status = response.dig('body', 'status')
+      if FINISHED_STATUSES.include?(status)
+        job = response['body']
+        return { 'status_code' => 200, 'body' => { 'job' => job } } if status == 'finished'
+
+        error = job.is_a?(Hash) ? job['error'] : nil
+        return { 'status_code' => 422, 'body' => { 'error' => error || 'job_failed', 'job' => job } }
+      end
+
+      sleep 0.05
+    end
   end
 
   def parse_socket_response(response_line)

--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -1389,7 +1389,6 @@ class Daemon
 
         payload = parse_payload(req)
         args = Array(payload['command'])
-        wait = payload.fetch('wait', true)
         internal = payload['internal'] || 0
         queue = payload['queue']
         task = payload['task']
@@ -1407,12 +1406,7 @@ class Daemon
           wait_for_capacity: wait_for_capacity
         )
 
-        if wait && job&.future
-          job.future.wait
-          job.future.value!
-        end
-
-        json_response(res, body: { 'job' => job&.to_h })
+        json_response(res, body: { 'job' => job&.to_h, 'accepted' => !job.nil? })
       when 'GET'
         return handle_job_not_found(res) unless req.path.start_with?('/jobs/')
 


### PR DESCRIPTION
### Motivation
- Ensure job enqueue requests return an immediate acknowledgement so CLI callers do not block and clients can optionally wait by polling.
- Restore error signaling on the wait path so failed or cancelled jobs are surfaced to callers as non-2xx responses instead of being treated as successful acknowledgements.

### Description
- Update the daemon POST /jobs response to return immediately with `{'job': job, 'accepted': !job.nil?}` so enqueue is non-blocking (see `app/daemon.rb`).
- Change `Client#enqueue` to default `wait: false`, always send `'wait': false` to the daemon, and when `wait: true` is requested perform an initial enqueue then poll for completion (see `app/client.rb`).
- Add `FINISHED_STATUSES` and update `wait_for_job_completion` to return HTTP 200 for successful `finished` jobs and HTTP 422 with an `error` and `job` body when the job reached `failed` or `cancelled` so CLI callers receive proper non-2xx error signaling (see `app/client.rb`).

### Testing
- Ran `bundle exec ruby -Itest test/daemon_integration_test.rb`, which failed due to a missing dependency checkout with the message: "Run `bundle install` first".
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69661975563c8327a1460dadc0493908)