### PR TITLE
Skip running command banner for child jobs

### DIFF
--- a/librarian.rb
+++ b/librarian.rb
@@ -276,10 +276,11 @@ class Librarian
         .map { |a| a.is_a?(String) ? a.gsub(/--?([^=\s]+)(?:=(.+))?/, '--\1=\'\2\'') : a.inspect }
         .join(' ')
 
+      child_job = Thread.current[:child_job].to_i.positive? || Thread.current[:parent]
       object = cmd[0..1].join(' ') if object.to_s.empty? || object == 'rcv'
       init_thread(Thread.current, object, direct, &block)
 
-      unless internal_email_command?(object, sanitized_cmd)
+      unless internal_email_command?(object, sanitized_cmd) || child_job
         app.speaker.speak_up(String.new('Running command: '), 0)
         app.speaker.speak_up("#{running_command}\n\n", 0)
       end


### PR DESCRIPTION
### Motivation
- Child/inline jobs were emitting the "Running command" banner, causing duplicate or misleading lines in parent emails and logs.
- The banner should remain for top-level/direct jobs and be skipped for child jobs or when a parent thread is present.

### Description
- In `Librarian.run_command` evaluate `child_job = Thread.current[:child_job].to_i.positive? || Thread.current[:parent]` and use it to guard the banner emission.
- Keep the existing `internal_email_command?` check and only emit the two `app.speaker.speak_up` lines when not an internal email command and not a child job.
- Add a unit test `test_child_job_email_excludes_running_command_banner` in `test/daemon_job_control_test.rb` to assert child-job email output does not include the extra running-banner while still including parent output and child email content.

### Testing
- Added the test `test_child_job_email_excludes_running_command_banner` in `test/daemon_job_control_test.rb` (not executed to completion in this environment).
- Attempted to run `bundle exec ruby -Itest test/daemon_job_control_test.rb` but the run failed due to a missing git-sourced bundle dependency (`bundle install` required), so automated tests could not be fully executed here.
- Manual inspection of updated `librarian.rb` and the new test confirms the intended guard and coverage were added.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977964e684c83278c0b30afd35deebc)