### PR TITLE
Add watchlist CSV import endpoint

### DIFF
--- a/app/library.rb
+++ b/app/library.rb
@@ -629,6 +629,7 @@ class Library
 
       count = WatchlistStore.upsert(rows)
       app.speaker.speak_up("import_list_csv: imported #{count} rows into watchlist", 0) if defined?(app.speaker)
+      added_titles = [] if detailed && count.to_i.zero?
       detailed ? { 'added_titles' => added_titles, 'total_added' => count, 'skipped' => skipped } : count
     rescue => e
       app.speaker.tell_error(e, Utils.arguments_dump(binding), 0) rescue nil

--- a/app/library.rb
+++ b/app/library.rb
@@ -584,16 +584,29 @@ class Library
   # Import a CSV into the watchlist
   # Usage:
   #   Library.import_list_csv(list_name: 'to_download', csv_path: '/path/to/list.csv', replace: '1') # replace rows
-  def self.import_list_csv(list_name: nil, csv_path: nil, replace: '1')
+  def self.import_list_csv(list_name: nil, csv_path: nil, csv_content: nil, csv_rows: nil, replace: '1', detailed: false)
     begin
-      raise ArgumentError, 'csv_path must be provided' if csv_path.to_s.strip.empty?
-      raise ArgumentError, "CSV file not found: #{csv_path}" unless File.file?(csv_path)
       list_name = list_name.to_s.strip
+      csv_rows ||= begin
+        if csv_content
+          CSV.parse(csv_content.to_s, headers: true)
+        else
+          raise ArgumentError, 'csv_path must be provided' if csv_path.to_s.strip.empty?
+          raise ArgumentError, "CSV file not found: #{csv_path}" unless File.file?(csv_path)
+
+          CSV.foreach(csv_path, headers: true)
+        end
+      end
       rows = []
-      CSV.foreach(csv_path, headers: true) do |row|
+      added_titles = []
+      skipped = 0
+      csv_rows.each do |row|
         title = row['title']&.to_s&.strip
         imdb_id = (row['imdb_id'] || row['imdb'] || row['external_id'])&.to_s&.strip
-        next if title.nil? || title.empty? || imdb_id.nil? || imdb_id.empty?
+        if title.nil? || title.empty? || imdb_id.nil? || imdb_id.empty?
+          skipped += 1
+          next
+        end
 
         type = Utils.regularise_media_type((row['type'] || 'movies').to_s)
         year = row['year']&.to_s&.strip
@@ -608,15 +621,18 @@ class Library
         metadata[:url] = url if url && !url.empty?
         metadata[:tmdb] = tmdb if tmdb && !tmdb.empty?
         rows << { imdb_id: imdb_id, title: title, type: type, metadata: metadata.empty? ? nil : metadata }
+        added_titles << title
       end
-      return 0 if rows.empty?
+      if rows.empty?
+        return detailed ? { 'added_titles' => [], 'total_added' => 0, 'skipped' => skipped } : 0
+      end
 
       count = WatchlistStore.upsert(rows)
       app.speaker.speak_up("import_list_csv: imported #{count} rows into watchlist", 0) if defined?(app.speaker)
-      count
+      detailed ? { 'added_titles' => added_titles, 'total_added' => count, 'skipped' => skipped } : count
     rescue => e
       app.speaker.tell_error(e, Utils.arguments_dump(binding), 0) rescue nil
-      0
+      detailed ? { 'added_titles' => [], 'total_added' => 0, 'skipped' => 0 } : 0
     end
   end
 


### PR DESCRIPTION
### Motivation
- Provide a server-side endpoint to import watchlist rows from CSV payloads so the UI can send CSV content directly instead of requiring a file path.
- Return structured metadata about the import (added titles, totals, skipped) to allow the UI to display meaningful feedback.

### Description
- Add `require 'csv'` and mount a new control endpoint at `/watchlist/import-csv` which authorizes, parses JSON payloads, validates `csv_content`, parses CSV via `CSV.parse`, and returns structured JSON or validation errors.
- Implement `handle_watchlist_import_csv_request` to detect and return `missing_csv`, `empty_csv`, and `invalid_csv` errors and to call the library import with `detailed: true`.
- Extend `Library.import_list_csv` signature to accept `csv_content`, `csv_rows`, and `detailed` options, accept parsed CSV rows or inline content, skip malformed rows, collect `added_titles`, `total_added`, and `skipped`, and return either a scalar count or a detailed hash when requested.
- Keep behavior backwards-compatible: existing `csv_path` support remains and non-detailed callers still receive numeric results.

### Testing
- Ran syntax checks with `ruby -c app/daemon.rb` which returned `Syntax OK`.
- Ran syntax checks with `ruby -c app/library.rb` which returned `Syntax OK`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69733ef91e048327b630eec2465a31d6)