### PR TITLE
Log full error backtraces in SimpleSpeaker

### DIFF
--- a/lib/simple_speaker.rb
+++ b/lib/simple_speaker.rb
@@ -82,7 +82,15 @@ module SimpleSpeaker
 
     def tell_error(e, src, in_mail = 1, thread = Thread.current)
       err = e.is_a?(Exception) ? e : StandardError.new(e.to_s)
-      @logger_error.error(err) if @logger_error
+      if @logger_error
+        @logger_error.error(err)
+        detail = if err.respond_to?(:full_message)
+                   err.full_message
+                 else
+                   "#{err.class}: #{err.message}\n#{Array(err.backtrace).join("\n")}"
+                 end
+        detail.to_s.each_line { |line| @logger_error.error(line.chomp) }
+      end
       parts = []
       parts << "jid=#{thread[:jid]}" if thread[:jid].to_s != ''
       parts << "obj=#{thread[:object]}" if thread[:object].to_s != ''


### PR DESCRIPTION
### Motivation
- Ensure the error log file contains the full exception details and backtrace so the UI can display complete error blocks.
- Preserve existing console output behavior while making sure each logged backtrace line is prefixed by the logger formatter so `renderErrorBlocks` can group lines correctly.

### Description
- In `SimpleSpeaker::Speaker#tell_error`, when `@logger_error` is present the code now gathers a `detail` string from `err.full_message` if available, otherwise builds `"#{err.class}: #{err.message}\n#{Array(err.backtrace).join("\n")}"` as a fallback.
- The exception object is still logged once via `@logger_error.error(err)` and then the full detail is written line-by-line with `@logger_error.error(line.chomp)` so each line is passed through the logger formatter.
- No changes were made to `speak_up` or console output; only the error logger output was enhanced.

### Testing
- Ran `ruby -c lib/simple_speaker.rb` to validate syntax and it reported `Syntax OK`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b6e14c7e483279ead269bcc9bbfe3)