### PR TITLE
Add async watchlist CSV import job

### DIFF
--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -17,7 +17,7 @@ require 'get_process_mem'
 require 'socket'
 require 'open3'
 require 'csv'
-require 'tempfile'
+require 'tmpdir'
 
 require_relative '../lib/cache'
 require_relative '../lib/logger'
@@ -2409,10 +2409,9 @@ class Daemon
       content = csv_content.to_s
       raise ArgumentError, 'empty_csv' if content.strip.empty?
 
-      file = Tempfile.new(['watchlist-import', '.csv'])
-      file.write(content)
-      file.close
-      file.path
+      path = File.join(Dir.tmpdir, "watchlist-import-#{SecureRandom.hex(8)}.csv")
+      File.write(path, content)
+      path
     end
 
     def handle_directory_request(req, res, base_path, directory, mutex, after_save: nil)

--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -17,6 +17,7 @@ require 'get_process_mem'
 require 'socket'
 require 'open3'
 require 'csv'
+require 'tempfile'
 
 require_relative '../lib/cache'
 require_relative '../lib/logger'
@@ -2314,6 +2315,12 @@ class Daemon
       return method_not_allowed(res, 'POST') unless req.request_method == 'POST'
 
       payload = parse_payload(req)
+      if truthy?(payload['async'])
+        args = build_watchlist_import_csv_args(payload)
+        job = enqueue(args: args, parent_thread: nil, task: 'watchlist_import_csv')
+        return json_response(res, body: { 'job_id' => job&.id, 'job' => job&.to_h })
+      end
+
       csv_content = payload['csv_content']
       return error_response(res, status: 422, message: 'missing_csv') if csv_content.nil?
 
@@ -2341,6 +2348,41 @@ class Daemon
       error_response(res, status: 422, message: e.message)
     rescue StandardError => e
       error_response(res, status: 422, message: e.message)
+    end
+
+    def build_watchlist_import_csv_args(payload)
+      list_name = payload['list_name'].to_s.strip
+      replace = payload['replace']
+      csv_content = payload['csv_content']
+      csv_path = payload['csv_path']
+
+      if csv_content.nil? && csv_path.nil?
+        raise ArgumentError, 'missing_csv'
+      end
+
+      args = ['library', 'import_csv']
+      args << "--list_name=#{list_name}" unless list_name.empty?
+      args << "--replace=#{replace}" unless replace.nil?
+      args << "--csv_path=#{resolve_watchlist_csv_path(csv_content, csv_path)}"
+      args
+    end
+
+    def resolve_watchlist_csv_path(csv_content, csv_path)
+      if csv_content.nil?
+        csv_path = csv_path.to_s.strip
+        raise ArgumentError, 'missing_csv' if csv_path.empty?
+        raise ArgumentError, "CSV file not found: #{csv_path}" unless File.file?(csv_path)
+
+        return csv_path
+      end
+
+      content = csv_content.to_s
+      raise ArgumentError, 'empty_csv' if content.strip.empty?
+
+      file = Tempfile.new(['watchlist-import', '.csv'])
+      file.write(content)
+      file.close
+      file.path
     end
 
     def handle_directory_request(req, res, base_path, directory, mutex, after_save: nil)


### PR DESCRIPTION
### Motivation
- Allow watchlist CSV imports to be dispatched as background jobs and return immediately with a `job_id` so long-running imports don't block the control API.
- Reuse the existing job infrastructure (`enqueue`/`/jobs`) and accept either inline CSV content or a provided CSV path to stay lean.

### Description
- Add `require 'tempfile'` and async handling in `handle_watchlist_import_csv_request` to enqueue a job when `async` is truthy and return `{ job_id, job }` immediately.
- Add `build_watchlist_import_csv_args(payload)` to construct the `library import_csv` command args from `list_name`, `replace`, and CSV source.
- Add `resolve_watchlist_csv_path(csv_content, csv_path)` which validates inputs and writes inline `csv_content` to a `Tempfile`, returning a filesystem path usable by the enqueued job.
- Keep validation consistent with existing endpoint behavior (missing/empty CSV, malformed CSV) and reuse the `enqueue` API with task `watchlist_import_csv`.

### Testing
- Run syntax check with `ruby -c app/daemon.rb` which returned `Syntax OK`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697388fd377883279d5263524e4bb2f0)