### PR TITLE
Link watchlist IMDB IDs to IMDb pages

### DIFF
--- a/app/web/app.js
+++ b/app/web/app.js
@@ -3206,13 +3206,14 @@ function renderWatchlist(entries = [], { message } = {}) {
     const imdb = entry.imdb_id || ids.imdb || '';
     const externalId = imdb || entry.id || ids.slug || '';
     const url = entry.url || '';
+    const imdbUrl = imdb ? `https://www.imdb.com/title/${imdb}` : '';
     const metadata = { ids, title, type, year, release_date: entry.release_date, imdb, url };
 
     const cells = [
       { text: title || '—' },
       { text: type || '—' },
       { text: year || '—' },
-      { text: imdb || externalId || '—' },
+      imdbUrl ? { link: imdbUrl, linkText: imdb, text: imdb } : { text: imdb || externalId || '—' },
       url ? { link: url } : { text: '—' },
     ];
 
@@ -3224,7 +3225,7 @@ function renderWatchlist(entries = [], { message } = {}) {
         link.href = value.link;
         link.target = '_blank';
         link.rel = 'noreferrer noopener';
-        link.textContent = 'Lien';
+        link.textContent = value.linkText || 'Lien';
         cell.appendChild(link);
       } else {
         cell.textContent = value.text || '—';


### PR DESCRIPTION
### Motivation
- Transform the IMDB ID column in the watchlist into a clickable link to the corresponding IMDb title page when an ID is available.

### Description
- Update `app/web/app.js` to compute `imdbUrl` and render the IMDB cell as an `<a>` to `https://www.imdb.com/title/<id>` using the IMDb ID as link text while preserving the original fallback text when no ID is present.

### Testing
- Ran `bundle exec rake test`, which failed due to a missing git dependency that requires running `bundle install` first, so automated tests did not complete successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974b83e840083278bfa6537d79020f4)