### PR TITLE
Harden OMDb JSON repair for missing commas

### DIFF
--- a/lib/omdb_api.rb
+++ b/lib/omdb_api.rb
@@ -279,7 +279,11 @@ class OmdbApi
 
   def tighten_json(body)
     closing = body.rindex(/[}\]]/)
-    closing ? body[0..closing].gsub(/([\]\}"0-9])\s*"(?=[A-Za-z0-9_]+":)/, '\\1,"') : nil
+    return nil unless closing
+
+    body[0..closing]
+      .gsub(/([\]\}"0-9])\s*"(?=[A-Za-z0-9_]+":)/, '\\1,"')
+      .gsub(/([\]\}"0-9])\s*([A-Za-z0-9_]+":)/, '\\1,"\\2')
   end
 
   def report_error(error, message)


### PR DESCRIPTION
### Motivation
- Improve resilience against malformed OMDb responses by making the JSON tightening routine recover when keys are missing quotes or commas after values.

### Description
- Update `tighten_json` to return `nil` when no closing bracket/brace is found and add an extra `gsub` pass to insert missing opening quotes before keys after values, making repairs more likely to yield valid JSON.

### Testing
- Ran the test runner with `bundle exec rake test`, which failed to start because a bundler git dependency (`archive-zip`) is not checked out and requires running `bundle install`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974e0ec1c9c83279e13666f385a7c91)