### PR TITLE
Resolve PR #776 conflicts: add websocket status indicator and fallback polling

### DIFF
--- a/app/web/app.css
+++ b/app/web/app.css
@@ -162,6 +162,26 @@ main {
   flex-wrap: wrap;
 }
 
+
+.ws-status {
+  display: inline-block;
+  margin-left: 0.5rem;
+  padding: 0.1rem 0.45rem;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  vertical-align: middle;
+}
+
+.ws-status-online {
+  background: #173f2a;
+  color: #6be2a2;
+}
+
+.ws-status-offline {
+  background: #4a1b1b;
+  color: #ff9e9e;
+}
+
 .jobs-metrics {
   display: flex;
   flex-wrap: wrap;

--- a/app/web/app.js
+++ b/app/web/app.js
@@ -6,6 +6,7 @@ const state = {
     status: null,
     watchlist: null,
   },
+  statusFallbackTimer: null,
   watchlistImport: {
     jobId: null,
   },
@@ -743,9 +744,42 @@ function closeSocket(name) {
 function closeSockets() {
   closeSocket('status');
   closeSocket('watchlist');
+  stopStatusFallback();
+  renderWsStatus('offline');
 }
 
-function openSocket(name, path, onMessage) {
+function renderWsStatus(stateLabel) {
+  const badge = document.getElementById('ws-status');
+  if (!badge) {
+    return;
+  }
+  const online = stateLabel === 'online';
+  badge.textContent = online ? 'WS en ligne' : 'WS hors ligne';
+  badge.classList.toggle('ws-status-online', online);
+  badge.classList.toggle('ws-status-offline', !online);
+}
+
+function startStatusFallback() {
+  if (state.statusFallbackTimer) {
+    return;
+  }
+  state.statusFallbackTimer = window.setInterval(() => {
+    if (!state.authenticated || document.visibilityState === 'hidden') {
+      return;
+    }
+    loadStatus();
+  }, 15000);
+}
+
+function stopStatusFallback() {
+  if (!state.statusFallbackTimer) {
+    return;
+  }
+  window.clearInterval(state.statusFallbackTimer);
+  state.statusFallbackTimer = null;
+}
+
+function openSocket(name, path, onMessage, { onOpen = null, onClose = null } = {}) {
   closeSocket(name);
   if (!state.authenticated || document.visibilityState === 'hidden') {
     return;
@@ -754,6 +788,12 @@ function openSocket(name, path, onMessage) {
   const url = `${protocol}//${window.location.host}${buildApiUrl(path)}`;
   const socket = new WebSocket(url);
   state.sockets[name] = socket;
+
+  socket.addEventListener('open', () => {
+    if (typeof onOpen === 'function') {
+      onOpen();
+    }
+  });
 
   socket.addEventListener('message', (event) => {
     try {
@@ -769,10 +809,13 @@ function openSocket(name, path, onMessage) {
       return;
     }
     state.sockets[name] = null;
+    if (typeof onClose === 'function') {
+      onClose();
+    }
     if (state.authenticated && document.visibilityState !== 'hidden') {
       window.setTimeout(() => {
         if (state.sockets[name] === null) {
-          openSocket(name, path, onMessage);
+          openSocket(name, path, onMessage, { onOpen, onClose });
         }
       }, 2000);
     }
@@ -780,14 +823,31 @@ function openSocket(name, path, onMessage) {
 }
 
 function startStatusStream() {
-  openSocket('status', '/ws?stream=status', (payload) => {
-    if (payload?.type !== 'status') {
-      return;
+  renderWsStatus('offline');
+  startStatusFallback();
+  loadStatus();
+  openSocket(
+    'status',
+    '/ws?stream=status',
+    (payload) => {
+      if (payload?.type !== 'status') {
+        return;
+      }
+      const data = payload.data || {};
+      updateJobMetrics(data);
+      renderJobs(data);
+    },
+    {
+      onOpen: () => {
+        renderWsStatus('online');
+        stopStatusFallback();
+      },
+      onClose: () => {
+        renderWsStatus('offline');
+        startStatusFallback();
+      },
     }
-    const data = payload.data || {};
-    updateJobMetrics(data);
-    renderJobs(data);
-  });
+  );
 }
 
 function setTrackerTemplates(trackers = []) {

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -112,7 +112,7 @@
           <section class="panel" id="jobs-panel">
             <div class="panel-header">
               <div class="panel-title">
-                <h2>Jobs</h2>
+                <h2>Jobs <span id="ws-status" class="ws-status ws-status-offline" title="Connexion websocket">WS hors ligne</span></h2>
                 <div id="jobs-metrics" class="jobs-metrics" hidden></div>
               </div>
               <div class="actions">


### PR DESCRIPTION
### Motivation
- Integrate the remaining changes from PR #776 that improve websocket UX by adding a connection status badge and a polling fallback when websockets are unavailable or disconnected.
- Avoid reintroducing duplicate websocket plumbing since websocket streams were already added by prior work, instead only merge the conflict-side improvements.

### Description
- Resolved merge conflict in `app/web/app.js` and merged the incremental logic: added `statusFallbackTimer` state, `renderWsStatus`, `startStatusFallback`/`stopStatusFallback`, and `onOpen`/`onClose` hooks for `openSocket` to toggle badge and fallback behavior.
- Ensure `closeSockets()` stops the fallback and updates the badge to offline to avoid stale timers or misleading UI state.
- Applied the accompanying UI changes: websocket badge styles in `app/web/app.css` and the badge element in the Jobs header in `app/web/index.html`.
- Kept existing daemon websocket implementation and merged only the missing frontend fallback/status indicator behavior to minimize duplication.

### Testing
- Verified repository status and absence of remaining conflict markers with `git status` and searches for conflict tokens, which succeeded. 
- Cherry-picked the upstream commit and resolved conflicts, producing a local commit (`Fix jobs refresh fallback and add websocket status indicator`).
- Attempted to run the websocket unit tests with `bundle exec ruby -Itest test/daemon_websocket_test.rb` but the run failed due to missing bundler git-sourced dependency (`archive-zip`) in the environment, so unit tests could not complete. 
- Attempted a browser smoke check via Playwright to capture the web UI, but it failed with `ERR_EMPTY_RESPONSE` because no running web server was available in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a47dda20448327b92e087fcbcb8a1a)