### PR TITLE
Fix all encoding issues in buffer append operations

### DIFF
--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -545,7 +545,10 @@ class Daemon
 
       if parent[:captured_output]
         captured = thread[:log_msg] || thread[:captured_output]
-        parent[:captured_output] << captured.to_s if captured
+        if captured
+          parent[:captured_output].force_encoding('UTF-8') if parent[:captured_output].encoding == Encoding::ASCII_8BIT
+          parent[:captured_output] << captured.to_s.force_encoding('UTF-8')
+        end
       end
     end
 
@@ -1043,8 +1046,9 @@ class Daemon
             elsif inline_child
               preserved_email = false
               if thread[:email_msg]
-                snapshot[:email_msg] ||= String.new
-                snapshot[:email_msg] << thread[:email_msg].to_s
+                snapshot[:email_msg] ||= String.new(encoding: 'UTF-8')
+                snapshot[:email_msg].force_encoding('UTF-8') if snapshot[:email_msg].encoding == Encoding::ASCII_8BIT
+                snapshot[:email_msg] << thread[:email_msg].to_s.force_encoding('UTF-8')
                 preserved_email = true
               end
               if preserved_email && thread[:send_email].to_i.positive?
@@ -3752,9 +3756,10 @@ class Daemon
       job = jid ? job_registry[jid] : job_for_thread(thread)
       return unless job&.capture_output
 
-      output = job.output || String.new
+      output = job.output || String.new(encoding: 'UTF-8')
       output = output.dup if output.frozen?
-      output << line.to_s
+      output.force_encoding('UTF-8') if output.encoding == Encoding::ASCII_8BIT
+      output << line.to_s.force_encoding('UTF-8')
       job.output = output
       output
     end

--- a/lib/simple_speaker.rb
+++ b/lib/simple_speaker.rb
@@ -46,7 +46,10 @@ module SimpleSpeaker
                  Daemon.append_job_output(thread[:jid], payload, thread: thread)
                end
       buffer = thread[:captured_output]
-      buffer&.<<(payload) if buffer && !buffer.equal?(output)
+      if buffer && !buffer.equal?(output)
+        buffer.force_encoding('UTF-8') if buffer.encoding == Encoding::ASCII_8BIT
+        buffer << payload.force_encoding('UTF-8')
+      end
     end
 
     def email_msg_add(str, in_mail, thread)
@@ -64,7 +67,10 @@ module SimpleSpeaker
     end
 
     def speak_up(str, in_mail = 1, thread = Thread.current, immediate = 0, error = 0)
-      thread[:log_msg] << str.to_s + @new_line if thread[:log_msg] && immediate.to_i <= 0
+      if thread[:log_msg] && immediate.to_i <= 0
+        thread[:log_msg].force_encoding('UTF-8') if thread[:log_msg].encoding == Encoding::ASCII_8BIT
+        thread[:log_msg] << str.to_s.force_encoding('UTF-8') + @new_line
+      end
       if immediate.to_i > 0 || thread[:log_msg].nil?
         str.to_s.each_line do |l|
           daemon_send(l, thread: thread)

--- a/librarian.rb
+++ b/librarian.rb
@@ -250,7 +250,8 @@ class Librarian
           thread[:child_job_override] = 1 if nested
           run_command(args, direct_flag)
           if nested && snapshot[:email_msg]
-            snapshot[:email_msg] << thread[:email_msg].to_s
+            snapshot[:email_msg].force_encoding('UTF-8') if snapshot[:email_msg].encoding == Encoding::ASCII_8BIT
+            snapshot[:email_msg] << thread[:email_msg].to_s.force_encoding('UTF-8')
             snapshot[:send_email] = thread[:send_email] if thread[:send_email].to_i.positive?
           end
         end


### PR DESCRIPTION
The previous fix only addressed buffer creation but existing buffers (created before restart or loaded from storage) could still be ASCII-8BIT.

This comprehensive fix:
- Forces UTF-8 encoding on buffers before appending when they are ASCII-8BIT
- Forces UTF-8 encoding on content being appended
- Covers all append operations: captured_output, log_msg, email_msg
- Fixes append_job_output to handle existing jobs with ASCII-8BIT output

Affected files:
- app/daemon.rb: merge_thread_output, append_job_output, inline_child handling
- lib/simple_speaker.rb: daemon_send, speak_up
- librarian.rb: nested command email handling

https://claude.ai/code/session_01FqmQAto8XQtDnuDmcy7Dfh