### PR TITLE
Fix movie identification failures for title variants and empty metadata

### DIFF
--- a/app/movie.rb
+++ b/app/movie.rb
@@ -217,6 +217,10 @@ class Movie
         end
       end
       movie = Movie.new(movie.merge('data_source' => src), app: app) if movie
+      if movie && movie.name.to_s.strip == ''
+        app.speaker.speak_up("movie_get: discarding empty movie from #{src} for ids=#{ids.inspect}") if Env.debug?
+        movie = nil
+      end
       full_save = movie
       title = movie.name if movie&.name.to_s != ''
     when 'movie_set_get'

--- a/test/app/movie_test.rb
+++ b/test/app/movie_test.rb
@@ -148,6 +148,23 @@ class MovieTest < Minitest::Test
                     'Movie.extract_value missing title, no fallback available: {"release_date"=>"2019-12-12"}'
   end
 
+  def test_movie_get_discards_empty_trakt_response
+    ensure_tmdb_stubs
+
+    # Simulate Trakt returning an object with no meaningful data
+    empty_trakt_response = { 'title' => nil, 'ids' => {} }
+
+    without_cache do
+      Tmdb::Movie.stub(:detail, ->(*) { nil }) do
+        TraktAgent.stub(:movie__summary, ->(*) { empty_trakt_response }) do
+          title, movie = Movie.movie_get({ 'imdb' => 'tt1234567' }, app: @environment.application)
+          assert_nil movie, "Expected nil movie when Trakt returns empty data"
+          assert_equal '', title
+        end
+      end
+    end
+  end
+
   private
 
   def ensure_tmdb_stubs

--- a/test/lib/metadata_match_titles_test.rb
+++ b/test/lib/metadata_match_titles_test.rb
@@ -20,4 +20,82 @@ class MetadataMatchTitlesTest < Minitest::Test
 
     assert Metadata.match_titles(title, target, 2008, 2008, 'movies')
   end
+
+  def test_matches_when_provider_title_is_suffix_of_search_title
+    # TMDB returns "Allegiant" but watchlist has "The Divergent Series: Allegiant"
+    assert Metadata.match_titles(
+      'Allegiant (2016)', 'The Divergent Series: Allegiant (2016)',
+      2016, 2016, 'movies'
+    )
+  end
+
+  def test_matches_when_provider_title_is_suffix_with_franchise_prefix
+    # TMDB returns "Dark Phoenix" but watchlist has "X-Men: Dark Phoenix"
+    assert Metadata.match_titles(
+      'Dark Phoenix (2019)', 'X-Men: Dark Phoenix (2019)',
+      2019, 2019, 'movies'
+    )
+  end
+
+  def test_matches_when_search_title_is_prefix_of_provider_title
+    # Watchlist has "Borat" but TMDB returns the full title
+    assert Metadata.match_titles(
+      'Borat: Cultural Learnings of America for Make Benefit Glorious Nation of Kazakhstan (2006)',
+      'Borat (2006)',
+      2006, 2006, 'movies'
+    )
+  end
+
+  def test_matches_superscript_numbers_to_regular_numbers
+    # Watchlist has "Cube²: Hypercube" but TMDB returns "Cube 2: Hypercube"
+    assert Metadata.match_titles(
+      'Cube 2: Hypercube (2002)', "Cube\u00B2: Hypercube (2003)",
+      2002, 2003, 'movies'
+    )
+  end
+
+  def test_rejects_different_movies_with_similar_prefix
+    # "Borat" should not match "Borat Subsequent Moviefilm" when years differ
+    refute Metadata.match_titles(
+      'Borat Subsequent Moviefilm (2020)', 'Borat (2006)',
+      2020, 2006, 'movies'
+    )
+  end
+
+  def test_rejects_completely_different_titles_same_year
+    # Unrelated movies with the same year should not match
+    refute Metadata.match_titles(
+      'Avatar (2009)', 'Inception (2009)',
+      2009, 2009, 'movies'
+    )
+  end
+
+  def test_reverse_regex_matches_exact_title_in_opposite_direction
+    # The regex of the shorter title matches the longer title
+    assert Metadata.match_titles(
+      'Alien 3 (1992)', "Alien\u00B3 (1992)",
+      1992, 1992, 'movies'
+    )
+  end
+
+  def test_normalize_special_chars
+    assert_equal '2', Metadata.normalize_special_chars("\u00B2")
+    assert_equal '3', Metadata.normalize_special_chars("\u00B3")
+    assert_equal '1', Metadata.normalize_special_chars("\u00B9")
+    assert_equal 'Alien 3', Metadata.normalize_special_chars("Alien\u00B3")
+    assert_equal 'Cube 2', Metadata.normalize_special_chars("Cube\u00B2")
+  end
+
+  def test_title_contained_suffix
+    assert Metadata.title_contained?('allegiant', 'divergent series allegiant')
+    assert Metadata.title_contained?('dark phoenix', 'x men dark phoenix')
+  end
+
+  def test_title_contained_prefix
+    assert Metadata.title_contained?('borat', 'borat cultural learnings of america')
+  end
+
+  def test_title_contained_rejects_unrelated
+    refute Metadata.title_contained?('avatar', 'inception')
+  end
 end


### PR DESCRIPTION
Two root causes were preventing movies from being identified:

1. Empty Trakt metadata cached in DB: When Trakt returns responses with
   empty fields, Movie objects with no name were created and persisted to
   the metadata_search cache. This prevented subsequent lookups from
   using TMDB search as fallback. Fix: discard Movie objects with empty
   names in movie_get, and skip cached results with empty names in
   media_lookup.

2. match_titles too strict for common title variations: TMDB often returns
   movies under different title variants (e.g. "Allegiant" vs "The
   Divergent Series: Allegiant", "Borat" vs full title). Fix: add
   bidirectional regex matching, token-based prefix/suffix containment
   checks, and superscript character normalization (² → 2).

https://claude.ai/code/session_011yp5GT84Yhy1RoCvHWEKqa