### PR TITLE
Allow `mkdir_p` override to accept and forward keyword options

### DIFF
--- a/lib/file_utils.rb
+++ b/lib/file_utils.rb
@@ -167,10 +167,10 @@ module FileUtils
       mkdir_orig(dirs)
     end
 
-    def mkdir_p(dirs)
+    def mkdir_p(dirs, *args, **kwargs)
       return MediaLibrarian.app.speaker.speak_up("Would mkdir_p #{dirs}") if Env.pretend?
       MediaLibrarian.app.speaker.speak_up("mkdir_p #{dirs}") if Env.debug?
-      mkdir_p_orig(dirs)
+      mkdir_p_orig(dirs, *args, **kwargs)
     end
 
     def move_file(original, destination, hard_link = 0, remove_outdated = 0, no_prompt = 1)


### PR DESCRIPTION
### Motivation
- Enable callers to pass options such as `mode:` to the overridden `FileUtils.mkdir_p` so existing callers (e.g. `FileUtils.mkdir_p(work_dir, mode: 0o700)`) don't raise when supplying keyword arguments while keeping the existing `Env.pretend?`/`Env.debug?` behavior.

### Description
- Change the `FileUtils.mkdir_p` override signature to `def mkdir_p(dirs, *args, **kwargs)` and forward `*args, **kwargs` to `mkdir_p_orig`, preserving the existing pretend/debug logging.

### Testing
- Ran a Ruby syntax check with `ruby -c lib/file_utils.rb`, which returned `Syntax OK`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697720bf3ed08327af7a806172008544)