### PR TITLE
Remove finished jobs column from dashboard and simplify queue summary

### DIFF
--- a/app/web/index.html
+++ b/app/web/index.html
@@ -132,10 +132,6 @@
                 <h3>En attente</h3>
                 <ul id="jobs-queued" class="job-list"></ul>
               </div>
-              <div>
-                <h3>Terminés</h3>
-                <ul id="jobs-finished" class="job-list"></ul>
-              </div>
             </div>
           </section>
         </section>


### PR DESCRIPTION
### Motivation
- Remove the finished-jobs history column and related rendering to simplify the Jobs UI when finished-job lists are not provided by the API.
- Keep per-job status/finished timestamp labels so individual job state is still visible.

### Description
- Removed the "Terminés" column and `#jobs-finished` list container from `app/web/index.html`.
- Dropped handling and DOM updates for the `finished` collection in `renderJobs` and removed use of `finished` when computing queue summaries in `app/web/app.js`.
- Simplified `computeQueueSummary` to accept only running and queued jobs and removed finished counts from the queue chip descriptions while preserving per-job `Terminé` timestamp in each job's meta.
- Removed references to the `jobs-finished` element and the code that rendered finished-job lists.

### Testing
- Ran `bundle exec rake test`, which failed due to a bundler git dependency not checked out (environment dependency issue).
- Started a static server (`python -m http.server`) and used an automated Playwright script to load `index.html` and capture a screenshot of the updated dashboard, which completed successfully (artifact saved).
- Performed an automated code search for "Terminé"/"Terminés" to verify only per-job status labels remain, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b2da054a48327b0a53946cacfc654)