### PR TITLE
Fix Torznab search crash when tracker returns single result

### DIFF
--- a/lib/torznab_tracker.rb
+++ b/lib/torznab_tracker.rb
@@ -25,7 +25,9 @@ class TorznabTracker
     end
     MediaLibrarian.app.speaker.speak_up "Running search on tracker '#{name}' for query '#{query}' for category '#{type}' (#{cat.join(',')})" if Env.debug?
     response = Hash.from_xml(@tracker.get({'t' => t, 'cat' => cat.join(','), 'q' => query, 'limit' => limit})) || {}
-    Array(response.dig(:rss, :channel, :item)).each do |i|
+    items = response.dig(:rss, :channel, :item)
+    items = [items] if items.is_a?(Hash)
+    Array(items).each do |i|
       enclosure_url = i.dig(:enclosure, :@url) || i.dig(:enclosure, :url)
       guid = if i[:guid].is_a?(Hash)
         guid_hash = i[:guid]


### PR DESCRIPTION
When a Torznab search returns only one <item>, Hash.from_xml returns it
as a Hash rather than an Array. Array(hash) then converts it into an
array of [key, value] pairs, causing "no implicit conversion of Symbol
into Integer" when dig is called on those pairs.

Wrap single-item Hash responses in an array before iterating.

https://claude.ai/code/session_01UNQ8d3A7iLeBZpnLUgG9PT