### PR TITLE
Skip missing columns when deleting dependents

### DIFF
--- a/scripts/fix_calendar_entry_titles.rb
+++ b/scripts/fix_calendar_entry_titles.rb
@@ -86,7 +86,10 @@ def delete_dependents(db, row, dry_run, verbose)
   deps.each do |table, cols|
     next unless db.table_exists?(table)
 
+    columns = db.database.schema(table).map(&:first)
     cols.each do |col|
+      next unless columns.include?(col)
+
       value = col == :external_id ? external_id : row[col]
       next if value.to_s.strip.empty?
 


### PR DESCRIPTION
### Motivation
- Prevent SQL errors when `scripts/fix_calendar_entry_titles.rb` attempts to delete dependent rows using columns that may not exist (for example `external_id` removed from `watchlist` by migrations).

### Description
- Add a guard in `delete_dependents` that inspects `db.database.schema(table).map(&:first)` and skips any configured dependent column that is not present before attempting deletion.

### Testing
- Ran `bundle exec ruby -c scripts/fix_calendar_entry_titles.rb` which returned `Syntax OK`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974ccc2642c83278bab8238ddb6702c)