### PR TITLE
Remove main_only from Deluge options filtering

### DIFF
--- a/app/torrent_client.rb
+++ b/app/torrent_client.rb
@@ -55,7 +55,7 @@ class TorrentClient
   end
 
   def download_file(download, options = {}, meta_id = '')
-    options.select! { |key, _| [:move_completed, :main_only].include?(key) }
+    options.select! { |key, _| [:move_completed].include?(key) }
     options = Utils.recursive_typify_keys(options, 0) if options.is_a?(Hash)
     if options['move_completed'].to_s != ''
       options['move_completed_path'] = options['move_completed']

--- a/test/app/torrent_client_test.rb
+++ b/test/app/torrent_client_test.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'base64'
+require_relative '../../app/torrent_client'
+
+class TorrentClientTest < Minitest::Test
+  class RecordingDelugeClient
+    attr_reader :calls
+
+    def initialize
+      @calls = []
+    end
+
+    def add_torrent_file(*args)
+      @calls << [:add_torrent_file, args]
+    end
+
+    def add_torrent_magnet(*args)
+      @calls << [:add_torrent_magnet, args]
+    end
+
+    def add_torrent_url(*args)
+      @calls << [:add_torrent_url, args]
+    end
+
+    def get_torrent_status(*args)
+      @calls << [:get_torrent_status, args]
+      { 'name' => 'test', 'progress' => 100, 'queue' => 1 }
+    end
+
+    def queue_top(*args)
+      @calls << [:queue_top, args]
+    end
+  end
+
+  class FakeApp
+    attr_accessor :speaker, :t_client, :config
+
+    def initialize(speaker:, t_client:)
+      @speaker = speaker
+      @t_client = t_client
+      @config = { 'deluge' => { 'host' => 'localhost', 'username' => 'test', 'password' => 'test' } }
+    end
+  end
+
+  def setup
+    @speaker = TestSupport::Fakes::Speaker.new
+    @recording_client = RecordingDelugeClient.new
+    @app = FakeApp.new(speaker: @speaker, t_client: @recording_client)
+    @torrent_client = TorrentClient.new(app: @app)
+  end
+
+  def test_download_file_does_not_pass_main_only_to_deluge
+    download = { type: 1, filename: 'test.torrent', file: 'torrent-data' }
+    options = {
+      move_completed: '/home/user/completed/Movies/',
+      main_only: 1,
+      rename_main: 'SomeMovie',
+      tdid: '12345',
+      queue: 'top'
+    }
+
+    @torrent_client.download_file(download, options.deep_dup)
+
+    assert_equal 1, @recording_client.calls.length
+    method_name, args = @recording_client.calls.first
+    assert_equal :add_torrent_file, method_name
+
+    passed_options = args.last
+    assert_instance_of Hash, passed_options
+    refute passed_options.key?(:main_only), "main_only symbol key should not be passed to Deluge"
+    refute passed_options.key?('main_only'), "main_only string key should not be passed to Deluge"
+  end
+
+  def test_download_file_passes_valid_deluge_options
+    download = { type: 1, filename: 'test.torrent', file: 'torrent-data' }
+    options = {
+      move_completed: '/home/user/completed/Movies/',
+      main_only: 1
+    }
+
+    @torrent_client.download_file(download, options.deep_dup)
+
+    _, args = @recording_client.calls.first
+    passed_options = args.last
+    assert_equal true, passed_options['move_completed'] || passed_options[:move_completed]
+    move_path = passed_options['move_completed_path'] || passed_options[:move_completed_path]
+    assert_equal '/home/user/completed/Movies/', move_path
+    add_paused = passed_options['add_paused'] || passed_options[:add_paused]
+    assert_equal true, add_paused
+  end
+
+  def test_download_file_strips_non_deluge_options
+    download = { type: 1, filename: 'test.torrent', file: 'torrent-data' }
+    options = {
+      move_completed: '/home/user/completed/',
+      main_only: 1,
+      rename_main: 'SomeName',
+      tdid: '999',
+      queue: 'top',
+      assume_quality: 'HD',
+      entry_id: 'abc',
+      category: 'movies',
+      whitelisted_extensions: ['mkv']
+    }
+
+    @torrent_client.download_file(download, options.deep_dup)
+
+    _, args = @recording_client.calls.first
+    passed_options = args.last
+    all_keys = passed_options.keys.map(&:to_s)
+
+    %w[main_only rename_main tdid queue assume_quality entry_id category whitelisted_extensions].each do |key|
+      refute all_keys.include?(key), "#{key} should not be passed to Deluge"
+    end
+  end
+
+  def test_download_file_magnet_does_not_pass_main_only
+    download = { type: 2, url: 'magnet:?xt=urn:btih:abc123' }
+    options = {
+      move_completed: '/home/user/completed/',
+      main_only: 1
+    }
+
+    @torrent_client.download_file(download, options.deep_dup)
+
+    assert_equal 1, @recording_client.calls.length
+    method_name, args = @recording_client.calls.first
+    assert_equal :add_torrent_magnet, method_name
+
+    passed_options = args.last
+    refute passed_options.key?(:main_only), "main_only symbol key should not be passed to Deluge"
+    refute passed_options.key?('main_only'), "main_only string key should not be passed to Deluge"
+  end
+end

--- a/test/support/dependency_stubs.rb
+++ b/test/support/dependency_stubs.rb
@@ -102,8 +102,10 @@ class Utils
       'arguments'
     end
 
-    def recursive_typify_keys(value)
-      value
+    def recursive_typify_keys(value, symbolize = 1)
+      return value unless value.is_a?(Hash)
+
+      value.transform_keys { |k| symbolize.to_i > 0 ? k.to_sym : k.to_s rescue k }
     end
 
     def parse_filename_template(template, _metadata)


### PR DESCRIPTION
## Summary
This PR removes `main_only` from the list of options that are passed to the Deluge torrent client. The `main_only` option is an application-level setting that should not be forwarded to Deluge's API.

## Key Changes
- **app/torrent_client.rb**: Updated the `download_file` method to exclude `main_only` from the options passed to Deluge (only `move_completed` is now whitelisted)
- **test/support/dependency_stubs.rb**: Enhanced the `recursive_typify_keys` method to properly handle key transformation with a `symbolize` parameter, allowing conversion between symbol and string keys
- **test/app/torrent_client_test.rb**: Added comprehensive test suite for `TorrentClient` with tests covering:
  - Verification that `main_only` is not passed to Deluge for file downloads
  - Validation of valid Deluge options being properly transformed
  - Stripping of non-Deluge-specific options (rename_main, tdid, queue, assume_quality, entry_id, category, whitelisted_extensions)
  - Verification that `main_only` is not passed for magnet link downloads

## Implementation Details
The `main_only` option is application-specific metadata used for filtering or processing logic and has no meaning in the Deluge API. By removing it from the whitelist, we ensure cleaner API calls and prevent potential issues with unrecognized parameters being sent to Deluge.

https://claude.ai/code/session_01TExR83tahssytd5CPJAAcB