### PR TITLE
Fix encoding of xattr values to UTF-8

### DIFF
--- a/lib/mergerfs_io.rb
+++ b/lib/mergerfs_io.rb
@@ -113,7 +113,7 @@ module MergerfsIo
     buffer = Fiddle::Pointer.malloc(size)
     read = @getxattr.call(path, name, buffer, size)
     return if read <= 0
-    buffer.to_s(read)
+    buffer.to_s(read).force_encoding(Encoding::UTF_8)
   rescue StandardError
     nil
   end

--- a/test/lib/mergerfs_io_test.rb
+++ b/test/lib/mergerfs_io_test.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'fiddle'
+require_relative '../../lib/mergerfs_io'
+
+class MergerfsIoTest < Minitest::Test
+  def teardown
+    MergerfsIo.instance_variable_set(:@getxattr, nil)
+  end
+
+  def test_xattr_value_returns_utf8_encoded_string
+    utf8_path = "/mnt/data/Movies/Alien\u00B3 (1992)/file.mkv"
+    stub_getxattr_with(utf8_path)
+
+    Dir.mktmpdir do |dir|
+      result = MergerfsIo.xattr_value(dir, 'user.mergerfs.fullpath')
+      assert_equal Encoding::UTF_8, result.encoding,
+                   "xattr_value should return UTF-8 encoded strings, got #{result.encoding}"
+      assert result.valid_encoding?, "returned string should be valid UTF-8"
+      assert_equal utf8_path, result
+    end
+  end
+
+  def test_xattr_value_returns_nil_for_nonexistent_path
+    result = MergerfsIo.xattr_value('/nonexistent/path/that/does/not/exist', 'user.mergerfs.fullpath')
+    assert_nil result
+  end
+
+  def test_xattr_value_utf8_result_concatenates_with_utf8_strings
+    # This reproduces the actual failure: xattr returns a path with non-ASCII chars
+    # and it gets interpolated into a UTF-8 string in transfer_with_fallback
+    utf8_path = "/mnt/data/Movies/Alien\u00B3 (1992)/file.mkv"
+    stub_getxattr_with(utf8_path)
+
+    Dir.mktmpdir do |dir|
+      result = MergerfsIo.xattr_value(dir, 'user.mergerfs.fullpath')
+      utf8_source = "Alien\u00B3 (1992)"
+      # This would raise Encoding::CompatibilityError without the fix
+      combined = "source=#{utf8_source} resolved=#{result}"
+      assert_includes combined, "Alien\u00B3"
+    end
+  end
+
+  private
+
+  def stub_getxattr_with(utf8_path)
+    raw_bytes = utf8_path.dup.force_encoding(Encoding::ASCII_8BIT)
+
+    fake_getxattr = lambda do |_path_arg, _name_arg, buf_arg, _size_arg|
+      if buf_arg.nil? || buf_arg.null?
+        raw_bytes.bytesize
+      else
+        raw_bytes.bytes.each_with_index { |b, i| buf_arg[i] = b }
+        raw_bytes.bytesize
+      end
+    end
+
+    MergerfsIo.instance_variable_set(:@getxattr, fake_getxattr)
+  end
+end


### PR DESCRIPTION
## Summary
Fixes an encoding compatibility error when xattr values containing non-ASCII characters are concatenated with UTF-8 strings.

## Changes
- **lib/mergerfs_io.rb**: Added `.force_encoding(Encoding::UTF_8)` to the `xattr_value` method's return value to ensure extended attribute data is properly decoded as UTF-8
- **test/lib/mergerfs_io_test.rb**: Added comprehensive test coverage for the xattr encoding behavior, including:
  - Test verifying returned values are UTF-8 encoded
  - Test for handling nonexistent paths
  - Test reproducing the actual failure scenario where xattr results with non-ASCII characters are interpolated into UTF-8 strings

## Implementation Details
The `getxattr` system call returns raw bytes that need to be properly interpreted as UTF-8. Without explicit encoding, Ruby treats the buffer data as ASCII-8BIT (binary), which causes `Encoding::CompatibilityError` when concatenated with UTF-8 strings. The fix explicitly marks the returned string as UTF-8 encoded, allowing seamless string interpolation in downstream code like `transfer_with_fallback`.

https://claude.ai/code/session_01U2e8qP1cWn2oLm9JUXhxzj