### PR TITLE
Normalize list import titles for calendar search

### DIFF
--- a/app/library.rb
+++ b/app/library.rb
@@ -661,8 +661,8 @@ class Library
         year = row['year']&.to_s&.strip
         year_i = (year && year =~ /^\d{4}$/) ? year.to_i : nil
         search_title = title
-        if year_i.nil? && (match = title.match(/\s*\((\d{4})\)\s*\z/))
-          year_i = match[1].to_i
+        if (match = title.match(/\s*\((\d{4})\)\s*\z/))
+          year_i ||= match[1].to_i
           search_title = title.sub(/\s*\(\d{4}\)\s*\z/, '').strip
         end
         imdb_id = imdb_from_row.call(row)


### PR DESCRIPTION
### Motivation
- Ensure calendar lookups use a cleaned title with any trailing year removed and the year supplied separately so provider searches are more accurate and not confused by embedded year tokens.

### Description
- Update `Library.import_list_csv` to strip a trailing `(<YYYY>)` from the CSV `title` into a new `search_title` while preserving an explicit `row['year']` by using `year_i ||= match[1].to_i` so an explicit year column takes precedence.
- Continue to call `calendar_service.search(title: search_title, year: year_i, ...)`, which preserves the contract that `MediaLibrarian::Services::CalendarFeedService::TmdbCalendarProvider#search_titles` receives `title` without an embedded year and `year` passed separately via `search_params`.

### Testing
- Ran a syntax check with `ruby -c app/library.rb` which returned `Syntax OK`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974b4f5ce5083279cd5af68e3523c14)