### PR TITLE
Add generated database schema documentation and generator script

### DIFF
--- a/docs/database_schema.md
+++ b/docs/database_schema.md
@@ -1,0 +1,197 @@
+# Database schema
+
+Regenerate with:
+```sh
+bundle exec ruby scripts/generate_database_schema.rb
+```
+
+## calendar_entries
+
+| Column | Type | Null | Default | PK |
+| --- | --- | --- | --- | --- |
+| id | INTEGER | NO |  | YES |
+| source | varchar(50) | NO |  |  |
+| external_id | varchar(200) | NO |  |  |
+| title | varchar(500) | NO |  |  |
+| media_type | varchar(50) | NO |  |  |
+| genres | TEXT | YES |  |  |
+| languages | TEXT | YES |  |  |
+| countries | TEXT | YES |  |  |
+| rating | double precision | YES |  |  |
+| release_date | date | YES |  |  |
+| created_at | timestamp | YES |  |  |
+| updated_at | timestamp | YES |  |  |
+| poster_url | varchar(500) | YES |  |  |
+| backdrop_url | varchar(500) | YES |  |  |
+| ids | TEXT | YES |  |  |
+| imdb_votes | INTEGER | YES |  |  |
+| synopsis | TEXT | YES |  |  |
+| imdb_id | varchar(50) | NO |  |  |
+
+### Indexes
+
+| Name | Columns | Unique |
+| --- | --- | --- |
+| idx_calendar_entries_imdb_id | imdb_id | YES |
+| idx_calendar_entries_release_date | release_date | NO |
+
+### Foreign keys (database)
+_None_
+
+### Foreign keys (logical)
+
+| Column | References | Notes |
+| --- | --- | --- |
+| imdb_id | watchlist.imdb_id | Shared IMDb identifier for the same title. |
+| imdb_id | local_media.imdb_id | Local media files for the same title. |
+
+## local_media
+
+| Column | Type | Null | Default | PK |
+| --- | --- | --- | --- | --- |
+| id | INTEGER | NO |  | YES |
+| media_type | TEXT | NO |  |  |
+| local_path | TEXT | NO |  |  |
+| created_at | timestamp | YES |  |  |
+| imdb_id | TEXT | YES |  |  |
+
+### Indexes
+
+| Name | Columns | Unique |
+| --- | --- | --- |
+| idx_local_media_type_imdb_id | media_type, imdb_id | YES |
+
+### Foreign keys (database)
+_None_
+
+### Foreign keys (logical)
+
+| Column | References | Notes |
+| --- | --- | --- |
+| imdb_id | calendar_entries.imdb_id | Calendar metadata for the same title. |
+| imdb_id | watchlist.imdb_id | Watchlist entry for the same title. |
+
+## metadata_search
+
+| Column | Type | Null | Default | PK |
+| --- | --- | --- | --- | --- |
+| keywords | TEXT | NO |  |  |
+| type | INTEGER | YES |  |  |
+| result | TEXT | YES |  |  |
+| created_at | timestamp | YES |  |  |
+
+### Indexes
+
+| Name | Columns | Unique |
+| --- | --- | --- |
+| idx_metadata_search_keywords_type | keywords, type | YES |
+
+### Foreign keys (database)
+_None_
+
+### Foreign keys (logical)
+_None_
+
+## queues_state
+
+| Column | Type | Null | Default | PK |
+| --- | --- | --- | --- | --- |
+| queue_name | varchar(200) | NO |  | YES |
+| value | TEXT | YES |  |  |
+| created_at | timestamp | YES |  |  |
+
+### Indexes
+_None_
+
+### Foreign keys (database)
+_None_
+
+### Foreign keys (logical)
+_None_
+
+## schema_info
+
+| Column | Type | Null | Default | PK |
+| --- | --- | --- | --- | --- |
+| version | INTEGER | NO | "0" |  |
+
+### Indexes
+_None_
+
+### Foreign keys (database)
+_None_
+
+### Foreign keys (logical)
+_None_
+
+## torrents
+
+| Column | Type | Null | Default | PK |
+| --- | --- | --- | --- | --- |
+| name | varchar(500) | NO |  | YES |
+| identifier | TEXT | YES |  |  |
+| identifiers | TEXT | YES |  |  |
+| tattributes | TEXT | YES |  |  |
+| created_at | timestamp | YES |  |  |
+| updated_at | timestamp | YES |  |  |
+| waiting_until | timestamp | YES |  |  |
+| torrent_id | TEXT | YES |  |  |
+| status | INTEGER | YES |  |  |
+
+### Indexes
+
+| Name | Columns | Unique |
+| --- | --- | --- |
+| idx_torrents_torrent_id | torrent_id | YES |
+
+### Foreign keys (database)
+_None_
+
+### Foreign keys (logical)
+_None_
+
+## trakt_auth
+
+| Column | Type | Null | Default | PK |
+| --- | --- | --- | --- | --- |
+| account | varchar(30) | NO |  | YES |
+| access_token | varchar(200) | YES |  |  |
+| token_type | varchar(200) | YES |  |  |
+| refresh_token | varchar(200) | YES |  |  |
+| scope | varchar(200) | YES |  |  |
+| created_at | INTEGER | YES |  |  |
+| expires_in | INTEGER | YES |  |  |
+
+### Indexes
+_None_
+
+### Foreign keys (database)
+_None_
+
+### Foreign keys (logical)
+_None_
+
+## watchlist
+
+| Column | Type | Null | Default | PK |
+| --- | --- | --- | --- | --- |
+| type | TEXT | NO |  |  |
+| created_at | timestamp | YES |  |  |
+| updated_at | timestamp | YES |  |  |
+| imdb_id | TEXT | NO |  |  |
+
+### Indexes
+
+| Name | Columns | Unique |
+| --- | --- | --- |
+| idx_watchlist_imdb_type | imdb_id, type | YES |
+
+### Foreign keys (database)
+_None_
+
+### Foreign keys (logical)
+
+| Column | References | Notes |
+| --- | --- | --- |
+| imdb_id | calendar_entries.imdb_id | Calendar metadata for the same title. |
+| imdb_id | local_media.imdb_id | Local media files for the same title. |

--- a/scripts/generate_database_schema.rb
+++ b/scripts/generate_database_schema.rb
@@ -1,0 +1,148 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'sequel'
+require 'tmpdir'
+
+MIGRATIONS_PATH = File.expand_path('../lib/db/migrations', __dir__)
+OUTPUT_PATH = File.expand_path('../docs/database_schema.md', __dir__)
+
+Sequel.extension :migration
+
+LOGICAL_FOREIGN_KEYS = {
+  calendar_entries: [
+    {
+      column: 'imdb_id',
+      references: 'watchlist.imdb_id',
+      description: 'Shared IMDb identifier for the same title.'
+    },
+    {
+      column: 'imdb_id',
+      references: 'local_media.imdb_id',
+      description: 'Local media files for the same title.'
+    }
+  ],
+  watchlist: [
+    {
+      column: 'imdb_id',
+      references: 'calendar_entries.imdb_id',
+      description: 'Calendar metadata for the same title.'
+    },
+    {
+      column: 'imdb_id',
+      references: 'local_media.imdb_id',
+      description: 'Local media files for the same title.'
+    }
+  ],
+  local_media: [
+    {
+      column: 'imdb_id',
+      references: 'calendar_entries.imdb_id',
+      description: 'Calendar metadata for the same title.'
+    },
+    {
+      column: 'imdb_id',
+      references: 'watchlist.imdb_id',
+      description: 'Watchlist entry for the same title.'
+    }
+  ]
+}.freeze
+
+def format_default(value)
+  value.nil? ? '' : value.inspect
+end
+
+def format_columns(schema)
+  schema.map do |(column, details)|
+    {
+      name: column.to_s,
+      type: details[:db_type],
+      null: details.fetch(:allow_null, true) ? 'YES' : 'NO',
+      default: format_default(details[:default]),
+      primary_key: details[:primary_key] ? 'YES' : ''
+    }
+  end
+end
+
+def format_indexes(indexes)
+  indexes.map do |name, details|
+    {
+      name: name.to_s,
+      columns: details[:columns].map(&:to_s).join(', '),
+      unique: details[:unique] ? 'YES' : 'NO'
+    }
+  end
+end
+
+Dir.mktmpdir('media_librarian_schema') do |dir|
+  db = Sequel.sqlite(File.join(dir, 'schema.sqlite3'))
+  Sequel::Migrator.run(db, MIGRATIONS_PATH)
+
+  lines = []
+  lines << '# Database schema'
+  lines << ''
+  lines << 'Regenerate with:'
+  lines << '```sh'
+  lines << 'bundle exec ruby scripts/generate_database_schema.rb'
+  lines << '```'
+  lines << ''
+
+  db.tables.sort.each do |table|
+    schema = format_columns(db.schema(table))
+    indexes = format_indexes(db.indexes(table))
+    foreign_keys = db.foreign_key_list(table)
+    logical_fks = LOGICAL_FOREIGN_KEYS.fetch(table.to_sym, [])
+
+    lines << "## #{table}"
+    lines << ''
+    lines << '| Column | Type | Null | Default | PK |'
+    lines << '| --- | --- | --- | --- | --- |'
+    schema.each do |column|
+      lines << "| #{column[:name]} | #{column[:type]} | #{column[:null]} | #{column[:default]} | #{column[:primary_key]} |"
+    end
+    lines << ''
+
+    lines << '### Indexes'
+    if indexes.empty?
+      lines << '_None_'
+    else
+      lines << ''
+      lines << '| Name | Columns | Unique |'
+      lines << '| --- | --- | --- |'
+      indexes.each do |index|
+        lines << "| #{index[:name]} | #{index[:columns]} | #{index[:unique]} |"
+      end
+    end
+    lines << ''
+
+    lines << '### Foreign keys (database)'
+    if foreign_keys.empty?
+      lines << '_None_'
+    else
+      lines << ''
+      lines << '| Columns | References |'
+      lines << '| --- | --- |'
+      foreign_keys.each do |fk|
+        columns = Array(fk[:columns]).map(&:to_s).join(', ')
+        target = [fk[:table], Array(fk[:key]).join(', ')].join('.')
+        lines << "| #{columns} | #{target} |"
+      end
+    end
+    lines << ''
+
+    lines << '### Foreign keys (logical)'
+    if logical_fks.empty?
+      lines << '_None_'
+    else
+      lines << ''
+      lines << '| Column | References | Notes |'
+      lines << '| --- | --- | --- |'
+      logical_fks.each do |fk|
+        lines << "| #{fk[:column]} | #{fk[:references]} | #{fk[:description]} |"
+      end
+    end
+    lines << ''
+  end
+
+  File.write(OUTPUT_PATH, lines.join("\n"))
+end


### PR DESCRIPTION
### Motivation
- Provide a human-readable database schema listing tables, columns, indexes and logical foreign-key relationships as requested. 
- Include a simple, repeatable way to regenerate the document from the project's migrations.

### Description
- Add a generator script `scripts/generate_database_schema.rb` that creates a temporary SQLite DB, runs migrations with `Sequel::Migrator`, and writes a Markdown schema to `docs/database_schema.md`.
- Embed a small `LOGICAL_FOREIGN_KEYS` map to document logical (non-enforced) relationships such as shared `imdb_id` across tables.
- Ensure the script loads Sequel migration extensions via `Sequel.extension :migration` so `Sequel::Migrator.run` is available.
- Add the generated output file `docs/database_schema.md` containing tables, columns, indexes, and logical foreign keys, plus a regeneration command.

### Testing
- Ran `bundle install` to install gems required by the script and environment preparation, which completed successfully.
- Executed `bundle exec ruby scripts/generate_database_schema.rb`, which ran successfully and produced `docs/database_schema.md`.
- Verified the produced `docs/database_schema.md` contains expected tables, columns, indexes, and the logical foreign-key section.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974ffd7acd48327bc0ed55b3e4d458c)