### PR TITLE
Always buffer speaker email output

### DIFF
--- a/lib/simple_speaker.rb
+++ b/lib/simple_speaker.rb
@@ -64,7 +64,7 @@ module SimpleSpeaker
           log("#{'[' + thread[:object].to_s + ']' if thread[:object].to_s != ''}#{l}")
         end
       end
-      email_msg_add(str, in_mail, thread) if in_mail.to_i >= 0
+      email_msg_add(str, in_mail, thread)
       str
     end
 


### PR DESCRIPTION
### Motivation
- Ensure every message passed to `speak_up` is appended to the thread email buffer while retaining the existing behavior that posting an email is only triggered when `in_mail > 0`.

### Description
- Call `email_msg_add` unconditionally from `speak_up` so each line is appended to `thread[:email_msg]`, relying on `email_msg_add` to only set `thread[:send_email]` when `in_mail.to_i > 0`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977500f177c8327b552aa179143cf23)