### PR TITLE
Fix watchlist import status data

### DIFF
--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -2379,6 +2379,7 @@ class Daemon
 
       args = ['library', 'import_csv']
       args << "--replace=#{replace}" unless replace.nil?
+      args << '--detailed=1'
       args << "--csv_path=#{resolve_watchlist_csv_path(csv_content, csv_path)}"
       args
     end

--- a/app/web/app.js
+++ b/app/web/app.js
@@ -3425,11 +3425,22 @@ async function pollWatchlistImport(jobId) {
   try {
     const job = await fetchJson(`/jobs/${encodeURIComponent(jobId)}`);
     const progress = job?.progress || {};
-    const added = Number.isFinite(Number(progress.added)) ? Number(progress.added) : 0;
-    const total = Number.isFinite(Number(progress.total)) ? Number(progress.total) : 0;
-    const skipped = Number.isFinite(Number(progress.skipped)) ? Number(progress.skipped) : 0;
+    const result = job?.result && typeof job.result === 'object' ? job.result : {};
+    const added = Number.isFinite(Number(progress.added))
+      ? Number(progress.added)
+      : Number(result.total_added) || 0;
+    const skipped = Number.isFinite(Number(progress.skipped))
+      ? Number(progress.skipped)
+      : Number(result.skipped) || 0;
+    const total = Number.isFinite(Number(progress.total))
+      ? Number(progress.total)
+      : added + skipped;
     const currentTitle = progress.current_title || '';
-    const titles = Array.isArray(progress.added_titles) ? progress.added_titles : [];
+    const titles = Array.isArray(progress.added_titles)
+      ? progress.added_titles
+      : Array.isArray(result.added_titles)
+      ? result.added_titles
+      : [];
     const status = String(job?.status || '');
     const statusLabel = status === 'finished'
       ? 'Terminé'


### PR DESCRIPTION
### Motivation
- The watchlist CSV import UI could show zeros because async import jobs sometimes expose results in `job.result` instead of `job.progress`, and background imports were not requesting detailed output.

### Description
- Pass `--detailed=1` when launching async watchlist CSV import jobs so the worker produces detailed result counts and titles via `Library.import_list_csv` (`app/daemon.rb`).
- Enhance the client-side poller to fall back to `job.result` fields when `job.progress` lacks counts or titles, computing `added`, `skipped`, `total`, and `added_titles` accordingly (`app/web/app.js`).

### Testing
- Ran `bundle exec rake test`, which failed due to missing Git checkout for a dependency and requires running `bundle install` first (failure unrelated to the change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974a900b83c8327beb5cfbdaa50256e)