### PR TITLE
Fix Zeitwerk autoload name for mergerfs IO helper

### DIFF
--- a/lib/mergerfs_io.rb
+++ b/lib/mergerfs_io.rb
@@ -1,4 +1,4 @@
-module MergerfsIO
+module MergerfsIo
   module_function
 
   def same_filesystem?(src, dst)
@@ -74,3 +74,5 @@ module MergerfsIO
     nil
   end
 end
+
+MergerfsIO = MergerfsIo


### PR DESCRIPTION
### Motivation
- Fix a Zeitwerk autoload error where `lib/mergerfs_io.rb` (filename -> `MergerfsIo`) defined `MergerfsIO` instead of the expected `MergerfsIo`, causing a `Zeitwerk::NameError`.

### Description
- Rename the module to `MergerfsIo` and add a compatibility alias `MergerfsIO = MergerfsIo` so existing callers continue to work.

### Testing
- Ran `ruby -c lib/mergerfs_io.rb` and it succeeded (`Syntax OK`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977d4cdbe848327ba0442f74ca6d923)