### PR TITLE
Avoid propagating inline child email output into parent email buffer

### DIFF
--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -1022,11 +1022,15 @@ class Daemon
                 thread[:parent][:send_email] = thread[:send_email].to_i
               end
             elsif inline_child
+              preserved_email = false
               if thread[:email_msg]
                 fallback_buffer = snapshot[:captured_output] || snapshot[:log_msg]
-                fallback_buffer&.<< thread[:email_msg].to_s
+                if fallback_buffer
+                  fallback_buffer << thread[:email_msg].to_s
+                  preserved_email = true
+                end
               end
-              if thread[:send_email].to_i.positive?
+              if preserved_email && thread[:send_email].to_i.positive?
                 snapshot[:send_email] = thread[:send_email].to_i
               end
             elsif thread[:log_msg]

--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -1023,13 +1023,8 @@ class Daemon
               end
             elsif inline_child
               if thread[:email_msg]
-                parent_email = snapshot[:email_msg]
-                if parent_email
-                  parent_email << thread[:email_msg].to_s
-                else
-                  fallback_buffer = snapshot[:captured_output] || snapshot[:log_msg]
-                  fallback_buffer&.<< thread[:email_msg].to_s
-                end
+                fallback_buffer = snapshot[:captured_output] || snapshot[:log_msg]
+                fallback_buffer&.<< thread[:email_msg].to_s
               end
               if thread[:send_email].to_i.positive?
                 snapshot[:send_email] = thread[:send_email].to_i


### PR DESCRIPTION
### Motivation
- Prevent inline child email output from being appended into parent email buffers and instead keep any preserved output routed only to existing non-email buffers when present.

### Description
- In `execute_job` (inline child branch) stop attempting to append `thread[:email_msg]` into `snapshot[:email_msg]` and only append it into an existing `snapshot[:captured_output]` or `snapshot[:log_msg]` without creating or replacing buffers.

### Testing
- Ran `ruby -c app/daemon.rb` which reported `Syntax OK`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69778abecf4883279eebf93dee3ebbab)