### PR TITLE
Use private-safe Daemon update in import_list_csv

### DIFF
--- a/app/library.rb
+++ b/app/library.rb
@@ -636,7 +636,7 @@ class Library
         return unless jid && defined?(Daemon) && Daemon.respond_to?(:update_job_progress, true)
         return unless force || (progress['processed'].positive? && (progress['processed'] % progress_step).zero?)
 
-        Daemon.update_job_progress(jid, progress.dup)
+        Daemon.send(:update_job_progress, jid, progress.dup)
       end
       update_progress.call(true)
       repository = CalendarEntriesRepository.new(app: app)


### PR DESCRIPTION
### Motivation
- Ensure the `update_job_progress` call in `Library#import_list_csv` respects private visibility and avoids private-method exceptions by using a private-safe invocation while keeping existing guards.

### Description
- Replace `Daemon.update_job_progress(jid, progress.dup)` with `Daemon.send(:update_job_progress, jid, progress.dup)` in `app/library.rb` so the method is invoked even if it is private while preserving the `Daemon.respond_to?(:update_job_progress, true)` check.

### Testing
- Ran `ruby -c app/library.rb` which returned `Syntax OK`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69750a07cefc83278523529f801db0f0)