### PR TITLE
Limit flush_queues to 20 torrents

### DIFF
--- a/app/media_librarian/services/torrent_queue_service.rb
+++ b/app/media_librarian/services/torrent_queue_service.rb
@@ -28,9 +28,9 @@ module MediaLibrarian
         @client = client
       end
 
-      def parse_pending_downloads
+      def parse_pending_downloads(limit: 20)
         speaker.speak_up('Downloading torrent(s) added during the session (if any)', 0)
-        app.db.get_rows('torrents', { status: 2 }).each do |torrent_row|
+        (app.db.get_rows('torrents', { status: 2 }) || []).first(limit).each do |torrent_row|
           torrent = Cache.object_unpack(torrent_row[:tattributes])
           log_torrent_details(torrent, torrent_row) if Env.debug?
           tdid = (Time.now.to_f * 1000).to_i.to_s

--- a/app/torrent_client.rb
+++ b/app/torrent_client.rb
@@ -114,8 +114,8 @@ class TorrentClient
     { 'file_priorities' => priorities }
   end
 
-  def parse_torrents_to_download
-    queue_service.parse_pending_downloads
+  def parse_torrents_to_download(limit = 20)
+    queue_service.parse_pending_downloads(limit: limit)
   end
 
   def process_added_torrents
@@ -169,7 +169,7 @@ class TorrentClient
 
   def self.flush_queues
     if app.t_client
-      app.t_client.parse_torrents_to_download
+      app.t_client.parse_torrents_to_download(20)
       sleep 15
       app.t_client.process_added_torrents
       app.t_client.process_completed_torrents


### PR DESCRIPTION
### Motivation
- Prevent processing an unbounded number of queued torrent downloads in a single flush run by capping work to 20 items to reduce load and avoid bursts.

### Description
- Thread a `limit` (default 20) through `TorrentClient#parse_torrents_to_download` to `TorrentQueueService#parse_pending_downloads` and make `flush_queues` call the parser with a 20-item cap.
- Update `TorrentQueueService#parse_pending_downloads` to only process `(app.db.get_rows(... ) || []).first(limit)` and add `test_parse_pending_downloads_limits_items` to verify the cap.

### Testing
- Ran the service unit test file with `bundle exec ruby -Itest test/services/torrent_queue_service_test.rb`, which failed to run due to Bundler requiring `bundle install` for a git-sourced dependency (so tests could not be fully executed in this environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697615ef8b10832793c29f9061d4a3f8)