### PR TITLE
Allow calendar search to include existing entries

### DIFF
--- a/app/library.rb
+++ b/app/library.rb
@@ -666,7 +666,7 @@ class Library
         persisted = entry
         row_notes << "db=#{entry ? 'hit' : 'miss'}"
         if entry.nil?
-          entry = calendar_service.search(title: title, year: year_i, type: type, persist: false).first
+          entry = calendar_service.search(title: title, year: year_i, type: type, persist: false, include_existing: true).first
           row_notes << "imdb_fallback=#{entry ? 'hit' : 'miss'}"
           persisted_entry = entry ? calendar_service.persist_entry(entry) : nil
           row_notes << "persist=#{persisted_entry ? 'ok' : 'failed'}" if entry

--- a/app/library.rb
+++ b/app/library.rb
@@ -668,11 +668,12 @@ class Library
         if entry.nil?
           entry = calendar_service.search(title: title, year: year_i, type: type, persist: false, include_existing: true).first
           row_notes << "imdb_fallback=#{entry ? 'hit' : 'miss'}"
-          persisted_entry = entry ? calendar_service.persist_entry(entry) : nil
-          row_notes << "persist=#{persisted_entry ? 'ok' : 'failed'}" if entry
-          entry = persisted_entry || entry if entry
           imdb_id = entry[:imdb_id].to_s.strip if entry
-          persisted = imdb_id.empty? ? nil : repository.find_by_imdb_id(imdb_id)
+          persisted = imdb_id.to_s.empty? ? nil : repository.find_by_imdb_id(imdb_id)
+          if entry && persisted.nil?
+            persisted = calendar_service.persist_entry(entry)
+            row_notes << "persist=#{persisted ? 'ok' : 'failed'}"
+          end
         end
         if entry.nil? || persisted.nil?
           skipped += 1

--- a/app/media_librarian/services/calendar_feed_service.rb
+++ b/app/media_librarian/services/calendar_feed_service.rb
@@ -58,13 +58,13 @@ module MediaLibrarian
         normalized
       end
 
-      def search(title:, year: nil, type: nil, persist: true)
+      def search(title:, year: nil, type: nil, persist: true, include_existing: false)
         return [] unless calendar_table_available?
         return [] if title.to_s.strip.empty?
 
         date_range = year ? Date.new(year.to_i, 1, 1)..Date.new(year.to_i, 12, 31) : nil
         normalized = normalize_entries(provider_search(title: title, year: year, type: type), date_range)
-        normalized = filter_existing_entries(normalized)
+        normalized = filter_existing_entries(normalized) unless include_existing
         persist_entries(normalized) if persist
         normalized
       end


### PR DESCRIPTION
### Motivation
- Allow specific callers (notably CSV imports) to retrieve calendar results that already exist in `calendar_entries` while preserving the default de-duplication behavior for other callers.

### Description
- Add an `include_existing: false` keyword argument to `MediaLibrarian::Services::CalendarFeedService#search` and bypass `filter_existing_entries` when `include_existing` is true.
- Update `Library.import_list_csv` in `app/library.rb` to call `calendar_service.search(..., include_existing: true)` for CSV fallback lookups.

### Testing
- Verified syntax with `bundle exec ruby -c app/media_librarian/services/calendar_feed_service.rb` which returned `Syntax OK`.
- Verified syntax with `bundle exec ruby -c app/library.rb` which returned `Syntax OK`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973caa0efec8327aa244f60eef8e272)