### PR TITLE
Allow import CSV progress to update private job progress

### DIFF
--- a/app/library.rb
+++ b/app/library.rb
@@ -633,7 +633,7 @@ class Library
       progress_step = 25
       jid = Thread.current[:jid]
       update_progress = lambda do |force = false|
-        return unless jid && defined?(Daemon) && Daemon.respond_to?(:update_job_progress)
+        return unless jid && defined?(Daemon) && Daemon.respond_to?(:update_job_progress, true)
         return unless force || (progress['processed'].positive? && (progress['processed'] % progress_step).zero?)
 
         Daemon.update_job_progress(jid, progress.dup)


### PR DESCRIPTION
### Motivation
- Ensure CSV import progress is persisted to the daemon job so the `/jobs/:id` endpoint can expose live progress including `total`, `current_title`, and `skipped_entries`.

### Description
- Change the `update_progress` guard in `Library.import_list_csv` to use `Daemon.respond_to?(:update_job_progress, true)` so the import can call a private `Daemon.update_job_progress` and the existing `progress` hash (containing `total`, `current_title`, and `skipped_entries`) is pushed into `job.progress`.

### Testing
- Ran a Ruby syntax check with `bundle exec ruby -c app/library.rb app/daemon.rb` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974fe44b3288327924107f88392371b)