### PR TITLE
Normalize OMDb calendar type mapping

### DIFF
--- a/app/media_librarian/services/calendar_feed_service.rb
+++ b/app/media_librarian/services/calendar_feed_service.rb
@@ -1425,10 +1425,11 @@ module MediaLibrarian
         end
 
         def omdb_type(value)
-          type = value.to_s.downcase
-          return 'series' if type.include?('show') || type == 'series'
+          type = Utils.canonical_media_type(value)
+          return 'movie' if type.to_s.strip.empty?
+          return 'series' if type == 'show'
 
-          type.empty? ? 'movie' : type
+          type
         end
 
         def api_last_request_path(fetcher)


### PR DESCRIPTION
### Motivation
- Ensure OMDb calls use the canonical types OMDb expects by mapping plural and variant inputs (e.g. `movies`, `shows`, `tv`, `series`) to OMDb types and defaulting empty inputs to `movie`.

### Description
- Update `MediaLibrarian::Services::CalendarFeedService::OmdbCalendarProvider#omdb_type` in `app/media_librarian/services/calendar_feed_service.rb` to normalize the incoming `value` via `Utils.canonical_media_type`, return `'movie'` for blank input, map the normalized `'show'` to OMDb's `'series'`, and otherwise return the normalized type.

### Testing
- Ran `bundle exec ruby -Itest test/services/calendar_feed_service_test.rb` to validate behavior but the run failed due to an unchecked-out git-sourced dependency (requires `bundle install`), so tests could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974b31de0bc83279a6d045b81cda0d1)