### PR TITLE
Add mkv processing helper for local remux pipeline

### DIFF
--- a/lib/video_utils.rb
+++ b/lib/video_utils.rb
@@ -107,6 +107,7 @@ class VideoUtils
       MediaLibrarian.app.speaker.speak_up("Post-check failed: default audio language #{post_lang} does not match target #{target_lang} for #{path}.")
       return false
     end
+    FileUtils.rm_f(result[:backup_path]) if result[:backup_path]
     MediaLibrarian.app.speaker.speak_up("Default audio track set to #{selected_track_index} for #{path} with target language #{target_lang}. Command returned #{result[:stdout]}")
     true
   end
@@ -167,8 +168,7 @@ class VideoUtils
     bak_path = "#{path_source}.bak"
     FileUtils.mv(path_source, bak_path) if backup
     FileUtils.mv(dest_tmp, path_source)
-    FileUtils.rm_f(bak_path) if backup
-    { success: true, stdout: stdout, stderr: stderr }
+    { success: true, stdout: stdout, stderr: stderr, backup_path: backup ? bak_path : nil }
   ensure
     FileUtils.rm_rf(work_dir) if work_dir && Dir.exist?(work_dir)
   end


### PR DESCRIPTION
### Motivation
- Ensure `mkvmerge`/`mkvpropedit` never write output directly to overlay/mergefs paths by running tools against local temporary files. 
- Provide a small reusable pipeline to copy a source to local temp, run the chosen tool, validate output, and perform an atomic replacement with an optional backup. 
- Replace fragile inline `Open3.capture3` remux logic in default-audio flow with a lean, validated helper.

### Description
- Add `process_mkv(path_source, tool:, args:, temp_dir: '/tmp', backup: true, timeout_s: nil)` which copies `path_source` to a local temp dir, rewrites `mkvmerge` output to a local `output.mkv`, runs the tool, validates the produced file, copies it back as a `.processing` temp file next to the source and atomically moves it into place, and cleans up temps.
- Update `set_default_original_audio!` to build `args` and call `process_mkv(..., tool: 'mkvmerge', args: args)` instead of invoking `Open3.capture3` and manually moving a tmp file.
- Add small helper methods: `replace_mkvmerge_output` to ensure `-o` targets a local file, `run_command` to run commands with an optional `timeout`, and `mkv_validate_local` to validate the local output using `mkvmerge -J` or fall back to `mkvinfo`.
- Add minimal requires for `tmpdir` and `timeout` and keep the `backup` (`.bak`) behavior until validation completes before removing it.

### Testing
- Ran `ruby -c lib/video_utils.rb` to validate syntax; result was `Syntax OK`.
- No unit tests were added; existing test suite was not modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69724af0f6d883278240e142cf4c4851)