### PR TITLE
Handle git update errors with capture3

### DIFF
--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -2503,6 +2503,8 @@ class Daemon
 
       message = err.to_s.lines.first.to_s.strip
       [false, message.empty? ? 'git_command_failed' : message]
+    rescue Errno::ENOENT
+      [false, 'git_command_failed']
     end
 
     def restart_from_disk

--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -15,6 +15,7 @@ require 'fileutils'
 require 'base64'
 require 'get_process_mem'
 require 'socket'
+require 'open3'
 
 require_relative '../lib/cache'
 require_relative '../lib/logger'
@@ -2455,8 +2456,9 @@ class Daemon
         return error_response(res, status: 404, message: 'update_root_missing')
       end
 
-      unless update_code(root)
-        return error_response(res, status: 500, message: 'update_failed')
+      updated, error = update_code(root)
+      unless updated
+        return error_response(res, status: 500, message: error || 'update_failed')
       end
 
       json_response(res, status: 202, body: { 'status' => 'update_stopping' })
@@ -2490,12 +2492,17 @@ class Daemon
     end
 
     def update_code(root)
-      return false unless run_git_command(root, ['git', 'fetch', '--all'])
-      return false unless run_git_command(root, ['git', 'pull', '--ff-only'])
+      success, error = run_git_command(root, ['git', 'fetch', '--all'])
+      return [false, error] unless success
+      run_git_command(root, ['git', 'pull', '--ff-only'])
     end
 
     def run_git_command(root, command)
-      system(*command, chdir: root)
+      _out, err, status = Open3.capture3(*command, chdir: root)
+      return [true, nil] if status.success?
+
+      message = err.to_s.lines.first.to_s.strip
+      [false, message.empty? ? 'git_command_failed' : message]
     end
 
     def restart_from_disk


### PR DESCRIPTION
### Motivation
- Make git update failures produce concise, actionable error text instead of only a boolean so the API can return a brief failure reason.
- Avoid returning large stderr blobs by extracting a minimal message (first stderr line) from git invocations.

### Description
- Added `require 'open3'` and replaced `system(*command, chdir: root)` with `Open3.capture3` in `run_git_command` to capture stdout/stderr and exit status and return `[true, nil]` or `[false, short_error]`.
- Updated `update_code` to propagate the `(success, error)` tuple from `run_git_command` and return `[false, error]` on failure.
- Modified `handle_update_stop_request` to accept the tuple from `update_code` and include the concise `error` string in the `error_response` when updates fail.
- Trimmed error text to the first line of stderr (falling back to `'git_command_failed'` if empty) to keep responses small.

### Testing
- Ran `ruby -c app/daemon.rb` and it returned `Syntax OK`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e07a4fd788327a97f6a1cfeb62874)