### PR TITLE
Add CSV import controls for watchlist

### DIFF
--- a/app/web/index.html
+++ b/app/web/index.html
@@ -541,9 +541,16 @@
               <h2>Liste d'intérêt</h2>
               <div class="panel-tools">
                 <div class="actions">
+                  <input id="watchlist-import-file" type="file" accept=".csv,text/csv" />
+                  <button id="watchlist-import-button" type="button">Importer CSV</button>
                   <button id="refresh-watchlist" type="button">Rafraîchir</button>
                 </div>
               </div>
+            </div>
+
+            <div id="watchlist-import-result" class="hidden">
+              <p class="hint" id="watchlist-import-summary"></p>
+              <div id="watchlist-import-list"></div>
             </div>
 
             <div class="download-list-table">


### PR DESCRIPTION
### Motivation
- Provide a compact UI and client-side handler to import watchlist entries from a CSV file and display the import result without duplicating existing helpers.

### Description
- Add CSV file input, import button and a small result container to the watchlist panel in `app/web/index.html`.
- Implement `importWatchlistCsv()` which reads the file with `FileReader`, POSTs the CSV content to `POST /watchlist/import-csv` via `fetchJson`, calls `loadWatchlist()` to refresh the list and uses existing helpers (`showNotification`, `buildFileList`) to render results in `app/web/app.js`.
- Add `renderWatchlistImportResult()` to display added titles, totals and skipped count, and wire the import button in `setupEventListeners()`.

### Testing
- Ran `bundle exec rake test`, which failed due to project dependency checkout requiring `bundle install` for a git-sourced gem (failure unrelated to the UI changes).
- Served the web UI with `python -m http.server 8000` and used an automated Playwright script to load `app/web/index.html` and capture a screenshot of the updated watchlist panel, which completed successfully and produced `artifacts/watchlist-import.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697342eb7120832797d26916d5c15e43)