### PR TITLE
Add WebSocket support for live status and job updates and update web UI to use streams

### DIFF
--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -13,6 +13,7 @@ require 'bcrypt'
 require 'yaml'
 require 'fileutils'
 require 'base64'
+require 'digest/sha1'
 require 'get_process_mem'
 require 'socket'
 require 'open3'
@@ -1434,6 +1435,12 @@ class Daemon
         handle_watchlist_import_csv_request(req, res)
       end
 
+      @control_server.mount_proc('/ws') do |req, res|
+        next unless require_authorization(req, res)
+
+        handle_websocket_request(req, res)
+      end
+
       start_socket_server
       @control_thread = Thread.new { @control_server.start }
     end
@@ -1497,6 +1504,96 @@ class Daemon
       else
         error_response(res, status: 404, message: 'not_found')
       end
+    end
+
+    def handle_websocket_request(req, res)
+      key = req.header['sec-websocket-key']&.first.to_s
+      upgrade = req.header['upgrade']&.first.to_s.downcase
+      connection = req.header['connection']&.first.to_s.downcase
+      unless req.request_method == 'GET' && upgrade == 'websocket' && connection.include?('upgrade') && !key.empty?
+        return error_response(res, status: 400, message: 'invalid_websocket_upgrade')
+      end
+
+      socket = req.instance_variable_get(:@socket)
+      return error_response(res, status: 500, message: 'websocket_unavailable') unless socket
+
+      stream = req.query['stream'].to_s
+      job_id = req.query['job_id'].to_s
+      socket << websocket_handshake_response(key)
+
+      case stream
+      when 'job'
+        stream_job_updates(socket, job_id)
+      else
+        stream_status_updates(socket)
+      end
+
+      raise WEBrick::HTTPStatus::EOFError
+    rescue StandardError => e
+      app.speaker.tell_error(e, 'websocket request failure') if Env.debug?
+    ensure
+      socket&.close unless socket&.closed?
+      res.keep_alive = false
+    end
+
+    def websocket_handshake_response(key)
+      accept = Base64.strict_encode64(Digest::SHA1.digest("#{key}258EAFA5-E914-47DA-95CA-C5AB0DC85B11"))
+      [
+        'HTTP/1.1 101 Switching Protocols',
+        'Upgrade: websocket',
+        'Connection: Upgrade',
+        "Sec-WebSocket-Accept: #{accept}",
+        "Date: #{Time.now.httpdate}",
+        '',
+        ''
+      ].join("\r\n")
+    end
+
+    def stream_status_updates(socket)
+      loop do
+        payload = {
+          type: 'status',
+          data: status_snapshot_payload
+        }
+        socket.write(websocket_text_frame(payload.to_json))
+        sleep 15
+      end
+    rescue IOError, SystemCallError
+      nil
+    end
+
+    def stream_job_updates(socket, job_id)
+      return if job_id.to_s.empty?
+
+      loop do
+        job = job_registry[job_id]
+        payload = {
+          type: 'job',
+          data: job ? job.to_h : { id: job_id, status: 'not_found' }
+        }
+        socket.write(websocket_text_frame(payload.to_json))
+        break if job && FINISHED_STATUSES.include?(job.status.to_s)
+
+        sleep 2
+      end
+    rescue IOError, SystemCallError
+      nil
+    end
+
+    def websocket_text_frame(message)
+      bytes = message.to_s.b
+      length = bytes.bytesize
+      header = [0x81]
+      if length < 126
+        header << length
+      elsif length <= 0xffff
+        header << 126
+        header.concat([(length >> 8) & 0xff, length & 0xff])
+      else
+        header << 127
+        8.times { |i| header << ((length >> (56 - (i * 8))) & 0xff) }
+      end
+      header.pack('C*') + bytes
     end
 
     def handle_jobs_request(req, res)

--- a/app/web/app.css
+++ b/app/web/app.css
@@ -162,6 +162,26 @@ main {
   flex-wrap: wrap;
 }
 
+
+.ws-status {
+  display: inline-block;
+  margin-left: 0.5rem;
+  padding: 0.1rem 0.45rem;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  vertical-align: middle;
+}
+
+.ws-status-online {
+  background: #173f2a;
+  color: #6be2a2;
+}
+
+.ws-status-offline {
+  background: #4a1b1b;
+  color: #ff9e9e;
+}
+
 .jobs-metrics {
   display: flex;
   flex-wrap: wrap;

--- a/app/web/app.js
+++ b/app/web/app.js
@@ -1,11 +1,14 @@
 const state = {
   authenticated: false,
   username: '',
-  autoRefresh: null,
   activeTab: 'jobs',
+  sockets: {
+    status: null,
+    watchlist: null,
+  },
+  statusFallbackTimer: null,
   watchlistImport: {
     jobId: null,
-    timer: null,
   },
   dirty: {
     config: false,
@@ -730,21 +733,121 @@ async function parseErrorMessage(response) {
   return text;
 }
 
-function stopAutoRefresh() {
-  if (state.autoRefresh) {
-    window.clearInterval(state.autoRefresh);
-    state.autoRefresh = null;
+function closeSocket(name) {
+  const socket = state.sockets[name];
+  if (socket) {
+    socket.close();
+    state.sockets[name] = null;
   }
 }
 
-function startAutoRefresh() {
-  stopAutoRefresh();
-  state.autoRefresh = window.setInterval(() => {
+function closeSockets() {
+  closeSocket('status');
+  closeSocket('watchlist');
+  stopStatusFallback();
+  renderWsStatus('offline');
+}
+
+function renderWsStatus(stateLabel) {
+  const badge = document.getElementById('ws-status');
+  if (!badge) {
+    return;
+  }
+  const online = stateLabel === 'online';
+  badge.textContent = online ? 'WS en ligne' : 'WS hors ligne';
+  badge.classList.toggle('ws-status-online', online);
+  badge.classList.toggle('ws-status-offline', !online);
+}
+
+function startStatusFallback() {
+  if (state.statusFallbackTimer) {
+    return;
+  }
+  state.statusFallbackTimer = window.setInterval(() => {
     if (!state.authenticated || document.visibilityState === 'hidden') {
       return;
     }
-    refreshActiveTab();
+    loadStatus();
   }, 15000);
+}
+
+function stopStatusFallback() {
+  if (!state.statusFallbackTimer) {
+    return;
+  }
+  window.clearInterval(state.statusFallbackTimer);
+  state.statusFallbackTimer = null;
+}
+
+function openSocket(name, path, onMessage, { onOpen = null, onClose = null } = {}) {
+  closeSocket(name);
+  if (!state.authenticated || document.visibilityState === 'hidden') {
+    return;
+  }
+  const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+  const url = `${protocol}//${window.location.host}${buildApiUrl(path)}`;
+  const socket = new WebSocket(url);
+  state.sockets[name] = socket;
+
+  socket.addEventListener('open', () => {
+    if (typeof onOpen === 'function') {
+      onOpen();
+    }
+  });
+
+  socket.addEventListener('message', (event) => {
+    try {
+      const payload = JSON.parse(event.data);
+      onMessage(payload);
+    } catch (error) {
+      // ignore malformed websocket payloads
+    }
+  });
+
+  socket.addEventListener('close', () => {
+    if (state.sockets[name] !== socket) {
+      return;
+    }
+    state.sockets[name] = null;
+    if (typeof onClose === 'function') {
+      onClose();
+    }
+    if (state.authenticated && document.visibilityState !== 'hidden') {
+      window.setTimeout(() => {
+        if (state.sockets[name] === null) {
+          openSocket(name, path, onMessage, { onOpen, onClose });
+        }
+      }, 2000);
+    }
+  });
+}
+
+function startStatusStream() {
+  renderWsStatus('offline');
+  startStatusFallback();
+  loadStatus();
+  openSocket(
+    'status',
+    '/ws?stream=status',
+    (payload) => {
+      if (payload?.type !== 'status') {
+        return;
+      }
+      const data = payload.data || {};
+      updateJobMetrics(data);
+      renderJobs(data);
+    },
+    {
+      onOpen: () => {
+        renderWsStatus('online');
+        stopStatusFallback();
+      },
+      onClose: () => {
+        renderWsStatus('offline');
+        startStatusFallback();
+      },
+    }
+  );
 }
 
 function setTrackerTemplates(trackers = []) {
@@ -1302,7 +1405,7 @@ function setAuthenticated(authenticated, username = '') {
     loginForm.classList.add('hidden');
     status.hidden = false;
     usernameLabel.textContent = username || '';
-    startAutoRefresh();
+    startStatusStream();
   } else {
     dashboard.classList.add('hidden');
     loginForm.classList.remove('hidden');
@@ -1312,7 +1415,7 @@ function setAuthenticated(authenticated, username = '') {
     state.calendar.availableGenres = [];
     state.calendar.filters.genres = [];
     resetTrackerTemplates();
-    stopAutoRefresh();
+    closeSockets();
     setActiveTab('jobs', { skipLoad: true });
     resetEditors();
   }
@@ -1340,7 +1443,7 @@ function updateConnectionHint() {
 
 function handleUnauthorized() {
   const wasAuthenticated = state.authenticated;
-  stopAutoRefresh();
+  closeSockets();
   setAuthenticated(false);
   if (wasAuthenticated) {
     showNotification('Session expirée. Veuillez vous reconnecter.', 'error');
@@ -1786,11 +1889,11 @@ function renderErrorBlocks(logEntry, text) {
     if (openBlockTitles.has(block[0])) {
       details.open = true;
       hasOpenBlock = true;
-      stopAutoRefresh();
+      closeSockets();
     }
     details.addEventListener('toggle', () => {
       if (details.open) {
-        stopAutoRefresh();
+        closeSockets();
       }
       updateRefreshLabel(Boolean(logContent.querySelector('details.log-error[open]')));
     });
@@ -3412,15 +3515,12 @@ function updateWatchlistImportPanel({
   }
 }
 
-function stopWatchlistImportPolling() {
-  if (state.watchlistImport.timer) {
-    clearInterval(state.watchlistImport.timer);
-  }
-  state.watchlistImport.timer = null;
+function stopWatchlistImportStream() {
+  closeSocket('watchlist');
 }
 
 function closeWatchlistImportView() {
-  stopWatchlistImportPolling();
+  stopWatchlistImportStream();
   state.watchlistImport.jobId = null;
   updateWatchlistImportPanel({
     statusLabel: 'En cours',
@@ -3434,11 +3534,11 @@ function closeWatchlistImportView() {
   setWatchlistImportView(false);
 }
 
-function startWatchlistImportPolling(jobId) {
+function startWatchlistImportStream(jobId) {
   if (!jobId) {
     return;
   }
-  stopWatchlistImportPolling();
+  stopWatchlistImportStream();
   state.watchlistImport.jobId = jobId;
   setWatchlistImportView(true);
   updateWatchlistImportPanel({
@@ -3450,17 +3550,11 @@ function startWatchlistImportPolling(jobId) {
     error: '',
     showBack: false,
   });
-  const poll = () => pollWatchlistImport(jobId);
-  poll();
-  state.watchlistImport.timer = setInterval(poll, 2000);
-}
-
-async function pollWatchlistImport(jobId) {
-  if (!jobId || jobId !== state.watchlistImport.jobId) {
-    return;
-  }
-  try {
-    const job = await fetchJson(`/jobs/${encodeURIComponent(jobId)}`);
+  openSocket('watchlist', `/ws?stream=job&job_id=${encodeURIComponent(jobId)}`, (payload) => {
+    if (payload?.type !== 'job' || jobId !== state.watchlistImport.jobId) {
+      return;
+    }
+    const job = payload.data || {};
     const progress = job?.progress || {};
     const result = job?.result && typeof job.result === 'object' ? job.result : {};
     const added = Number.isFinite(Number(progress.added))
@@ -3505,27 +3599,29 @@ async function pollWatchlistImport(jobId) {
       showBack: done,
     });
     if (done) {
-      stopWatchlistImportPolling();
+      stopWatchlistImportStream();
       renderWatchlistImportResult({
         total_added: added,
         skipped,
         added_titles: titles,
         skipped_entries: skippedEntries,
       });
-      await loadWatchlist();
+      loadWatchlist();
     }
-  } catch (error) {
-    stopWatchlistImportPolling();
-    updateWatchlistImportPanel({
-      statusLabel: 'Erreur',
-      added: 0,
-      total: 0,
-      currentTitle: '',
-      summary: '',
-      error: error.message || 'Impossible de suivre le job.',
-      showBack: true,
-    });
-  }
+    if (status === 'not_found') {
+      stopWatchlistImportStream();
+      updateWatchlistImportPanel({
+        statusLabel: 'Erreur',
+        added: 0,
+        total: 0,
+        currentTitle: '',
+        summary: '',
+        error: 'Job introuvable.',
+        showBack: true,
+      });
+      return;
+    }
+  });
 }
 
 async function loadWatchlist() {
@@ -3572,7 +3668,7 @@ async function importWatchlistCsv() {
       throw new Error("Job d'import introuvable.");
     }
     showNotification('Import démarré.');
-    startWatchlistImportPolling(jobId);
+    startWatchlistImportStream(jobId);
   } catch (error) {
     showNotification(error.message || 'Import impossible.', 'error');
     closeWatchlistImportView();
@@ -4403,6 +4499,19 @@ function setupEventListeners() {
   setupCalendarEvents();
   setupCalendarSearchEvents();
   setupCollectionEvents();
+  document.addEventListener('visibilitychange', () => {
+    if (!state.authenticated) {
+      return;
+    }
+    if (document.visibilityState === 'hidden') {
+      closeSockets();
+      return;
+    }
+    startStatusStream();
+    if (state.watchlistImport.jobId) {
+      startWatchlistImportStream(state.watchlistImport.jobId);
+    }
+  });
 }
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -112,7 +112,7 @@
           <section class="panel" id="jobs-panel">
             <div class="panel-header">
               <div class="panel-title">
-                <h2>Jobs</h2>
+                <h2>Jobs <span id="ws-status" class="ws-status ws-status-offline" title="Connexion websocket">WS hors ligne</span></h2>
                 <div id="jobs-metrics" class="jobs-metrics" hidden></div>
               </div>
               <div class="actions">

--- a/test/daemon_websocket_test.rb
+++ b/test/daemon_websocket_test.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require_relative '../app/daemon'
+
+class DaemonWebsocketTest < Minitest::Test
+  def setup
+    reset_librarian_state!
+    @environment = build_stubbed_environment
+    MediaLibrarian.application = @environment.application
+    Daemon.configure(app: @environment.application)
+  end
+
+  def teardown
+    MediaLibrarian.application = nil
+    @environment.cleanup if @environment
+  end
+
+  def test_websocket_handshake_response_contains_expected_accept
+    key = 'dGhlIHNhbXBsZSBub25jZQ=='
+
+    response = Daemon.send(:websocket_handshake_response, key)
+
+    assert_includes response, 'HTTP/1.1 101 Switching Protocols'
+    assert_includes response, 'Upgrade: websocket'
+    assert_includes response, 'Connection: Upgrade'
+    assert_includes response, 'Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo='
+  end
+
+  def test_websocket_text_frame_for_short_payload
+    frame = Daemon.send(:websocket_text_frame, 'ok')
+
+    assert_equal 0x81, frame.getbyte(0)
+    assert_equal 2, frame.getbyte(1)
+    assert_equal 'ok', frame.byteslice(2..)
+  end
+
+  def test_websocket_text_frame_for_126_plus_payload
+    payload = 'a' * 130
+
+    frame = Daemon.send(:websocket_text_frame, payload)
+
+    assert_equal 0x81, frame.getbyte(0)
+    assert_equal 126, frame.getbyte(1)
+    assert_equal 130, (frame.getbyte(2) << 8) | frame.getbyte(3)
+    assert_equal payload, frame.byteslice(4..)
+  end
+end


### PR DESCRIPTION
### Motivation

- Replace frequent client polling with a WebSocket-based streaming channel to provide real-time status and job progress updates.
- Allow the web UI to follow long-running import jobs and general daemon status more efficiently and with less latency. 

### Description

- Add WebSocket endpoint handling to the daemon by mounting `/ws` and implementing `handle_websocket_request`, `websocket_handshake_response`, `websocket_text_frame`, `stream_status_updates`, and `stream_job_updates`, and require `digest/sha1` for handshake computation. 
- Keep existing socket/UNIX control interfaces and add safe handling/cleanup for upgraded sockets and errors in the daemon. 
- Update web client JS to manage persistent sockets via `openSocket`, `closeSocket`, `startStatusStream`, `startWatchlistImportStream` and related helpers, replacing previous polling for status and watchlist import with streaming and a fallback polling timer. 
- Add UI feedback for WebSocket connectivity by injecting a `#ws-status` badge in `index.html` and corresponding styles in `app.css` (`.ws-status`, `.ws-status-online`, `.ws-status-offline`). 
- Add `visibilitychange` handling so sockets are closed when the tab is hidden and resumed when visible, and wire the watchlist import UI to consume job updates from the job stream. 
- Add tests in `test/daemon_websocket_test.rb` that verify the handshake and frame encoding logic via `websocket_handshake_response` and `websocket_text_frame`.

### Testing

- Added `test/daemon_websocket_test.rb` covering handshake (`websocket_handshake_response`) and frame encoding (`websocket_text_frame`) for short and extended payloads. 
- Ran the test suite with `rake test` and the new websocket tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a46c85fe588327a6942731ced0bb39)