### PR TITLE
Set `thread[:send_email]` when message requests email

### DIFF
--- a/lib/simple_speaker.rb
+++ b/lib/simple_speaker.rb
@@ -53,7 +53,7 @@ module SimpleSpeaker
       buffer = buffer.dup if buffer.frozen?
       thread[:email_msg] = buffer
       buffer << str.to_s.force_encoding('UTF-8') + @new_line
-      thread[:send_email] = in_mail.to_i if in_mail.to_i > 0 && thread[:send_email]
+      thread[:send_email] = in_mail.to_i if in_mail.to_i > 0
     end
 
     def speak_up(str, in_mail = 1, thread = Thread.current, immediate = 0)


### PR DESCRIPTION
### Motivation
- Ensure new messages can mark a thread for email delivery even if `thread[:send_email]` was previously reset, so `Librarian.reset_notifications` can clear the flag and subsequent messages can re-enable it.

### Description
- Change `SimpleSpeaker::Speaker#email_msg_add` to set `thread[:send_email] = in_mail.to_i` whenever `in_mail.to_i > 0` instead of requiring an existing truthy `thread[:send_email]`.

### Testing
- Ran `bundle exec rake test`, which failed due to missing dependencies and requires running `bundle install` first.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697121875cfc8327bb2a2fc4d032fbc0)