### PR TITLE
Clarify websocket status badge and improve its styling

### DIFF
--- a/app/web/app.css
+++ b/app/web/app.css
@@ -164,17 +164,33 @@ main {
 
 
 .ws-status {
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
   margin-left: 0.5rem;
-  padding: 0.1rem 0.45rem;
+  padding: 0.2rem 0.55rem;
   border-radius: 999px;
-  font-size: 0.72rem;
+  font-size: 0.78rem;
+  line-height: 1;
   vertical-align: middle;
+}
+
+.ws-status::before {
+  content: '';
+  width: 0.45rem;
+  height: 0.45rem;
+  border-radius: 999px;
+  background: currentColor;
 }
 
 .ws-status-online {
   background: #173f2a;
   color: #6be2a2;
+}
+
+.ws-status-fallback {
+  background: #3a2f0d;
+  color: #ffd76b;
 }
 
 .ws-status-offline {

--- a/app/web/app.js
+++ b/app/web/app.js
@@ -753,10 +753,11 @@ function renderWsStatus(stateLabel) {
   if (!badge) {
     return;
   }
-  const online = stateLabel === 'online';
-  badge.textContent = online ? 'WS en ligne' : 'WS hors ligne';
-  badge.classList.toggle('ws-status-online', online);
-  badge.classList.toggle('ws-status-offline', !online);
+  const mode = stateLabel === 'online' ? 'online' : stateLabel === 'fallback' ? 'fallback' : 'offline';
+  badge.textContent = mode === 'online' ? 'WS en ligne' : mode === 'fallback' ? 'Mise à jour périodique' : 'WS indisponible';
+  badge.classList.toggle('ws-status-online', mode === 'online');
+  badge.classList.toggle('ws-status-fallback', mode === 'fallback');
+  badge.classList.toggle('ws-status-offline', mode === 'offline');
 }
 
 function startStatusFallback() {
@@ -823,7 +824,7 @@ function openSocket(name, path, onMessage, { onOpen = null, onClose = null } = {
 }
 
 function startStatusStream() {
-  renderWsStatus('offline');
+  renderWsStatus('fallback');
   startStatusFallback();
   loadStatus();
   openSocket(
@@ -843,7 +844,7 @@ function startStatusStream() {
         stopStatusFallback();
       },
       onClose: () => {
-        renderWsStatus('offline');
+        renderWsStatus('fallback');
         startStatusFallback();
       },
     }

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -112,7 +112,7 @@
           <section class="panel" id="jobs-panel">
             <div class="panel-header">
               <div class="panel-title">
-                <h2>Jobs <span id="ws-status" class="ws-status ws-status-offline" title="Connexion websocket">WS hors ligne</span></h2>
+                <h2>Jobs <span id="ws-status" class="ws-status ws-status-fallback" title="Connexion websocket">Mise à jour périodique</span></h2>
                 <div id="jobs-metrics" class="jobs-metrics" hidden></div>
               </div>
               <div class="actions">


### PR DESCRIPTION
## Summary
- changed the Jobs websocket badge wording so it no longer reports a false "WS hors ligne" when the app is actively refreshing via HTTP polling
- introduced a third badge state (`fallback`) with text "Mise à jour périodique"
- kept true offline only for explicit socket shutdown paths
- improved badge appearance with a compact pill + status dot and readable sizing

## Why
On some deployments (notably behind certain reverse-proxy/TLS setups), websocket upgrades can fail while normal API requests still work. The UI previously showed "WS hors ligne", which looked like a full outage even though job data was still being updated through fallback polling.

## Validation
- `node --test test/web/*.test.js` ✅
- `ruby -Itest test/daemon_websocket_test.rb` ⚠️ fails in this environment because bundled git dependency `archive-zip` is not checked out (requires `bundle install`)

## Screenshot
- Updated mobile view badge: `browser:/tmp/codex_browser_invocations/44ca9ad12d926836/artifacts/artifacts/ws-status-fallback.png`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5c49068b08327b628da81c6ed5b95)