### PR TITLE
Make CSV import verbose by default

### DIFF
--- a/app/library.rb
+++ b/app/library.rb
@@ -599,7 +599,7 @@ class Library
       csv_rows = csv_rows.to_a unless csv_rows.is_a?(Array)
       total = csv_rows.size
       speaker = app.respond_to?(:speaker) ? app.speaker : nil
-      verbose = detailed || (defined?(Env) && Env.debug?)
+      verbose = true
       speaker&.speak_up("import_list_csv: starting (total #{total})", 0)
       rows = []
       added_titles = []


### PR DESCRIPTION
### Motivation
- Ensure `import_list_csv` always emits per-row logs to aid troubleshooting instead of depending on `detailed` or `Env.debug?`.

### Description
- In `app/library.rb` set `verbose = true` inside `Library.import_list_csv`, replacing the previous `detailed || (defined?(Env) && Env.debug?)` conditional so logging is enabled by default.

### Testing
- Ran `bundle exec ruby -c app/library.rb` to validate syntax and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973afcfb8388327acf9ab6a224b9491)