### PR TITLE
Add confirmation dialogs to daemon stop operations

### DIFF
--- a/app/web/app.js
+++ b/app/web/app.js
@@ -4039,6 +4039,9 @@ async function restartDaemon() {
 }
 
 async function stopDaemon() {
+  if (!confirm('Êtes-vous sûr de vouloir arrêter le démon ?')) {
+    return;
+  }
   await controlDaemon({
     path: '/stop',
     buttonId: 'stop-daemon',
@@ -4047,6 +4050,9 @@ async function stopDaemon() {
 }
 
 async function updateCodeAndStop() {
+  if (!confirm('Êtes-vous sûr de vouloir mettre à jour le code et arrêter le démon ?')) {
+    return;
+  }
   await controlDaemon({
     path: '/update-stop',
     buttonId: 'update-stop-daemon',


### PR DESCRIPTION
## Summary
Added confirmation dialogs to prevent accidental daemon shutdown operations. Users must now explicitly confirm before stopping the daemon or updating code and stopping the daemon.

## Changes
- Added confirmation dialog to `stopDaemon()` function
- Added confirmation dialog to `updateCodeAndStop()` function
- Both dialogs use French language prompts to match the application's localization

## Implementation Details
- Confirmation dialogs use the native browser `confirm()` function
- If the user cancels the confirmation, the function returns early without executing the daemon control operation
- This provides a safety mechanism to prevent unintended service interruptions

https://claude.ai/code/session_01PHaTkSZCcizskbiJxWQ8GM