### PR TITLE
Show watchlist import titles in job progress

### DIFF
--- a/app/library.rb
+++ b/app/library.rb
@@ -608,6 +608,7 @@ class Library
       end
       rows = []
       added_titles = []
+      title_limit = 50
       skipped = 0
       progress = {
         'processed' => 0,
@@ -674,14 +675,17 @@ class Library
         update_progress.call
       end
       if rows.empty?
+        progress['added_titles'] = []
         update_progress.call(true)
         return detailed ? { 'added_titles' => [], 'total_added' => 0, 'skipped' => skipped } : 0
       end
 
       count = WatchlistStore.upsert(rows)
       app.speaker.speak_up("import_list_csv: imported #{count} rows into watchlist", 0) if defined?(app.speaker)
-      added_titles = [] if detailed && count.to_i.zero?
+      added_titles = [] if count.to_i.zero?
+      added_titles = added_titles.first(title_limit)
       progress['added'] = count
+      progress['added_titles'] = added_titles
       update_progress.call(true)
       detailed ? { 'added_titles' => added_titles, 'total_added' => count, 'skipped' => skipped } : count
     rescue => e

--- a/app/web/app.js
+++ b/app/web/app.js
@@ -3337,12 +3337,14 @@ function updateWatchlistImportPanel({
   summary,
   error,
   showBack,
+  titles,
 } = {}) {
   const status = document.getElementById('watchlist-import-status');
   const count = document.getElementById('watchlist-import-count');
   const title = document.getElementById('watchlist-import-title');
   const errorEl = document.getElementById('watchlist-import-error');
   const finalEl = document.getElementById('watchlist-import-final');
+  const finalList = document.getElementById('watchlist-import-final-list');
   const backButton = document.getElementById('watchlist-import-back');
   if (status && statusLabel) {
     status.textContent = statusLabel;
@@ -3360,6 +3362,11 @@ function updateWatchlistImportPanel({
   if (finalEl) {
     finalEl.textContent = summary || '';
     finalEl.classList.toggle('hidden', !summary);
+  }
+  if (finalList) {
+    const list = buildFileList(titles);
+    finalList.replaceChildren(...(list ? [list] : []));
+    finalList.classList.toggle('hidden', !list);
   }
   if (backButton) {
     backButton.classList.toggle('hidden', !showBack);
@@ -3420,6 +3427,7 @@ async function pollWatchlistImport(jobId) {
     const total = Number.isFinite(Number(progress.total)) ? Number(progress.total) : 0;
     const skipped = Number.isFinite(Number(progress.skipped)) ? Number(progress.skipped) : 0;
     const currentTitle = progress.current_title || '';
+    const titles = Array.isArray(progress.added_titles) ? progress.added_titles : [];
     const status = String(job?.status || '');
     const statusLabel = status === 'finished'
       ? 'Terminé'
@@ -3436,12 +3444,13 @@ async function pollWatchlistImport(jobId) {
       total,
       currentTitle,
       summary,
+      titles: done ? titles : [],
       error: done && statusLabel === 'Erreur' ? job?.error || 'Import échoué.' : '',
       showBack: done,
     });
     if (done) {
       stopWatchlistImportPolling();
-      renderWatchlistImportResult({ total_added: added, skipped });
+      renderWatchlistImportResult({ total_added: added, skipped, added_titles: titles });
       await loadWatchlist();
     }
   } catch (error) {

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -585,6 +585,7 @@
               <p class="hint hidden" id="watchlist-import-error"></p>
             </div>
             <p class="hint hidden" id="watchlist-import-final"></p>
+            <div id="watchlist-import-final-list" class="hidden"></div>
             <button id="watchlist-import-back" type="button" class="primary hidden">Retour à la liste d’intérêt</button>
           </section>
         </section>


### PR DESCRIPTION
### Motivation
- Provide the final job state with a sample of the titles added by a CSV watchlist import so users see what was actually inserted alongside the counts.
- Surface that information in the import UI and keep the watchlist view up to date after import completion.

### Description
- Added an `added_titles` array into the import job progress payload (capped to 50 titles) so the daemon returns a trimmed list of inserted titles during/finalizing the job (`app/library.rb`).
- Exposed the trimmed `added_titles` through the jobs polling flow and passed it to the UI panel updater (`app/web/app.js`).
- Rendered the added-title list in the import completion UI and added a new container element with id `watchlist-import-final-list` to `app/web/index.html`.
- Kept existing behavior to refresh the watchlist view after job completion by calling `loadWatchlist()` at the end of the polling flow.

### Testing
- Ran `ruby -c app/library.rb` and `ruby -c app/daemon.rb` to validate Ruby syntax: both succeeded.
- Ran `node --check app/web/app.js` to validate JavaScript syntax: succeeded.
- Performed a headless render test (served `app/web` and used Playwright) to verify the import panel shows the final summary and list; a screenshot artifact was produced successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697391c682508327817ac2229bc590c0)