### PR TITLE
Enforce per-queue concurrency limits for scheduled jobs

### DIFF
--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -596,6 +596,7 @@ class Daemon
       return unless running?
 
       queue_name = queue || task || args[0..1].join(' ')
+      apply_queue_limit(queue_name, args)
       job = Job.new(
         id: job_id,
         queue: queue_name || 'default',
@@ -879,6 +880,9 @@ class Daemon
       end
 
       loop do
+        unless wait_for_queue_capacity(job.queue, wait_for_capacity: wait_for_capacity)
+          raise Concurrent::RejectedExecutionError
+        end
         return Concurrent::Promises.future_on(@executor) { execute_job(job) }
       rescue Concurrent::RejectedExecutionError
         raise unless wait_for_capacity && running?
@@ -940,6 +944,16 @@ class Daemon
         end
         sleep(0.05)
       end
+    end
+
+    def wait_for_queue_capacity(queue, wait_for_capacity:)
+      return true if queue.to_s.empty? || !queue_busy?(queue)
+      return false unless wait_for_capacity && running?
+
+      while running? && queue_busy?(queue)
+        sleep(0.05)
+      end
+      true
     end
 
     def executor_saturated?(executor)
@@ -3345,6 +3359,14 @@ class Daemon
 
     def queue_limits
       @queue_limits ||= Concurrent::Hash.new
+    end
+
+    def apply_queue_limit(queue_name, args)
+      return if queue_name.to_s.empty? || queue_limits.key?(queue_name)
+
+      limit = fetch_function_config(args)[0]
+      limit = limit.to_i if limit
+      queue_limits[queue_name] = limit if limit && limit.positive?
     end
 
     def build_task_args(params)


### PR DESCRIPTION
### Motivation
- Scheduled tasks like `flush_queues` can unintentionally run concurrently when multiple scheduled entries trigger, so per-queue concurrency caps must be applied and respected at enqueue/start time.
- Queue limits declared in templates or function configs should be discovered when a job is enqueued so runtime concurrency honors those settings.

### Description
- Apply queue limit discovery during `enqueue` via a new `apply_queue_limit(queue_name, args)` helper that reads limits from function config and stores them in `queue_limits`.
- Block job start when a queue is busy by checking `wait_for_queue_capacity` inside `obtain_future`, which waits until the queue has capacity (or rejects when waiting is disabled).
- Add `wait_for_queue_capacity(queue, wait_for_capacity:)` to poll `queue_busy?` and sleep until capacity is available, and only allow waiting when `wait_for_capacity` is true and the daemon is running.
- Keep existing behavior for executor saturation and inline child execution while integrating per-queue capacity checks into the job startup flow.

### Testing
- Ran repository searches and inspected `app/torrent_client.rb` to confirm `flush_queues` is scheduled and relevant to queue behavior (automated file inspection only).
- Ran `bundle exec rake test`, which failed due to a missing bundled git dependency (`archive-zip`), so tests could not be executed until `bundle install` completes (automated tests: failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976207e183083278c598e8bea7b1cf9)