### PR TITLE
Fix Encoding::CompatibilityError when renaming torrent files with non-ASCII filenames

### DIFF
--- a/app/torrent_client.rb
+++ b/app/torrent_client.rb
@@ -144,7 +144,7 @@ class TorrentClient
     paths = []
     files.each do |file|
       old_name = Quality.filename_quality_change(File.basename(file['path']), torrent_qualities, [], category)
-      new_path = "#{new_dir_name.to_s + '/' if new_dir_name.to_s != ''}#{StringUtils.fix_encoding(old_name)}"
+      new_path = "#{StringUtils.fix_encoding(new_dir_name.to_s) + '/' if new_dir_name.to_s != ''}#{StringUtils.fix_encoding(old_name)}"
       paths << [file['index'], new_path]
     end
     app.t_client.rename_files(tid, paths)
@@ -212,7 +212,7 @@ class TorrentClient
     log_operation(debug_message)
     return if skip_operation?(name)
 
-    safely_execute_deluge_operation(name, sanitized_args, debug_message, tries)
+    safely_execute_deluge_operation(name, binarize_strings(sanitized_args), debug_message, tries)
   rescue => e
     app.speaker.tell_error(e, error_context(debug_message, sanitized_args))
     raise e unless invalid_torrent_error?(e)
@@ -304,6 +304,15 @@ class TorrentClient
     Cache.queue_state_remove('deluge_torrents_added', tid)
     Cache.queue_state_remove('deluge_torrents_completed', tid)
     {}
+  end
+
+  def binarize_strings(obj)
+    case obj
+    when String then obj.b
+    when Array then obj.map { |e| binarize_strings(e) }
+    when Hash then obj.transform_values { |v| binarize_strings(v) }
+    else obj
+    end
   end
 
   def reset_connection


### PR DESCRIPTION
When a torrent contains files in directories with non-Latin names (e.g.
Korean), two related encoding issues caused `rename_files` to fail with
"incompatible character encodings: ASCII-8BIT and UTF-8":

1. In `rename_torrent_files`, `new_dir_name` was not passed through
   `StringUtils.fix_encoding` before string interpolation, so an
   ASCII-8BIT directory name (from torrent RPC data) could collide with
   the UTF-8 `old_name`.

2. In `method_missing`, `StringUtils.accents_clear` converts all strings
   to UTF-8, but the `rencoder` gem (used by deluge-rpc for bencode
   serialisation) builds its output as ASCII-8BIT and fails when it tries
   to concatenate a UTF-8 string onto that accumulator. A new private
   `binarize_strings` helper recursively force-encodes all strings to
   ASCII-8BIT (binary) after `accents_clear`, preserving the UTF-8 byte
   content but making it compatible with the rencoder.

Tests added for both fixes and for `binarize_strings` edge cases.

https://claude.ai/code/session_01KD5QBJEo36uC1PpSwSbLtu