### PR TITLE
Add IO methods to trakt_output_proxy for Ruby 3.2+ compatibility

### DIFF
--- a/app/media_librarian/services/calendar_feed_service.rb
+++ b/app/media_librarian/services/calendar_feed_service.rb
@@ -768,6 +768,11 @@ module MediaLibrarian
             args.each { |arg| output.call(arg) }
           end
         end
+        # Add IO methods required by Open3/spawn in Ruby 3.2+
+        proxy.define_singleton_method(:flush) { }
+        proxy.define_singleton_method(:sync) { true }
+        proxy.define_singleton_method(:sync=) { |_| }
+        proxy.define_singleton_method(:tty?) { false }
         proxy
       end
 


### PR DESCRIPTION
## Summary
This change adds required IO interface methods to the `trakt_output_proxy` object to ensure compatibility with Ruby 3.2+ when used with `Open3.popen3` and process spawning utilities.

## Changes
- Added `flush` method (no-op) to satisfy IO flush requirements
- Added `sync` getter method returning `true` for synchronous IO behavior
- Added `sync=` setter method to allow sync property assignment
- Added `tty?` method returning `false` to indicate non-TTY output

## Details
Ruby 3.2+ enforces stricter IO interface requirements when spawning processes with `Open3`. The proxy object used to capture stdout/stderr now implements these required methods as singleton methods to prevent `NoMethodError` exceptions during process execution. These are minimal implementations appropriate for a non-interactive output proxy.

https://claude.ai/code/session_01MWbmvmS77kFsDe8EmNQFFX