### PR TITLE
Initialize email message buffer when missing

### DIFF
--- a/lib/simple_speaker.rb
+++ b/lib/simple_speaker.rb
@@ -48,7 +48,10 @@ module SimpleSpeaker
     def email_msg_add(str, in_mail, thread)
       str = "[*] #{str}" if in_mail.to_i > 0
       buffer = thread[:email_msg]
-      return unless buffer
+      if buffer.nil?
+        buffer = String.new
+        thread[:email_msg] = buffer
+      end
 
       buffer = buffer.dup if buffer.frozen?
       thread[:email_msg] = buffer


### PR DESCRIPTION
### Motivation
- Ensure `email_msg_add` can append to `thread[:email_msg]` even when it is `nil` while preserving the existing send-trigger behavior guarded by `in_mail.to_i > 0`.

### Description
- In `email_msg_add` initialize `thread[:email_msg]` with `String.new` when `buffer` is `nil`, then reuse the existing frozen-dup/append logic and keep the `thread[:send_email] = in_mail.to_i` assignment guarded by `in_mail.to_i > 0`.

### Testing
- Checked Ruby syntax with `ruby -c lib/simple_speaker.rb`, which returned "Syntax OK".

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69776a7cb1048327b119aebe0de5d33a)