### PR TITLE
Enhance scripts/fix_calendar_entry_titles.rb with dry-run, verbose, and deletion of orphaned rows

### DIFF
--- a/scripts/fix_calendar_entry_titles.rb
+++ b/scripts/fix_calendar_entry_titles.rb
@@ -1,0 +1,106 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# Fix calendar entries whose titles match their external identifiers.
+#
+# Usage:
+#   bundle exec ruby scripts/fix_calendar_entry_titles.rb [--dry-run] [--verbose]
+#
+# Requires OMDb credentials to fetch real titles via IMDb IDs:
+#   - OMDB_API_KEY (env var), or
+#   - ~/.medialibrarian/conf.yml with omdb.api_key
+#
+# If enrichment fails, the script deletes the calendar entry (and watchlist
+# rows referencing the same ids) and logs the row for manual review.
+
+require 'bundler/setup'
+require 'optparse'
+require_relative '../lib/media_librarian/application'
+require_relative '../lib/omdb_api'
+require_relative '../app/media_librarian/services/calendar_feed_service'
+
+options = { dry_run: false, verbose: false }
+OptionParser.new do |opts|
+  opts.banner = 'Usage: bundle exec ruby scripts/fix_calendar_entry_titles.rb [options]'
+  opts.on('--dry-run', 'Do not update/delete records') { options[:dry_run] = true }
+  opts.on('--verbose', 'Print per-row details') { options[:verbose] = true }
+end.parse!(ARGV)
+
+app = MediaLibrarian.application
+db = app.db
+
+rows = Array(db.get_rows(:calendar_entries))
+
+api = begin
+  config = app.config || {}
+  api_key = ENV['OMDB_API_KEY'] || config.dig('omdb', 'api_key')
+  base_url = config.dig('omdb', 'base_url')
+  api_key.to_s.strip.empty? ? nil : OmdbApi.new(api_key: api_key, base_url: base_url)
+rescue StandardError
+  nil
+end
+
+def id_title_match?(title, value)
+  title = title.to_s.strip
+  value = value.to_s.strip
+  return false if title.empty? || value.empty?
+
+  title.casecmp?(value)
+end
+
+def enrich_title(row, api, app, db)
+  imdb_id = row[:imdb_id].to_s.strip
+  imdb_id = nil if imdb_id.empty?
+  title = nil
+
+  if api && imdb_id
+    details = api.title(imdb_id)
+    title = details[:title] || details['title'] if details
+  end
+
+  if title.to_s.strip.empty?
+    enriched = MediaLibrarian::Services::CalendarFeedService.enrich_entries([row.dup], app: app, db: db)&.first
+    title = enriched[:title] if enriched
+  end
+
+  title.to_s.strip.empty? ? nil : title
+end
+
+candidates = rows.select do |row|
+  id_title_match?(row[:title], row[:external_id]) || id_title_match?(row[:title], row[:imdb_id])
+end
+
+if candidates.empty?
+  puts 'No calendar entries need title fixes.'
+  exit(0)
+end
+
+updated = 0
+deleted = 0
+flagged = 0
+
+candidates.each do |row|
+  puts "Candidate ##{row[:id]} title=#{row[:title].inspect} external_id=#{row[:external_id].inspect} imdb_id=#{row[:imdb_id].inspect}" if options[:verbose]
+  new_title = enrich_title(row, api, app, db)
+  if !new_title || id_title_match?(new_title, row[:external_id]) || id_title_match?(new_title, row[:imdb_id])
+    puts "Needs review (delete): #{row.inspect}"
+    flagged += 1
+    unless options[:dry_run]
+      db.delete_rows(:calendar_entries, { id: row[:id] })
+      if db.table_exists?(:watchlist)
+        db.delete_rows(:watchlist, { imdb_id: row[:imdb_id] }) unless row[:imdb_id].to_s.strip.empty?
+        db.delete_rows(:watchlist, { external_id: row[:external_id] }) unless row[:external_id].to_s.strip.empty?
+      end
+    end
+    deleted += 1
+    next
+  end
+
+  unless options[:dry_run]
+    db.update_rows(:calendar_entries, { title: new_title }, { id: row[:id] })
+  end
+  puts "Updated ##{row[:id]} -> #{new_title.inspect}" if options[:verbose]
+  updated += 1
+end
+
+puts "Updated #{updated} calendar entr#{updated == 1 ? 'y' : 'ies'}, deleted #{deleted} (#{flagged} flagged)."


### PR DESCRIPTION
### Motivation
- Repair calendar rows whose `title` is an identifier (e.g. equals `external_id` or `imdb_id`) so the UI/search shows real titles instead of raw IDs. 
- Prefer removing unreachable/invalid rows (and related watchlist references) instead of writing placeholder titles to avoid orphaned or misleading data. 
- Provide safe execution via a `--dry-run` mode and improve visibility with a `--verbose` option for operator confidence.

### Description
- Add CLI parsing via `OptionParser` and support for `--dry-run` and `--verbose` flags in `scripts/fix_calendar_entry_titles.rb`.
- Attempt enrichment first with `OmdbApi` (using `OMDB_API_KEY` env or config `omdb.api_key`) and then with `MediaLibrarian::Services::CalendarFeedService.enrich_entries`, and update `calendar_entries.title` when a valid title is found.
- When enrichment fails or the returned title still matches an identifier, delete the `calendar_entries` row and also delete `watchlist` rows referencing the same `imdb_id` or `external_id` when the `watchlist` table exists, honoring `--dry-run` to skip actual DB changes.
- Add row-level logging and a final summary that reports updated and deleted counts, and keep the script header documenting usage and OMDb credential sources.

### Testing
- Ran a syntax check with `ruby -c scripts/fix_calendar_entry_titles.rb`, which returned `Syntax OK`.
- Verified the script loads the application and DB accessor paths without require-time errors by exercising the code paths in a dry-run (no database changes) during development, and those checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974c320cdd083279aa863c826057201)