### PR TITLE
Use timed shutdown path for stop requests

### DIFF
--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -165,6 +165,7 @@ class Daemon
     def stop
       if running?
         app.speaker.speak_up('Will shutdown after pending operations')
+        force_shutdown_flag.make_true
         app.librarian.quit = true
         if Thread.current[:jid]
           Thread.new { shutdown }


### PR DESCRIPTION
### Motivation
- Ensure `stop` follows the same timed shutdown flow as `restart`/`update-stop` so executor shutdown can be bounded by the existing timeout logic in `wait_for_executor_shutdown`.

### Description
- Set `force_shutdown_flag.make_true` in `app/daemon.rb` inside `stop` before calling `shutdown`, reusing the existing `force_shutdown_flag` and relying on the existing `cleanup` reset (`@force_shutdown_flag&.make_false` / clearing) without adding new configuration.

### Testing
- Ran `bundle exec rake test`, but the test run failed due to an environment bundler/git dependency (could not check out a git gem), so automated tests could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bbdc002f08327b4c85bc2c238c612)