### PR TITLE
Reorder completed download error checks

### DIFF
--- a/app/library.rb
+++ b/app/library.rb
@@ -281,8 +281,8 @@ class Library
     end
     if root_process.to_i > 0
       FileUtils.rm_r(full_p) if completed_folder != move_completed_torrent['torrent_completed_path'].to_s
-      raise 'Could not find any file to handle!' if handled == 0
       raise "An error occured" if error.to_i > 0
+      raise 'Could not find any file to handle!' if handled == 0
       post_process_start = Time.now
       folders = process_folder_list.uniq
       folders.each do |p|


### PR DESCRIPTION
### Motivation
- Preserve and surface the original error (for example `ENOSPC`) during completed-download handling by ensuring error checks are raised before the generic "no file handled" message.

### Description
- In `app/library.rb`, inside `handle_completed_download`, swapped the two root-process checks so `raise "An error occured" if error.to_i > 0` is executed before `raise 'Could not find any file to handle!' if handled == 0`.
- The change is a single-line reorder to avoid masking actionable errors with a generic message.

### Testing
- Attempted to run `bundle exec rake test`, but the run failed due to Bundler/Git dependency checkout issues (`archive-zip` not checked out), so automated tests could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b605baad48327b628bb47951e6ed4)