### PR TITLE
Specify UTF-8 encoding for new String instances

### DIFF
--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -1008,12 +1008,12 @@ class Daemon
         thread[:jid] = job.id
         thread[:queue_name] = job.queue
         if job.child.to_i.positive?
-          thread[:log_msg] = inline_child ? nil : String.new
+          thread[:log_msg] = inline_child ? nil : String.new(encoding: 'UTF-8')
         end
         thread[:child_job] = job.child.to_i.positive? ? 1 : 0
         thread[:child_job_override] = thread[:child_job]
 
-        captured_output = job.capture_output ? (job.output || String.new) : nil
+        captured_output = job.capture_output ? (job.output || String.new(encoding: 'UTF-8')) : nil
         if captured_output
           job.output = captured_output
           thread[:captured_output] = captured_output
@@ -1034,7 +1034,7 @@ class Daemon
             if thread[:parent]
               merge_notifications(thread, thread[:parent])
               if thread[:email_msg]
-                thread[:parent][:email_msg] ||= String.new
+                thread[:parent][:email_msg] ||= String.new(encoding: 'UTF-8')
                 thread[:parent][:email_msg] << thread[:email_msg].to_s
               end
               if thread[:send_email].to_i.positive?

--- a/lib/simple_speaker.rb
+++ b/lib/simple_speaker.rb
@@ -53,7 +53,7 @@ module SimpleSpeaker
       str = "[*] #{str}" if in_mail.to_i > 0
       buffer = thread[:email_msg]
       if buffer.nil?
-        buffer = String.new
+        buffer = String.new(encoding: 'UTF-8')
         thread[:email_msg] = buffer
       end
 


### PR DESCRIPTION
## Summary
This PR explicitly specifies UTF-8 encoding when creating new String instances throughout the codebase to ensure consistent character encoding handling.

## Changes
- **app/daemon.rb**: Updated 3 instances of `String.new` to include `encoding: 'UTF-8'` parameter:
  - Line 1011: `thread[:log_msg]` initialization for child jobs
  - Line 1015: `captured_output` initialization when capturing job output
  - Line 1037: `thread[:parent][:email_msg]` initialization when merging notifications

- **lib/simple_speaker.rb**: Updated 1 instance of `String.new` to include `encoding: 'UTF-8'` parameter:
  - Line 56: `buffer` initialization in `email_msg_add` method

## Implementation Details
By explicitly setting `encoding: 'UTF-8'` when creating new String instances, we ensure that all string buffers used for logging, output capture, and email message composition operate with consistent UTF-8 encoding. This prevents potential encoding-related issues when these strings are concatenated with other UTF-8 encoded content or processed downstream.

https://claude.ai/code/session_01FqmQAto8XQtDnuDmcy7Dfh