### PR TITLE
Clean up test code: deduplicate shared helpers and remove dead code

### DIFF
--- a/test/app/calendar_test.rb
+++ b/test/app/calendar_test.rb
@@ -284,19 +284,7 @@ class CalendarTest < Minitest::Test
     db
   end
 
-  class FakeResponse
-    attr_accessor :status, :body
-
-    def initialize
-      @headers = {}
-      @status = nil
-      @body = nil
-    end
-
-    def []=(key, value)
-      @headers[key] = value
-    end
-  end
+  FakeResponse = TestSupport::Fakes::FakeResponse
 
   class FakeCalendar
     def initialize(app:, on_entries: nil)
@@ -310,13 +298,4 @@ class CalendarTest < Minitest::Test
     end
   end
 
-  def attach_db(db)
-    singleton = @environment.application.singleton_class
-    unless @environment.application.respond_to?(:db)
-      singleton.class_eval do
-        attr_accessor :db
-      end
-    end
-    @environment.application.db = db
-  end
 end

--- a/test/app/collection_repository_test.rb
+++ b/test/app/collection_repository_test.rb
@@ -123,16 +123,6 @@ class CollectionRepositoryTest < Minitest::Test
 
   private
 
-  def attach_db(db)
-    singleton = @environment.application.singleton_class
-    unless @environment.application.respond_to?(:db)
-      singleton.class_eval do
-        attr_accessor :db
-      end
-    end
-    @environment.application.db = db
-  end
-
   def insert_media(rows)
     rows.each do |row|
       @environment.application.db.insert_row(:local_media, base_row.merge(row), 1)
@@ -238,17 +228,5 @@ class CollectionRequestTest < Minitest::Test
     end
   end
 
-  class FakeResponse
-    attr_accessor :status, :body
-
-    def initialize
-      @headers = {}
-      @status = nil
-      @body = nil
-    end
-
-    def []=(key, value)
-      @headers[key] = value
-    end
-  end
+  FakeResponse = TestSupport::Fakes::FakeResponse
 end

--- a/test/client_connection_errors_test.rb
+++ b/test/client_connection_errors_test.rb
@@ -36,12 +36,4 @@ class ClientConnectionErrorsTest < Minitest::Test
     end
   end
 
-  private
-
-  def remove_app_reference(klass)
-    singleton = klass.singleton_class
-    if singleton.instance_variable_defined?(:@app)
-      singleton.remove_instance_variable(:@app)
-    end
-  end
 end

--- a/test/daemon_authentication_requirements_test.rb
+++ b/test/daemon_authentication_requirements_test.rb
@@ -54,19 +54,5 @@ class DaemonAuthenticationRequirementsTest < Minitest::Test
 
   class FakeRequest; end
 
-  class FakeResponse
-    attr_accessor :status, :body
-
-    def initialize
-      @headers = {}
-    end
-
-    def []=(key, value)
-      @headers[key] = value
-    end
-
-    def [](key)
-      @headers[key]
-    end
-  end
+  FakeResponse = TestSupport::Fakes::FakeResponse
 end

--- a/test/daemon_cli_stop_test.rb
+++ b/test/daemon_cli_stop_test.rb
@@ -152,12 +152,4 @@ class DaemonCliStopTest < Minitest::Test
     assert_equal 1, fake_client.stop_calls
   end
 
-  private
-
-  def remove_app_reference(klass)
-    singleton = klass.singleton_class
-    if singleton.instance_variable_defined?(:@app)
-      singleton.remove_instance_variable(:@app)
-    end
-  end
 end

--- a/test/daemon_watchlist_api_test.rb
+++ b/test/daemon_watchlist_api_test.rb
@@ -13,8 +13,7 @@ require_relative '../lib/storage/db'
 class DaemonWatchlistApiTest < Minitest::Test
   def setup
     @environment = build_stubbed_environment
-    ensure_db_accessor(@environment.application)
-    @environment.application.db = Storage::Db.new(File.join(@environment.root_path, 'librarian.db'))
+    attach_db(Storage::Db.new(File.join(@environment.root_path, 'librarian.db')))
     MediaLibrarian.application = @environment.application
     Daemon.configure(app: @environment.application)
   end
@@ -72,23 +71,5 @@ class DaemonWatchlistApiTest < Minitest::Test
 
   private
 
-  def ensure_db_accessor(application)
-    return if application.respond_to?(:db)
-
-    application.singleton_class.class_eval { attr_accessor :db }
-  end
-
-  class FakeResponse
-    attr_accessor :status, :body
-
-    def initialize
-      @headers = {}
-      @status = nil
-      @body = nil
-    end
-
-    def []=(key, value)
-      @headers[key] = value
-    end
-  end
+  FakeResponse = TestSupport::Fakes::FakeResponse
 end

--- a/test/lib/string_utils_test.rb
+++ b/test/lib/string_utils_test.rb
@@ -78,4 +78,3 @@ class StringUtilsTest < Minitest::Test
     assert pattern.end_with?('.{0,7}$')
   end
 end
-

--- a/test/lib/time_utils_test.rb
+++ b/test/lib/time_utils_test.rb
@@ -25,4 +25,3 @@ class TimeUtilsTest < Minitest::Test
     assert_equal '', TimeUtils.seconds_in_words(0)
   end
 end
-

--- a/test/lib/torrent_rss_test.rb
+++ b/test/lib/torrent_rss_test.rb
@@ -46,7 +46,7 @@ class TorrentRssTest < Minitest::Test
     agent.verify
     assert_equal 1, results.size
   ensure
-    cleanup_application(environment, old_application, app_defined)
+    restore_application(environment, old_application, app_defined)
   end
 
   def test_links_use_global_agent_without_metadata
@@ -63,7 +63,7 @@ class TorrentRssTest < Minitest::Test
     global_agent.verify
     assert_equal 1, results.size
   ensure
-    cleanup_application(environment, old_application, app_defined)
+    restore_application(environment, old_application, app_defined)
   end
 
   private
@@ -77,12 +77,6 @@ class TorrentRssTest < Minitest::Test
     MediaLibrarian.application = app
     tracker = 'secure'
     [environment, app, tracker, old_application, app_defined]
-  end
-
-  def ensure_mechanizer_accessor(app)
-    return if app.respond_to?(:mechanizer)
-
-    app.singleton_class.attr_accessor :mechanizer
   end
 
   def verify_links(entries)
@@ -102,12 +96,4 @@ class TorrentRssTest < Minitest::Test
     )
   end
 
-  def cleanup_application(environment, old_application, app_defined)
-    if app_defined
-      MediaLibrarian.application = old_application
-    elsif MediaLibrarian.instance_variable_defined?(:@application)
-      MediaLibrarian.remove_instance_variable(:@application)
-    end
-    environment&.cleanup
-  end
 end

--- a/test/lib/utils_test.rb
+++ b/test/lib/utils_test.rb
@@ -165,4 +165,3 @@ class UtilsTest < Minitest::Test
     assert_equal 'My Movie - 1080p - Pilot', parsed
   end
 end
-

--- a/test/librarian_cli_test.rb
+++ b/test/librarian_cli_test.rb
@@ -297,9 +297,4 @@ class LibrarianCliTest < Minitest::Test
     @environments << env
     env
   end
-
-  def remove_app_reference(klass)
-    singleton = klass.singleton_class
-    singleton.remove_instance_variable(:@app) if singleton.instance_variable_defined?(:@app)
-  end
 end

--- a/test/services/tracker_query_service_test.rb
+++ b/test/services/tracker_query_service_test.rb
@@ -344,20 +344,4 @@ class TrackerQueryServiceTest < Minitest::Test
     restore_application(environment, old_application, app_defined)
   end
 
-  private
-
-  def ensure_mechanizer_accessor(app)
-    return if app.respond_to?(:mechanizer)
-
-    app.singleton_class.attr_accessor :mechanizer
-  end
-
-  def restore_application(environment, old_application, app_defined)
-    if app_defined
-      MediaLibrarian.application = old_application
-    elsif MediaLibrarian.instance_variable_defined?(:@application)
-      MediaLibrarian.remove_instance_variable(:@application)
-    end
-    environment&.cleanup
-  end
 end

--- a/test/support/dependency_stubs.rb
+++ b/test/support/dependency_stubs.rb
@@ -84,79 +84,41 @@ unless defined?(TimeUtils)
   end
 end
 
-if defined?(Utils)
-  class Utils
-    class << self
-      def lock_time_get(*)
-        ''
-      end
+class Utils
+  class << self
+    def lock_time_get(*)
+      ''
+    end
 
-      def lock_block(*)
-        yield if block_given?
-      end
+    def lock_block(*)
+      yield if block_given?
+    end
 
-      def lock_time_merge(*)
-        # no-op in tests
-      end
+    def lock_time_merge(*)
+      # no-op in tests
+    end
 
-      def arguments_dump(*)
-        'arguments'
-      end
+    def arguments_dump(*)
+      'arguments'
+    end
 
-      def recursive_typify_keys(value)
-        value
-      end
+    def recursive_typify_keys(value)
+      value
+    end
 
-      def parse_filename_template(template, _metadata)
-        template
-      end
+    def parse_filename_template(template, _metadata)
+      template
+    end
 
-      def check_if_active(*)
-        true
-      end
+    def check_if_active(*)
+      true
+    end
 
-      def timeperiod_to_sec(*)
-        0
-      end
+    def timeperiod_to_sec(*)
+      0
     end
   end
-else
-  class Utils
-    class << self
-      def lock_time_get(*)
-        ''
-      end
-
-      def lock_block(*)
-        yield if block_given?
-      end
-
-      def lock_time_merge(*)
-        # no-op in tests
-      end
-
-      def arguments_dump(*)
-        'arguments'
-      end
-
-      def recursive_typify_keys(value)
-        value
-      end
-
-      def parse_filename_template(template, _metadata)
-        template
-      end
-
-      def check_if_active(*)
-        true
-      end
-
-      def timeperiod_to_sec(*)
-        0
-      end
-    end
-  end
-end
+end unless defined?(Utils) && Utils.is_a?(Class)
 
 unless defined?(Report)
   class Report


### PR DESCRIPTION
- Remove duplicated Utils stub in dependency_stubs.rb (both if/else
  branches were identical)
- Extract FakeResponse to TestSupport::Fakes (was duplicated in 4 files)
- Extract remove_app_reference to ContainerHelpers (was duplicated in
  3 files)
- Extract attach_db to ContainerHelpers (was duplicated in 2 files)
- Extract ensure_mechanizer_accessor and restore_application to
  ContainerHelpers (were duplicated in 2 files each)
- Remove trailing blank lines in string_utils_test, time_utils_test,
  and utils_test

https://claude.ai/code/session_019n6zssnpM1ShymQNpYCtfN