### PR TITLE
Adjust jobs columns layout at 1200px

### DIFF
--- a/app/web/app.css
+++ b/app/web/app.css
@@ -474,7 +474,7 @@ button.danger:hover {
 
 @media (min-width: 1200px) {
   .jobs-columns {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 


### PR DESCRIPTION
### Motivation
- Keep the jobs columns grid at two columns on large screens so the “En cours” and “En attente” columns can span the full width after the third column was removed.

### Description
- Updated `app/web/app.css` in the `@media (min-width: 1200px)` rule to change `grid-template-columns` from `repeat(3, minmax(0, 1fr))` to `repeat(2, minmax(0, 1fr))`.

### Testing
- Ran `bundle exec rake test`, which failed due to a missing `bundle install` for the `archive-zip` git dependency so the test suite could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b4444c98883279a958e97d66a6c1d)