### PR TITLE
Improve mergerfs path resolution using xattr for existing files

### DIFF
--- a/lib/file_utils.rb
+++ b/lib/file_utils.rb
@@ -266,7 +266,7 @@ module FileUtils
         if MergerfsIO.destination_is_mergerfs?(destination)
           local_branch = ENV['LOCAL_BRANCH'].to_s
           if !local_branch.empty? && resolved.start_with?(local_branch)
-            dst_effective = MergerfsIO.resolve_destination_local(destination)
+            dst_effective = MergerfsIO.resolve_to_local(destination)
             FileUtils.mkdir_p(File.dirname(dst_effective)) unless File.exist?(File.dirname(dst_effective))
           end
         end

--- a/lib/video_utils.rb
+++ b/lib/video_utils.rb
@@ -240,6 +240,13 @@ class VideoUtils
 
     # If on mergerfs, resolve to local path for accurate space check
     if MergerfsIo.source_is_mergerfs?(existing)
+      # First try using mergerfs xattr to get the actual underlying path (most reliable for existing files)
+      fullpath = MergerfsIo.xattr_value(existing, 'user.mergerfs.fullpath')
+      if fullpath && !fullpath.empty? && File.exist?(fullpath)
+        return fullpath
+      end
+
+      # Fall back to env-var based resolution (useful for paths that don't exist yet)
       local_path = MergerfsIo.resolve_destination_local(existing)
       if local_path && !local_path.empty? && local_path != existing
         # Walk up to find existing local path


### PR DESCRIPTION
## Summary
Enhanced the mergerfs path resolution logic to prioritize xattr-based lookup for more reliable path resolution of existing files, with fallback to environment variable-based resolution for non-existent paths.

## Key Changes
- Added xattr-based path resolution using `user.mergerfs.fullpath` as the primary method for resolving existing files on mergerfs
- Implemented fallback to the existing environment variable-based resolution (`resolve_destination_local`) for paths that don't exist yet
- Added validation checks to ensure the xattr-resolved path exists before returning it

## Implementation Details
The change improves accuracy by leveraging mergerfs's native xattr mechanism, which directly provides the underlying filesystem path for existing files. This is more reliable than environment variable-based resolution. The fallback mechanism ensures backward compatibility and handles edge cases where files don't yet exist on the filesystem.

https://claude.ai/code/session_01UyZx2nbDoroGcE53ARfoSQ