### PR TITLE
Skip Trakt initialization in client mode

### DIFF
--- a/init/trakt.rb
+++ b/init/trakt.rb
@@ -6,43 +6,45 @@ require_relative '../boot/librarian'
 require_relative 'db'
 require_relative '../lib/http_debug_logger'
 
-app = MediaLibrarian::Boot.application
-trakt_config = app.config['trakt']
+unless ENV['MEDIA_LIBRARIAN_CLIENT_MODE'] == '1'
+  app = MediaLibrarian::Boot.application
+  trakt_config = app.config['trakt']
 
-if trakt_config.is_a?(Hash)
-  account_id = trakt_config['account_id'].to_s.strip
-  client_id = trakt_config['client_id'].to_s.strip
-  client_secret = trakt_config['client_secret'].to_s.strip
+  if trakt_config.is_a?(Hash)
+    account_id = trakt_config['account_id'].to_s.strip
+    client_id = trakt_config['client_id'].to_s.strip
+    client_secret = trakt_config['client_secret'].to_s.strip
 
-  credentials = { account_id: account_id, client_id: client_id, client_secret: client_secret }
-  missing_credentials = credentials.any? do |key, value|
-    value.empty? || value == key.to_s
-  end
-
-  if missing_credentials
-    app.speaker.speak_up('Skipping Trakt integration because credentials are missing or still set to defaults.', 0)
-  else
-    app.trakt_account = account_id
-    token_rows = app.db.get_rows('trakt_auth', { account: app.trakt_account })
-    token_row = token_rows.empty? ? nil : Utils.recursive_typify_keys(token_rows.first.reject { |k, _| k.to_s == :account.to_s }, 0)
-    token_row = nil if token_row.nil? || token_row.values.any? { |v| v.to_s == '' || v.to_s == '0' }
-
-    app.trakt = Trakt.new({
-                            client_id: client_id,
-                            client_secret: client_secret,
-                            account_id: app.trakt_account,
-                            speaker: app.speaker,
-                            token: token_row
-                          })
-
-    begin
-      app.trakt.account.access_token
-      token = app.trakt.token
-      app.db.insert_row('trakt_auth', token.merge({ account: app.trakt_account }), 1) if token && !app.db.readonly?
-    rescue StandardError => e
-      app.speaker.tell_error(e, 'Trakt token initialization')
+    credentials = { account_id: account_id, client_id: client_id, client_secret: client_secret }
+    missing_credentials = credentials.any? do |key, value|
+      value.empty? || value == key.to_s
     end
+
+    if missing_credentials
+      app.speaker.speak_up('Skipping Trakt integration because credentials are missing or still set to defaults.', 0)
+    else
+      app.trakt_account = account_id
+      token_rows = app.db.get_rows('trakt_auth', { account: app.trakt_account })
+      token_row = token_rows.empty? ? nil : Utils.recursive_typify_keys(token_rows.first.reject { |k, _| k.to_s == :account.to_s }, 0)
+      token_row = nil if token_row.nil? || token_row.values.any? { |v| v.to_s == '' || v.to_s == '0' }
+
+      app.trakt = Trakt.new({
+                              client_id: client_id,
+                              client_secret: client_secret,
+                              account_id: app.trakt_account,
+                              speaker: app.speaker,
+                              token: token_row
+                            })
+
+      begin
+        app.trakt.account.access_token
+        token = app.trakt.token
+        app.db.insert_row('trakt_auth', token.merge({ account: app.trakt_account }), 1) if token && !app.db.readonly?
+      rescue StandardError => e
+        app.speaker.tell_error(e, 'Trakt token initialization')
+      end
+    end
+  else
+    app.speaker.speak_up('Skipping Trakt integration because no configuration is available.', 0)
   end
-else
-  app.speaker.speak_up('Skipping Trakt integration because no configuration is available.', 0)
 end


### PR DESCRIPTION
### Motivation
- Avoid touching the app/container or `app.db` when running in client mode so client-only commands (e.g. `daemon stop`, `daemon status`) do not trigger DB exceptions by skipping Trakt setup when `MEDIA_LIBRARIAN_CLIENT_MODE == '1'`.

### Description
- Wrap the initialization in `init/trakt.rb` with `unless ENV['MEDIA_LIBRARIAN_CLIENT_MODE'] == '1'` so the early `app = MediaLibrarian::Boot.application` and any subsequent `app.db` access are skipped; the only modified file is `init/trakt.rb`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e07bf93bc8327b968c23b6b5141b2)