### PR TITLE
Add cache-busted app.js versioning

### DIFF
--- a/app/web/index.html
+++ b/app/web/index.html
@@ -615,6 +615,6 @@
     <script src="path_utils.js" defer></script>
     <script src="calendar_window.js" defer></script>
     <script src="tracker_links.js" defer></script>
-    <script src="app.js" defer></script>
+    <script src="app.js?v=__APP_VERSION__" defer></script>
   </body>
 </html>


### PR DESCRIPTION
### Motivation
- Prevent browsers/proxies from serving a stale `app.js` after the server is updated by forcing a cache-busted URL.

### Description
- Update `app/web/index.html` to use a version placeholder in the script tag: `app.js?v=__APP_VERSION__`.
- Inject a startup-generated version timestamp (`@web_asset_version = Time.now.utc.strftime('%Y%m%d%H%M')`) in `app/daemon.rb` and replace the placeholder when serving `index.html`.
- Replace the default file handler mount for `/` with a small `mount_proc` that serves the patched `index.html` (with substituted version) while delegating other asset requests to the `WEBrick::HTTPServlet::FileHandler`.

### Testing
- Ran `bundle exec rake test`, which failed due to an external Bundler git dependency not being checked out (`bundle install` required).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69739f7f6ba88327bc380670896cc086)