### PR TITLE
Format "Disponible le" column to show future date or "Maintenant"

### DIFF
--- a/app/web/app.js
+++ b/app/web/app.js
@@ -676,6 +676,17 @@ function formatDateTime(value) {
   return date.toLocaleString();
 }
 
+function formatAvailability(value) {
+  if (!value) {
+    return 'Maintenant';
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return date > new Date() ? date.toLocaleString() : 'Maintenant';
+}
+
 function showNotification(message, kind = 'info') {
   const container = document.getElementById('notification');
   container.textContent = message;
@@ -3118,7 +3129,7 @@ function renderPendingTorrentList(rowsId, emptyId, entries = []) {
       entry?.tracker || '—',
       entry?.category || '—',
       formatDateTime(entry?.created_at),
-      formatDateTime(entry?.waiting_until),
+      formatAvailability(entry?.waiting_until),
       entry?.identifier || '—',
     ];
 


### PR DESCRIPTION
### Motivation
- Ensure the "Disponible le" column shows a friendly future date when applicable and displays "Maintenant" for immediate or missing availability.

### Description
- Add `formatAvailability` helper in `app/web/app.js` that returns a localized date when the value is a future date, `Maintenant` when absent or in the past, and falls back to the raw value on parse errors.
- Apply `formatAvailability(entry?.waiting_until)` to the pending torrent list rendering so the "Disponible le" column uses the new formatter.

### Testing
- Ran `bundle exec rake test`, which failed to run due to a missing `bundle install` for a git dependency so automated tests did not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69761fdcafd08327820d6d228b23c9c8)