### PR TITLE
Expose skipped watchlist import entries

### DIFF
--- a/app/web/index.html
+++ b/app/web/index.html
@@ -552,6 +552,7 @@
             <div id="watchlist-import-result" class="hidden">
               <p class="hint" id="watchlist-import-summary"></p>
               <div id="watchlist-import-list"></div>
+              <div id="watchlist-import-skipped"></div>
             </div>
 
             <div class="download-list-table">
@@ -587,6 +588,7 @@
             </div>
             <p class="hint hidden" id="watchlist-import-final"></p>
             <div id="watchlist-import-final-list" class="hidden"></div>
+            <div id="watchlist-import-final-skipped" class="hidden"></div>
             <button id="watchlist-import-back" type="button" class="primary hidden">Retour à la liste d’intérêt</button>
           </section>
         </section>


### PR DESCRIPTION
### Motivation
- Collect detailed information about CSV rows skipped during watchlist import so users can see which entries failed identification and why.
- Surface that information in both async progress updates and the final detailed import result so UIs and APIs can present skipped entries.
- Improve the watchlist import UI to clearly distinguish added titles from non‑identified/skipped entries.

### Description
- Add tracking of skipped entries in `Library.import_list_csv` by collecting human‑readable labels and reasons into `skipped_entries`, updating `progress['skipped_entries']`, and returning `skipped_entries` in detailed results and on errors (`app/library.rb`).
- Add a small helper `register_skip` to format skipped entry labels (title, imdb) and record reasons (`app/library.rb`).
- Extend the web UI with a new labeled list renderer and containers to display skipped entries, update the poll/render logic to consume `skipped_entries` from job progress/result, and adjust wording to distinguish added vs non‑identified titles (`app/web/app.js`, `app/web/index.html`).

### Testing
- Ran `bundle exec rake test`, which failed due to an environment dependency error requiring `bundle install` for a git dependency (test run did not complete).
- Attempted a lightweight UI smoke test by serving `app/web` and exercising the new client code via a Playwright script, but Playwright crashed in this environment (browser process SIGSEGV / TargetClosedError), so automated UI screenshot capture did not complete.
- Performed local code inspection and manual sanity checks of the updated JS/HTML to ensure lists render when `skipped_entries` is present (no runtime JS syntax errors observed in the edited files).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974d361c1a08327b161aa275600c7d1)