### PR TITLE
Preserve send_email for inline child jobs

### DIFF
--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -1031,6 +1031,9 @@ class Daemon
                   fallback_buffer&.<< thread[:email_msg].to_s
                 end
               end
+              if thread[:send_email].to_i.positive?
+                snapshot[:send_email] = thread[:send_email].to_i
+              end
             elsif thread[:log_msg]
               parent_daemon = thread[:parent_daemon]
               if parent_daemon


### PR DESCRIPTION
### Motivation
- Inline child jobs could append their `:email_msg` into the parent snapshot but lose the `:send_email` flag when `ThreadState.restore` reset the parent, causing legitimate email notifications to be dropped.

### Description
- When an inline child sets `thread[:send_email]`, persist that value into the captured `snapshot[:send_email]` so the parent retains the mail flag after `ThreadState.restore` (`app/daemon.rb` change adds `snapshot[:send_email] = thread[:send_email].to_i`).

### Testing
- Ran a syntax check with `ruby -c app/daemon.rb`, which returned `Syntax OK`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69778a1494b88327babd02c547b94d60)