### PR TITLE
Remove debug logging statements from file operations

### DIFF
--- a/lib/file_utils.rb
+++ b/lib/file_utils.rb
@@ -24,7 +24,6 @@ module FileUtils
 
     def cp(source, target)
       return MediaLibrarian.app.speaker.speak_up("Would cp #{source} to #{target}") if Env.pretend?
-      MediaLibrarian.app.speaker.speak_up("cp #{source} #{target}") if Env.debug?
       if source.is_a?(Array)
         source.each { |item| cp(item, File.join(target, File.basename(item))) }
         return
@@ -215,7 +214,6 @@ module FileUtils
 
     def mv(original, destination)
       return MediaLibrarian.app.speaker.speak_up("Would mv #{original} #{destination}") if Env.pretend?
-      MediaLibrarian.app.speaker.speak_up("mv #{original} #{destination}") if Env.debug?
       if original.is_a?(Array)
         original.each { |item| mv(item, File.join(destination, File.basename(item))) }
         return
@@ -274,7 +272,6 @@ module FileUtils
       end
       resolved, dst_effective = resolver.call
       attempts << resolved
-      MediaLibrarian.app.speaker.speak_up("Resolved transfer src_effective=#{resolved} dst_effective=#{dst_effective}") if Env.debug?
       yield resolved, dst_effective
     rescue Errno::ENOENT
       if !mkdir_attempted
@@ -283,7 +280,6 @@ module FileUtils
         begin
           resolved, dst_effective = resolver.call
           attempts << resolved
-          MediaLibrarian.app.speaker.speak_up("Resolved transfer src_effective=#{resolved} dst_effective=#{dst_effective}") if Env.debug?
           return yield resolved, dst_effective
         rescue Errno::ENOENT
         end
@@ -291,7 +287,6 @@ module FileUtils
       raise unless mergerfs_source
       resolved, dst_effective = resolver.call
       attempts << resolved
-      MediaLibrarian.app.speaker.speak_up("Resolved transfer src_effective=#{resolved} dst_effective=#{dst_effective}") if Env.debug?
       begin
         yield resolved, dst_effective
       rescue Errno::ENOENT


### PR DESCRIPTION
## Summary
Removes conditional debug logging statements from file utility methods to reduce noise in debug output and simplify the codebase.

## Changes
- Removed debug logging from `cp()` method
- Removed debug logging from `mv()` method
- Removed debug logging from `with_mergerfs_retry()` method (3 instances)

## Details
These debug statements were logging file operation details (source/destination paths and resolved transfer paths) when `Env.debug?` was true. Removing them streamlines the debug output and reduces redundant logging, as the actual file operations themselves likely provide sufficient visibility into what the code is doing.

https://claude.ai/code/session_01U1NqHF6aLBpavWmbsuxLYp