### PR TITLE
Unify cp/mv into shared transfer helper and use atomic rename for same-FS operations

### DIFF
--- a/lib/file_utils.rb
+++ b/lib/file_utils.rb
@@ -25,7 +25,10 @@ module FileUtils
     def cp(source, target)
       return MediaLibrarian.app.speaker.speak_up("Would cp #{source} to #{target}") if Env.pretend?
       MediaLibrarian.app.speaker.speak_up("cp #{source} #{target}") if Env.debug?
-      return cp_orig(source, target) if source.is_a?(Array)
+      if source.is_a?(Array)
+        source.each { |item| cp(item, File.join(target, File.basename(item))) }
+        return
+      end
       rm(target) if File.exist?(target)
       mkdir_p(File.dirname(target)) unless File.exist?(File.dirname(target))
       MediaLibrarian.app.speaker.speak_up("File '#{source}' doesn't exist!") unless File.exist?(source)
@@ -223,8 +226,7 @@ module FileUtils
       return MediaLibrarian.app.speaker.speak_up("Would mv #{original} #{destination}") if Env.pretend?
       MediaLibrarian.app.speaker.speak_up("mv #{original} #{destination}") if Env.debug?
       if original.is_a?(Array)
-        mv_orig(original, destination)
-        file_remove_parents(original)
+        original.each { |item| mv(item, File.join(destination, File.basename(item))) }
         return
       end
       transfer_with_fallback(original, destination) do |resolved, same_fs|

--- a/lib/file_utils.rb
+++ b/lib/file_utils.rb
@@ -25,6 +25,7 @@ module FileUtils
     def cp(source, target)
       return MediaLibrarian.app.speaker.speak_up("Would cp #{source} to #{target}") if Env.pretend?
       MediaLibrarian.app.speaker.speak_up("cp #{source} #{target}") if Env.debug?
+      return cp_orig(source, target) if source.is_a?(Array)
       rm(target) if File.exist?(target)
       mkdir_p(File.dirname(target)) unless File.exist?(File.dirname(target))
       MediaLibrarian.app.speaker.speak_up("File '#{source}' doesn't exist!") unless File.exist?(source)
@@ -221,6 +222,11 @@ module FileUtils
     def mv(original, destination)
       return MediaLibrarian.app.speaker.speak_up("Would mv #{original} #{destination}") if Env.pretend?
       MediaLibrarian.app.speaker.speak_up("mv #{original} #{destination}") if Env.debug?
+      if original.is_a?(Array)
+        mv_orig(original, destination)
+        file_remove_parents(original)
+        return
+      end
       transfer_with_fallback(original, destination) do |resolved, same_fs|
         if same_fs
           File.rename(resolved, destination)


### PR DESCRIPTION
### Motivation
- Ensure `cp` and `mv` prefer same-filesystem atomic operations when possible and transparently handle cross-filesystem cases.
- Reduce duplication between `cp` and `mv` by centralizing cross-FS detection and mergerfs-specific retries.
- Make the code leaner and easier to follow while preserving mergerfs-aware resolution and retry semantics.

### Description
- Introduced `transfer_with_fallback(source, destination)` to centralize cross-filesystem detection and control flow for both `cp` and `mv`.
- Added `with_mergerfs_retry(...)` to resolve accelerated mergerfs source paths only when needed and to retry once on `Errno::ENOENT`, surfacing all attempted paths on final failure.
- Updated `cp` to copy to a temporary target and perform an atomic `File.rename` for same-filesystem copies, with safe cleanup via `rm_orig` in the `ensure` block.
- Updated `mv` to use `File.rename` for same-filesystem moves and fall back to original cross-FS logic when `Errno::EXDEV` occurs, and simplified the transfer control flow by removing unused return values.

### Testing
- Ran `bundle exec ruby -Itest test/lib/storage_db_test.rb`, which failed to start due to a missing Bundler git dependency (`archive-zip` not checked out) and requires running `bundle install` first; no project unit tests completed due to this setup error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977c771602c8327baad25cd1fdfaa33)