### PR TITLE
Fix watchlist import panel visibility toggling

### DIFF
--- a/app/web/app.js
+++ b/app/web/app.js
@@ -3326,7 +3326,9 @@ function setWatchlistImportView(active) {
     return;
   }
   panel.hidden = !active;
+  panel.classList.toggle('hidden', !active);
   watchlistPanel.hidden = active;
+  watchlistPanel.classList.toggle('hidden', active);
 }
 
 function updateWatchlistImportPanel({


### PR DESCRIPTION
### Motivation
- Ensure the watchlist import panel becomes visible when activated by preventing the `.hidden` class from keeping it hidden and by keeping class-based visibility in sync with the `hidden` attribute.

### Description
- Update `setWatchlistImportView` in `app/web/app.js` to also toggle the `.hidden` class for `#watchlist-import-panel` and `#watchlist-panel` via `panel.classList.toggle('hidden', !active)` and `watchlistPanel.classList.toggle('hidden', active)`.

### Testing
- Ran the project test suite with `bundle exec rake test`, which failed due to a missing bundled git dependency and requires running `bundle install` first (test run failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973930095d48327b359e6f742c21c01)