### PR TITLE
Add watchlist import progress view and polling

### DIFF
--- a/app/web/index.html
+++ b/app/web/index.html
@@ -574,6 +574,19 @@
               <p class="hint" id="watchlist-empty">Aucun média dans cette liste.</p>
             </div>
           </section>
+          <section class="panel hidden" id="watchlist-import-panel">
+            <div class="panel-header">
+              <h2>Import en cours</h2>
+            </div>
+            <div class="import-status">
+              <p>Statut: <span id="watchlist-import-status">En cours</span></p>
+              <p>Ajoutés / total: <span id="watchlist-import-count">0 / 0</span></p>
+              <p>Dernier titre traité: <span id="watchlist-import-title">—</span></p>
+              <p class="hint hidden" id="watchlist-import-error"></p>
+            </div>
+            <p class="hint hidden" id="watchlist-import-final"></p>
+            <button id="watchlist-import-back" type="button" class="primary hidden">Retour à la liste d’intérêt</button>
+          </section>
         </section>
       </div>
     </main>


### PR DESCRIPTION
### Motivation
- Provide user feedback during long-running CSV imports of the watchlist by showing progress, current item and final summary. 
- Switch watchlist CSV import to async mode and poll job status so the UI remains responsive and shows live progress.

### Description
- Added a new `Import en cours` panel in `app/web/index.html` with elements for `status`, `ajoutés / total`, `dernier titre traité`, error display and a `Retour à la liste d’intérêt` button. 
- Added `watchlistImport` state and lightweight UI helpers in `app/web/app.js`: `setWatchlistImportView`, `updateWatchlistImportPanel`, `startWatchlistImportPolling`, `pollWatchlistImport`, `stopWatchlistImportPolling` and `closeWatchlistImportView` to manage the panel and polling. 
- Modified `importWatchlistCsv` to POST `async: true` to `/watchlist/import-csv`, extract the returned `job_id`, show a notification and start polling the created job every 2s to update the panel and render final summary when done. 
- Wire up the `Retour à la liste d’intérêt` button to close the import view and restored watchlist content once the job finishes.

### Testing
- Ran `bundle exec rake test`, which failed due to missing Bundler git dependencies and requires `bundle install` (automated test run failed). 
- Performed a lightweight automated UI verification by serving `app/web` with `python -m http.server` and running a headless Playwright script that loads `index.html`, activates the `downloads` view, reveals the import panel and captures a screenshot; the script succeeded and produced `artifacts/watchlist-import.png` demonstrating the new panel layout and dynamic fields.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973904b581483279602601b85dded50)