### PR TITLE
Refactor CSV watchlist import to resolve titles via calendar and providers

### DIFF
--- a/app/library.rb
+++ b/app/library.rb
@@ -609,7 +609,7 @@ class Library
           next
         end
 
-        type = row['type']&.to_s&.strip
+        type = row['type'].to_s.strip
         type = type.empty? ? nil : Utils.regularise_media_type(type)
         year = row['year']&.to_s&.strip
         year_i = (year && year =~ /^\d{4}$/) ? year.to_i : nil

--- a/app/library.rb
+++ b/app/library.rb
@@ -600,17 +600,32 @@ class Library
       rows = []
       added_titles = []
       skipped = 0
+      repository = CalendarEntriesRepository.new(app: app)
+      calendar_service = MediaLibrarian::Services::CalendarFeedService.new(app: app)
       csv_rows.each do |row|
         title = row['title']&.to_s&.strip
-        imdb_id = (row['imdb_id'] || row['imdb'] || row['external_id'])&.to_s&.strip
-        if title.nil? || title.empty? || imdb_id.nil? || imdb_id.empty?
+        if title.nil? || title.empty?
           skipped += 1
           next
         end
 
-        type = Utils.regularise_media_type((row['type'] || 'movies').to_s)
+        type = row['type']&.to_s&.strip
+        type = type.empty? ? nil : Utils.regularise_media_type(type)
         year = row['year']&.to_s&.strip
         year_i = (year && year =~ /^\d{4}$/) ? year.to_i : nil
+        entry = repository.search(title: title, year: year_i, type: type).first
+        if entry.nil?
+          entry = calendar_service.search(title: title, year: year_i, type: type, persist: false).first
+          entry = calendar_service.persist_entry(entry) || entry if entry
+        end
+        unless entry && entry[:imdb_id].to_s != ''
+          skipped += 1
+          next
+        end
+
+        entry_title = entry[:title].to_s.strip
+        entry_title = title if entry_title.empty?
+        entry_type = Utils.regularise_media_type((entry[:type] || entry[:media_type] || type || 'movies').to_s)
         alts = row['alt_titles']&.to_s&.strip
         url = row['url']&.to_s&.strip
         tmdb = (row['tmdb_id'] || row['tmdb'])&.to_s&.strip
@@ -620,8 +635,8 @@ class Library
         metadata[:alt_titles] = alts if alts && !alts.empty?
         metadata[:url] = url if url && !url.empty?
         metadata[:tmdb] = tmdb if tmdb && !tmdb.empty?
-        rows << { imdb_id: imdb_id, title: title, type: type, metadata: metadata.empty? ? nil : metadata }
-        added_titles << title
+        rows << { imdb_id: entry[:imdb_id], title: entry_title, type: entry_type, metadata: metadata.empty? ? nil : metadata }
+        added_titles << entry_title
       end
       if rows.empty?
         return detailed ? { 'added_titles' => [], 'total_added' => 0, 'skipped' => skipped } : 0


### PR DESCRIPTION
### Motivation
- Allow importing CSVs that contain at minimum a `title` (with optional `year`/`type`) instead of requiring an `imdb_id`.
- Resolve titles to calendar entries (local first, then external providers) so the watchlist can show enriched details.
- Persist externally discovered calendar entries before adding them to the watchlist so UI details are available.

### Description
- Instantiate `CalendarEntriesRepository` and `MediaLibrarian::Services::CalendarFeedService` and prefer `repository.search(title:, year:, type:)` before falling back to `CalendarFeedService.search`.
- Accept optional `type`/`year` CSV columns and treat missing `imdb_id` as acceptable by resolving entries from calendar/provider lookups; skip rows without a resolvable entry.
- Persist provider results with `CalendarFeedService.persist_entry` (when found) and build `rows` for `WatchlistStore.upsert` using the resolved `entry[:imdb_id]`, `title`, and normalized `type`.
- Preserve the older CLI-compatible return behavior when `detailed` is false (integer count) and return a structure with `added_titles` and `total_added` when `detailed` is requested.

### Testing
- Ran `bundle exec rake test`, which failed to run due to bundler/git dependency checkout issues for git-sourced gems (error: run `bundle install` / missing checkout for `archive-zip`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973456d762c83278ec213d476aed718)