### PR TITLE
Merge inline child email buffer into snapshot

### DIFF
--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -1024,11 +1024,9 @@ class Daemon
             elsif inline_child
               preserved_email = false
               if thread[:email_msg]
-                fallback_buffer = snapshot[:captured_output] || snapshot[:log_msg]
-                if fallback_buffer
-                  fallback_buffer << thread[:email_msg].to_s
-                  preserved_email = true
-                end
+                snapshot[:email_msg] ||= String.new
+                snapshot[:email_msg] << thread[:email_msg].to_s
+                preserved_email = true
               end
               if preserved_email && thread[:send_email].to_i.positive?
                 snapshot[:send_email] = thread[:send_email].to_i


### PR DESCRIPTION
### Motivation
- The inline-child path previously appended child email content into a fallback buffer (`snapshot[:captured_output]` or `snapshot[:log_msg]`) which mixed concerns and did not preserve a dedicated email buffer.

### Description
- In `app/daemon.rb` inside the `elsif inline_child` block, append `thread[:email_msg].to_s` into `snapshot[:email_msg]`, initializing it with `String.new` when nil.
- Preserve the existing `send_email` propagation by setting `snapshot[:send_email]` when the inline child had a positive `send_email`.
- The change is minimal and scoped to the inline child merge logic to avoid duplicating output in other buffers.

### Testing
- Ran `ruby -c app/daemon.rb` which returned `Syntax OK`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977911e36088327babcde925703f5b3)