### PR TITLE
Fix watchlist type enum value in file system scan service test

### DIFF
--- a/test/services/file_system_scan_service_test.rb
+++ b/test/services/file_system_scan_service_test.rb
@@ -144,6 +144,6 @@ class FileSystemScanServiceTest < Minitest::Test
     end
 
     deletion = @db.deleted_rows.find { |row| row[:table] == :watchlist }
-    assert_equal({ table: :watchlist, imdb_id: 'tt7654321', type: 'show' }, deletion)
+    assert_equal({ table: :watchlist, imdb_id: 'tt7654321', type: 'shows' }, deletion)
   end
 end


### PR DESCRIPTION
## Summary
Updated the test assertion to use the correct enum value for watchlist media types.

## Changes
- Changed the expected watchlist type from `'show'` to `'shows'` in the `test_removes_watchlist_entry_for_detected_media` test
- This aligns the test with the actual enum values used in the application

## Details
The test was asserting an incorrect type value. The watchlist type enum uses the plural form `'shows'` rather than the singular `'show'`. This fix ensures the test accurately validates the behavior of the file system scan service when removing watchlist entries for detected media.

https://claude.ai/code/session_018ceDt6G4kGhxradL3eUMYq