### PR TITLE
Preserve inline child email output in daemon jobs

### DIFF
--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -1021,6 +1021,16 @@ class Daemon
               if thread[:send_email].to_i.positive?
                 thread[:parent][:send_email] = thread[:send_email].to_i
               end
+            elsif inline_child
+              if thread[:email_msg]
+                parent_email = snapshot[:email_msg]
+                if parent_email
+                  parent_email << thread[:email_msg].to_s
+                else
+                  fallback_buffer = snapshot[:captured_output] || snapshot[:log_msg]
+                  fallback_buffer&.<< thread[:email_msg].to_s
+                end
+              end
             elsif thread[:log_msg]
               parent_daemon = thread[:parent_daemon]
               if parent_daemon


### PR DESCRIPTION
### Motivation
- Inline child jobs were discarding email output when `thread[:parent]` was nil, which violates the test expectation that a parent email buffer object must not be replaced and can lead to lost notifications. 

### Description
- Add an `inline_child` branch in `Daemon.execute_job` (inside the `ensure` block) to handle the inline-child case when `thread[:parent]` is nil and `job.child` is positive. 
- If `thread[:email_msg]` exists, append it to the parent snapshot's `email_msg` when present; otherwise append into a minimal fallback buffer (`snapshot[:captured_output]` or `snapshot[:log_msg]`) without replacing the parent email buffer object. 
- Preserve existing `send_email` propagation behavior and avoid replacing parent buffers, keeping changes localized to `app/daemon.rb`.

### Testing
- Ran `bundle exec ruby -I test test/daemon_job_control_test.rb` to execute relevant job control tests, but the run failed due to a missing bundled git dependency requiring `bundle install` (Bundler error), so automated tests could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697784bec0cc8327a424c8ed49c27b0f)