### PR TITLE
Expand special character stripping in tracker search keywords

### DIFF
--- a/app/media_librarian/services/tracker_query_service.rb
+++ b/app/media_librarian/services/tracker_query_service.rb
@@ -41,7 +41,7 @@ module MediaLibrarian
         r = {}
         search_category = request.search_category.to_s == '' ? request.category : request.search_category
         keyword = request.keyword.dup
-        keyword.gsub!(/[\(\)\:]/, '')
+        keyword.gsub!(/[\(\)\:\'\"!\?\;\,]/, '')
         trackers = get_trackers(request.sources)
         timeframe_trackers = parse_tracker_timeframes(request.sources || {})
         trackers.each do |tracker|


### PR DESCRIPTION
## Summary
Extended the special character filtering in tracker search queries to handle a broader set of punctuation marks that may interfere with search results.

## Key Changes
- Updated the keyword sanitization regex in `TrackerQueryService#get_results` to strip additional special characters: single quotes, double quotes, exclamation marks, question marks, semicolons, and commas
- Added comprehensive test coverage with two new test cases:
  - `test_get_results_strips_special_characters_from_keyword`: Validates removal of colons, parentheses, quotes, exclamation marks, question marks, semicolons, and commas
  - `test_get_results_strips_exclamation_and_question_marks`: Specifically tests handling of exclamation and question marks

## Implementation Details
The regex pattern was expanded from `[\(\)\:]` to `[\(\)\:\'\"!\?\;\,]` to ensure search keywords are properly normalized before being passed to tracker backends. This prevents special characters in titles (like "Now You See Me: Now You Don't (2025)") from causing search failures or unexpected results.

https://claude.ai/code/session_015kVLYW3o1VbKUNBCdwtpjK