### PR TITLE
Add debug flag for watchlist CSV import

### DIFF
--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -2380,6 +2380,7 @@ class Daemon
       args = ['library', 'import_csv']
       args << "--replace=#{replace}" unless replace.nil?
       args << "--csv_path=#{resolve_watchlist_csv_path(csv_content, csv_path)}"
+      args << '--debug=1' if truthy?(payload['debug']) || payload['debug'] == 1
       args
     end
 

--- a/app/web/app.js
+++ b/app/web/app.js
@@ -3492,16 +3492,21 @@ async function importWatchlistCsv() {
     button.disabled = true;
   }
   try {
+    const debug = document.getElementById('watchlist-import-debug')?.checked;
     const csvContent = await new Promise((resolve, reject) => {
       const reader = new FileReader();
       reader.onload = () => resolve(reader.result);
       reader.onerror = () => reject(reader.error || new Error('Lecture du fichier impossible.'));
       reader.readAsText(file);
     });
+    const payload = { csv_content: csvContent, async: true };
+    if (debug) {
+      payload.debug = 1;
+    }
     const data = await fetchJson('/watchlist/import-csv', {
       method: 'POST',
       headers: new Headers({ 'Content-Type': 'application/json' }),
-      body: JSON.stringify({ csv_content: csvContent, async: true, debug: 1 }),
+      body: JSON.stringify(payload),
     });
     const jobId = data?.job_id || data?.job?.id;
     if (!jobId) {

--- a/app/web/app.js
+++ b/app/web/app.js
@@ -3501,7 +3501,7 @@ async function importWatchlistCsv() {
     const data = await fetchJson('/watchlist/import-csv', {
       method: 'POST',
       headers: new Headers({ 'Content-Type': 'application/json' }),
-      body: JSON.stringify({ csv_content: csvContent, async: true }),
+      body: JSON.stringify({ csv_content: csvContent, async: true, debug: 1 }),
     });
     const jobId = data?.job_id || data?.job?.id;
     if (!jobId) {

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -543,6 +543,7 @@
                 <div class="actions">
                   <input id="watchlist-import-file" type="file" accept=".csv,text/csv" />
                   <button id="watchlist-import-button" type="button">Importer CSV</button>
+                  <label><input id="watchlist-import-debug" type="checkbox" /> Debug</label>
                   <button id="refresh-watchlist" type="button">Rafraîchir</button>
                 </div>
               </div>


### PR DESCRIPTION
### Motivation
- Ensure async watchlist CSV imports can enable debug mode by propagating a debug flag from the web UI to the daemon job args.

### Description
- Added `debug: 1` to the JSON payload in `importWatchlistCsv()` in `app/web/app.js` and updated `build_watchlist_import_csv_args(payload)` in `app/daemon.rb` to append `--debug=1` when `payload['debug']` is truthy or equals `1`.

### Testing
- Ran `bundle exec rake test`, which failed due to an unchecked-out git dependency and requires running `bundle install` first.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974a70773a483279954ea46e2226fca)