### PR TITLE
Add periodic debug logging during torrent move waits

### DIFF
--- a/app/library.rb
+++ b/app/library.rb
@@ -117,8 +117,15 @@ class Library
           app.t_client.move_storage([torrent_id], opath) rescue nil
           app.speaker.speak_up "Waiting for storage file to be moved" if Env.debug?
           move_wait_start = Time.now
+          last_log = Time.now
           while FileUtils.is_in_path([app.t_client.get_torrent_status(torrent_id, ['save_path'])['save_path'].to_s], StringUtils.accents_clear(opath)).nil?
             break if Time.now - completion_time > 3600
+            if Env.debug? && Time.now - last_log >= 300
+              elapsed = Time.now - move_wait_start
+              save_path = app.t_client.get_torrent_status(torrent_id, ['save_path'])['save_path'].to_s
+              app.speaker.speak_up "Storage wait #{elapsed.round(2)}s, save_path=#{save_path}"
+              last_log = Time.now
+            end
             sleep 60
           end
           if Env.debug?


### PR DESCRIPTION
### Motivation
- Provide periodic progress output while waiting for torrent storage to be moved when `Env.debug?` is enabled so long waits are visible to operators.

### Description
- In `app/library.rb` inside `handle_completed_download`, add `last_log = Time.now` before the move-wait loop and a conditional inside the loop that, when `Env.debug?` and `Time.now - last_log >= 300`, logs the elapsed wait time and the current `save_path` (via `app.t_client.get_torrent_status(...)`) and then updates `last_log`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978b40402e08327a7c607c93a4454ab)