### PR TITLE
Fix email delivery for scheduled jobs with parent threads

### DIFF
--- a/librarian.rb
+++ b/librarian.rb
@@ -403,7 +403,7 @@ class Librarian
       if thread[:block].is_a?(Array) && !thread[:block].empty?
         thread[:block].reverse_each { |b| b.call rescue nil }
       end
-      if thread[:parent]
+      if thread[:parent] && thread[:child_job].to_i.positive?
         Utils.lock_block("merge_child_thread_#{thread[:object]}") { Daemon.merge_notifications(thread, thread[:parent]) }
       elsif thread[:child_job].to_i.positive?
         # Inline child jobs share the parent's thread, so email delivery should be deferred

--- a/test/librarian_terminate_command_test.rb
+++ b/test/librarian_terminate_command_test.rb
@@ -19,8 +19,8 @@ class LibrarianTerminateCommandTest < Minitest::Test
 
   def test_child_threads_defer_email_delivery_to_parent
     parent = build_thread(object: 'parent job', jid: 'parent-jid')
-    child_one = build_thread(object: 'child-one', parent: parent, jid: 'child-jid-1')
-    child_two = build_thread(object: 'child-two', parent: parent, jid: 'child-jid-2')
+    child_one = build_thread(object: 'child-one', parent: parent, jid: 'child-jid-1', child_job: 1)
+    child_two = build_thread(object: 'child-two', parent: parent, jid: 'child-jid-2', child_job: 1)
 
     sent_out_calls = []
     merged_children = []
@@ -50,6 +50,28 @@ class LibrarianTerminateCommandTest < Minitest::Test
         end
       end
     end
+  end
+
+  def test_scheduled_jobs_with_parent_but_not_child_job_send_email_directly
+    # Scheduled jobs have parent set (scheduler thread) but child_job: 0
+    # They should send email directly, not try to merge with parent
+    scheduler_thread = build_thread(object: 'scheduler', jid: 'scheduler-jid')
+    scheduled_job = build_thread(object: 'monitor_torrent_client', parent: scheduler_thread, jid: 'job-jid', child_job: 0)
+
+    sent_out_calls = []
+    merged_children = []
+
+    Env.stub(:email_notif?, ->(*) { true }) do
+      Daemon.stub(:merge_notifications, ->(child, parent_thread) { merged_children << [child, parent_thread] }) do
+        Report.stub(:sent_out, ->(subject, thread) { sent_out_calls << [subject, thread] }) do
+          Librarian.terminate_command(scheduled_job, 'job-value', scheduled_job[:object])
+        end
+      end
+    end
+
+    assert_empty merged_children, 'scheduled job should not merge notifications'
+    assert_equal 1, sent_out_calls.size, 'scheduled job should send email directly'
+    assert_equal scheduled_job, sent_out_calls.first.last
   end
 
   private


### PR DESCRIPTION
## Summary
Fixed a bug where scheduled jobs with a parent thread but no child job would incorrectly attempt to merge notifications with their parent instead of sending email directly.

## Changes
- **librarian.rb**: Updated the condition in `terminate_command` to check both `thread[:parent]` AND `thread[:child_job].to_i.positive?` before merging notifications. This ensures only actual child jobs (where `child_job > 0`) merge with their parent, while scheduled jobs (where `child_job == 0`) send email directly.

- **test/librarian_terminate_command_test.rb**: 
  - Updated existing child thread tests to explicitly set `child_job: 1` to reflect the intended behavior
  - Added new test `test_scheduled_jobs_with_parent_but_not_child_job_send_email_directly` to verify scheduled jobs send email directly rather than merging with their parent scheduler thread

## Implementation Details
The fix distinguishes between two types of jobs with parent threads:
- **Child jobs** (`child_job > 0`): Spawned by parent, should defer email delivery and merge notifications
- **Scheduled jobs** (`child_job == 0`): Spawned by scheduler, should send email directly despite having a parent reference

This prevents scheduled jobs from incorrectly attempting to merge with their scheduler's thread context.

https://claude.ai/code/session_01Gduu4MgXZaoBQsWn2Dhv6Q