### PR TITLE
Initialize parent email buffer for child jobs

### DIFF
--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -1014,9 +1014,12 @@ class Daemon
           if job.child.to_i.positive?
             if thread[:parent]
               merge_notifications(thread, thread[:parent])
-              if thread[:parent][:email_msg]
+              if thread[:email_msg]
+                thread[:parent][:email_msg] ||= String.new
                 thread[:parent][:email_msg] << thread[:email_msg].to_s
-                thread[:parent][:send_email] = thread[:send_email].to_i if thread[:send_email].to_i.positive?
+              end
+              if thread[:send_email].to_i.positive?
+                thread[:parent][:send_email] = thread[:send_email].to_i
               end
             elsif thread[:log_msg]
               parent_daemon = thread[:parent_daemon]


### PR DESCRIPTION
### Motivation
- Avoid losing child job email output when a parent thread has no `:email_msg` buffer by ensuring the parent buffer exists before appending.

### Description
- In `app/daemon.rb` (inside `execute_job` ensure block) initialize `thread[:parent][:email_msg] ||= String.new` when the child has `thread[:email_msg]`, append the child content, and keep promotion of `:send_email` separate so it only happens when the child sets it; `merge_notifications` behavior is left intact.

### Testing
- Ran `ruby -c app/daemon.rb` to validate syntax and it returned `Syntax OK`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69772022690c83278c878d6803ce26c5)