### PR TITLE
Handle year suffix in list imports

### DIFF
--- a/app/library.rb
+++ b/app/library.rb
@@ -660,13 +660,18 @@ class Library
         type = type.empty? ? nil : Utils.regularise_media_type(type)
         year = row['year']&.to_s&.strip
         year_i = (year && year =~ /^\d{4}$/) ? year.to_i : nil
+        search_title = title
+        if year_i.nil? && (match = title.match(/\s*\((\d{4})\)\s*\z/))
+          year_i = match[1].to_i
+          search_title = title.sub(/\s*\(\d{4}\)\s*\z/, '').strip
+        end
         imdb_id = imdb_from_row.call(row)
         row_notes << "imdb_id=#{imdb_id.empty? ? '(empty)' : imdb_id}"
         entry = imdb_id.empty? ? nil : repository.find_by_imdb_id(imdb_id)
         persisted = entry
         row_notes << "db=#{entry ? 'hit' : 'miss'}"
         if entry.nil?
-          entry = calendar_service.search(title: title, year: year_i, type: type, persist: false, include_existing: true).first
+          entry = calendar_service.search(title: search_title, year: year_i, type: type, persist: false, include_existing: true).first
           row_notes << "imdb_fallback=#{entry ? 'hit' : 'miss'}"
           imdb_id = entry[:imdb_id].to_s.strip if entry
           persisted = imdb_id.to_s.empty? ? nil : repository.find_by_imdb_id(imdb_id)


### PR DESCRIPTION
### Motivation
- Ensure CSV rows with titles like `Title (YYYY)` and no `year` column still match calendar entries by extracting the year from the title for searching.

### Description
- In `Library.import_list_csv` (in `app/library.rb`) detect a trailing `"(YYYY)"` when `year` is missing, populate `year_i` from the extracted year, and use a cleaned `search_title` (original title with the ` (YYYY)` suffix removed) when calling `calendar_service.search`, while keeping the visible title unchanged for the watchlist.

### Testing
- Ran `bundle exec rake test`, which could not complete due to a Bundler error (missing git checkout for dependency `archive-zip`), so automated test suite did not run successfully for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974b3ca806083278d4f38f26268765e)