### PR TITLE
Return true after successful update_code git operations

### DIFF
--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -2494,7 +2494,9 @@ class Daemon
     def update_code(root)
       success, error = run_git_command(root, ['git', 'fetch', '--all'])
       return [false, error] unless success
-      run_git_command(root, ['git', 'pull', '--ff-only'])
+      success, error = run_git_command(root, ['git', 'pull', '--ff-only'])
+      return [false, error] unless success
+      true
     end
 
     def run_git_command(root, command)


### PR DESCRIPTION
### Motivation
- Ensure `update_code(root)` returns `true` only after both `git fetch --all` and `git pull --ff-only` succeed to provide an unambiguous success signal.

### Description
- Capture the result of the second `run_git_command` as `success, error`, return `[false, error]` on failure, and return `true` at the end of `update_code`.

### Testing
- Ran `bundle exec rake test` which failed early due to missing dependencies (`bundle install` required and external `archive-zip` not checked out), so no test failures related to this change were observed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e0c406c8083278c69bff81dc77748)