### PR TITLE
Require 'unrar' when extracting RAR/CBR archives

### DIFF
--- a/lib/file_utils.rb
+++ b/lib/file_utils.rb
@@ -36,6 +36,12 @@ module FileUtils
       return MediaLibrarian.app.speaker.speak_up "Would extract archive #{type} '#{archive}' to '#{destination}'" if Env.pretend?
       case type
       when 'cbr', 'rar'
+        begin
+          require 'unrar'
+        rescue LoadError => e
+          MediaLibrarian.app.speaker.speak_up("Missing 'unrar' gem for #{type} extraction: #{e.message}")
+          return
+        end
         unrar = Unrar::Archive.new(archive, destination)
         extracted = unrar.extract
         MediaLibrarian.app.speaker.speak_up("Extracted #{archive} to #{destination}") if extracted


### PR DESCRIPTION
### Motivation
- Ensure the `Unrar` constant is defined when handling `cbr`/`rar` archives by loading the gem with `require 'unrar'` so extraction does not raise a `NameError` if the gem was not previously required.

### Description
- Add a guarded `require 'unrar'` inside `FileUtils.extract_archive` for the `cbr`/`rar` branch, rescuing `LoadError`, emitting a clear message via `MediaLibrarian.app.speaker.speak_up`, and returning early to avoid a crash (file: `lib/file_utils.rb`).

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69764110113883278d3b0457c2256e49)