### PR TITLE
Preserve banners for scheduled top-level jobs

### DIFF
--- a/librarian.rb
+++ b/librarian.rb
@@ -276,7 +276,7 @@ class Librarian
         .map { |a| a.is_a?(String) ? a.gsub(/--?([^=\s]+)(?:=(.+))?/, '--\1=\'\2\'') : a.inspect }
         .join(' ')
 
-      child_job = Thread.current[:child_job].to_i.positive? || Thread.current[:parent]
+      child_job = Thread.current[:child_job].to_i.positive? || Thread.current[:child_job_override].to_i.positive?
       object = cmd[0..1].join(' ') if object.to_s.empty? || object == 'rcv'
       init_thread(Thread.current, object, direct, &block)
 


### PR DESCRIPTION
### Motivation
- The daemon scheduler sets `Thread.current[:parent]` for scheduled periodic/continuous jobs even when `child: 0`, which caused `run_command` to treat those threads as child jobs and suppress the "Running command" banner and command context in logs/emails.

### Description
- Update child-job detection in `Librarian#run_command` (in `librarian.rb`) to check `Thread.current[:child_job]` or `Thread.current[:child_job_override]` instead of relying on the presence of `Thread.current[:parent]`, so only explicitly marked child jobs hide the banner.

### Testing
- Validated syntax with `ruby -c librarian.rb`, which returned `Syntax OK`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69779bb5d618832789971d2597689499)