### PR TITLE
Refactor notification merging to prevent duplicate messages

### DIFF
--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -533,13 +533,11 @@ class Daemon
       Utils.lock_time_merge(thread, parent)
 
       if thread[:log_msg]
+        # Send log_msg to output/daemon without adding to email_msg
+        # (email_msg is merged separately to avoid duplicates)
         parent_daemon = thread[:parent_daemon]
-        if parent_daemon
-          thread[:log_msg].to_s.each_line do |line|
-            app.speaker.daemon_send(line, thread: parent, daemon: parent_daemon)
-          end
-        else
-          app.speaker.speak_up(thread[:log_msg].to_s, -1, parent, 1)
+        thread[:log_msg].to_s.each_line do |line|
+          app.speaker.daemon_send(line, thread: parent, daemon: parent_daemon)
         end
       end
 

--- a/librarian.rb
+++ b/librarian.rb
@@ -405,7 +405,8 @@ class Librarian
         thread[:block].reverse_each { |b| b.call rescue nil }
       end
       if thread[:parent] && thread[:child_job].to_i.positive?
-        Utils.lock_block("merge_child_thread_#{thread[:object]}") { Daemon.merge_notifications(thread, thread[:parent]) }
+        # Child jobs with a separate parent thread: notification merging is handled
+        # by Daemon.run_job ensure block to avoid duplicate merges
       elsif thread[:child_job].to_i.positive?
         # Inline child jobs share the parent's thread, so email delivery should be deferred
       elsif Env.email_notif?


### PR DESCRIPTION
## Summary
This PR refactors the notification merging logic to prevent duplicate messages when handling child job notifications. The changes simplify the daemon message sending logic and defer notification merging to a more appropriate location in the execution flow.

## Key Changes
- **daemon.rb**: Simplified `merge_notifications` method by removing the conditional check for `parent_daemon`. Now all log messages are sent via `daemon_send` without the fallback to `speak_up`, with added clarifying comments about the email message handling.
- **librarian.rb**: Removed the explicit `Daemon.merge_notifications` call in `terminate_command` for child jobs with a separate parent thread. Notification merging is now handled by the `Daemon.run_job` ensure block to avoid duplicate merges.

## Implementation Details
- The refactoring consolidates notification merging into a single code path, reducing complexity and potential for race conditions
- By deferring the merge operation to the ensure block in `Daemon.run_job`, we guarantee it executes at the proper time in the job lifecycle
- Comments have been added to clarify that `email_msg` is merged separately to prevent duplicates

https://claude.ai/code/session_019mszbCGwgXSoLzWZtXjh5u