### PR TITLE
Add tests for VideoUtils MKV workflows

### DIFF
--- a/lib/video_utils.rb
+++ b/lib/video_utils.rb
@@ -149,6 +149,10 @@ class VideoUtils
   def self.process_mkv(path_source, tool:, args:, temp_dir: '/tmp', backup: true, timeout_s: nil, dry_run: false)
     log = lambda { |msg| MediaLibrarian.app.speaker.speak_up(msg) }
     return { success: false, message: "source file not found: #{path_source}" } unless File.file?(path_source)
+    if tool.to_s == 'mkvmerge' && !dry_run && !system('command -v mkvmerge >/dev/null 2>&1')
+      log.call('mkvmerge not available in PATH')
+      return { success: false, message: 'mkvmerge not available in PATH' }
+    end
 
     dir = File.dirname(path_source)
     base = File.basename(path_source)

--- a/test/video_utils_test.rb
+++ b/test/video_utils_test.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require_relative 'test_helper'
+require_relative '../lib/video_utils'
+
+class VideoUtilsTest < Minitest::Test
+  def setup
+    @speaker = TestSupport::Fakes::Speaker.new
+    @environment = build_stubbed_environment(speaker: @speaker)
+    @old_application = MediaLibrarian.application
+    MediaLibrarian.application = @environment.application
+  end
+
+  def teardown
+    MediaLibrarian.application = @old_application
+    @environment.cleanup
+  end
+
+  def test_process_mkv_dry_run_logs_without_modifying_file
+    Dir.mktmpdir do |dir|
+      path = File.join(dir, 'sample.mkv')
+      File.write(path, 'original')
+
+      result = VideoUtils.process_mkv(path, tool: 'mkvmerge', args: ['-o', path, path], dry_run: true)
+
+      assert result[:success]
+      messages = @speaker.messages.grep(String).join("\n")
+      assert_includes messages, 'mkv temp dir:'
+      assert_includes messages, 'dry_run: would lock'
+      assert_equal 'original', File.read(path)
+      refute File.exist?(File.join(dir, '.sample.mkv.lock'))
+    end
+  end
+
+  def test_process_mkv_reports_missing_mkvmerge
+    Dir.mktmpdir do |dir|
+      path = File.join(dir, 'missing.mkv')
+      File.write(path, 'payload')
+
+      with_env('PATH', '') do
+        result = VideoUtils.process_mkv(path, tool: 'mkvmerge', args: ['-o', path, path])
+
+        refute result[:success]
+        assert_includes @speaker.messages, 'mkvmerge not available in PATH'
+      end
+    end
+  end
+
+  def test_process_mkv_pipeline_with_stubbed_mkvmerge
+    # To generate a real MKV fixture for manual runs:
+    # ffmpeg -f lavfi -i testsrc=size=128x72:rate=1 -t 1 -c:v libx264 test/fixtures/sample.mkv
+    Dir.mktmpdir do |dir|
+      path = File.join(dir, 'fixture.mkv')
+      File.write(path, 'original')
+      mkvmerge_dir = File.join(dir, 'bin')
+      FileUtils.mkdir_p(mkvmerge_dir)
+      mkvmerge = File.join(mkvmerge_dir, 'mkvmerge')
+      File.write(mkvmerge, "#!/bin/sh\nexit 0\n")
+      FileUtils.chmod(0o755, mkvmerge)
+
+      with_env('PATH', "#{mkvmerge_dir}:#{ENV['PATH']}") do
+        status = Struct.new(:success?).new(true)
+        run_stub = lambda do |_tool, args, _timeout|
+          out_index = args.index('-o') || args.index('--output')
+          out_path = out_index ? args[out_index + 1] : args.first
+          File.write(out_path, 'processed')
+          ['ok', '', status]
+        end
+
+        result = VideoUtils.stub(:run_command, run_stub) do
+          VideoUtils.stub(:mkv_validate_local, true) do
+            VideoUtils.process_mkv(path, tool: 'mkvmerge', args: ['-o', path, path])
+          end
+        end
+
+        assert result[:success]
+        assert_equal 'processed', File.read(path)
+        assert File.exist?("#{path}.bak")
+      end
+    end
+  end
+
+  private
+
+  def with_env(key, value)
+    old_value = ENV.fetch(key, nil)
+    ENV[key] = value
+    yield
+  ensure
+    ENV[key] = old_value
+  end
+end


### PR DESCRIPTION
### Motivation
- Ensure `VideoUtils.process_mkv` behaves safely when invoked in dry‑run mode and when external tool dependencies are missing. 
- Provide automated coverage for the MKV remux pipeline so regressions around locking, copying and mkvmerge invocation are detected.

### Description
- Added a guard in `lib/video_utils.rb` to detect when `mkvmerge` is missing and log/return a clear error when not in `dry_run` mode. 
- Added `test/video_utils_test.rb` with three focused tests that cover dry‑run logging, reporting when `mkvmerge` is not available (via `PATH` stub), and a full pipeline path using a stubbed `run_command` and `mkv_validate_local`. 
- Tests are compact and use the existing test helpers (`build_stubbed_environment`, `TestSupport::Fakes::Speaker`) and include a short note on how to create a real MKV fixture for manual runs.

### Testing
- Ran the new test file with `bundle exec ruby -Itest test/video_utils_test.rb`, which failed to start due to missing bundler git checkout (`Bundler::GitError: https://github.com/raphyduck/archive-zip.git is not yet checked out`), so the automated tests could not be executed in this environment. 
- No other automated test runs were performed in this session due to the dependency installation error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69733965177c8327bc614936c3ee2277)