### PR TITLE
Read auto-repair setting from conf.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,24 @@ The daemon logs to `~/.medialibrarian/logs/` by default, and jobs are queued acc
 Finished job history is capped per queue (defaults to `finished_jobs_per_queue: 100` in `~/.medialibrarian/conf.yml`) to keep the
 in-memory registry bounded; raise or lower the limit to tune how many completed entries remain visible via `/status`.
 
+### Réparer une base SQLite corrompue
+
+Le script `scripts/repair_db.sh` tente une récupération via `.recover` et vérifie ensuite l'intégrité de la base récupérée.
+
+```bash
+./scripts/repair_db.sh ~/.medialibrarian/librarian.db
+```
+
+Pour proposer automatiquement la réparation au démarrage (si la corruption est détectée), ajoutez la clé suivante dans
+`~/.medialibrarian/conf.yml` :
+
+```yaml
+sqlite:
+  auto_repair_on_corruption: true
+```
+
+Un prompt interactif demandera si vous souhaitez lancer la réparation avant de relancer l'application.
+
 ### Trakt integration
 
 `TraktAgent` is now a thin shim that forwards dynamic API calls via `method_missing`. Legacy helpers for list management and automated watchlist/collection curation have been retired. Features such as the calendar rely on locally persisted watchlist entries instead of pulling Trakt lists directly.

--- a/config/conf.yml.example
+++ b/config/conf.yml.example
@@ -33,6 +33,8 @@ calendar:
   window_future_days: 365
   refresh_limit: 200
   providers: imdb|trakt|tmdb
+# sqlite:
+#   auto_repair_on_corruption: true
 # imdb:
 #   enabled: false # Optional toggle; remove or set to false to disable the IMDb feed
 kodi:


### PR DESCRIPTION
### Motivation

- Move the SQLite auto-repair opt-in from an environment variable to the application's YAML configuration so operators can enable it via `~/.medialibrarian/conf.yml` instead of exporting `MEDIA_LIBRARIAN_AUTO_REPAIR_DB`.
- Improve startup resilience by allowing the process to offer a repair prompt and retry connecting when corruption is detected.

### Description

- Refactored DB initialization to use a new `connect_db` helper and store connection options in `@db_options` so reconnects after repair are possible via `connect_db`.
- Added `@repair_attempted` tracking and an `attempt_repair` flow that reads `MediaLibrarian.app.config.dig('sqlite', 'auto_repair_on_corruption')` and prompts the user via `speaker.ask_if_needed` before executing `scripts/repair_db.sh`.
- Changed `verify_sqlite` to raise `SQLite3::CorruptException` on integrity failure and updated the constructor to call `attempt_repair` and retry `connect_db` when corruption is caught.
- Documented the new config key in `README.md` and added a commented example in `config/conf.yml.example` (`sqlite:
  auto_repair_on_corruption: true`).

### Testing

- Ran `bundle exec rake test`, which did not run because of a missing dependency checkout: `https://github.com/raphyduck/archive-zip.git is not yet checked out. Run \`bundle install\` first.` (tests could not be executed until `bundle install` is run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e0de964848327bed25d18782a1b46)