### PR TITLE
Fix TV episode recognition for `Sxx.Exx` naming in completed downloads

### DIFF
--- a/init/global.rb
+++ b/init/global.rb
@@ -52,7 +52,7 @@ VALID_VIDEO_EXT="(.*)\\.(#{EXTENSIONS_TYPE[:video].join('|')})$"
 SEP_CHARS='[\/ \.\(\)\-]'
 REGEX_QUALITIES=Regexp.new('(?=(' + SEP_CHARS + '(' + VALID_QUALITIES.join('|') + ')' + SEP_CHARS + '))')
 SPACE_SUBSTITUTE='\. _\-'
-BASIC_EP_MATCH='((([' + SPACE_SUBSTITUTE + ']|^)[sS]|[' + SPACE_SUBSTITUTE + '\^\[])(\d{1,3})[exEX](\d{1,4})([' + SPACE_SUBSTITUTE + '](part|cd|disc|pt)(\d))?([\&\-exEX]{1,2}(\d{1,2})([' + SPACE_SUBSTITUTE + '](part|cd|disc|pt)(\d))?)?([\&\-exEX]{1,2}(\d{1,2})([' + SPACE_SUBSTITUTE + '](part|cd|disc|pt)(\d))?)?|([\. \-]|^)[sS](\d{1,3}))'
+BASIC_EP_MATCH='((([' + SPACE_SUBSTITUTE + ']|^)[sS]|[' + SPACE_SUBSTITUTE + '\^\[])(\d{1,3})[' + SPACE_SUBSTITUTE + ']?[exEX](\d{1,4})([' + SPACE_SUBSTITUTE + '](part|cd|disc|pt)(\d))?([\&\-exEX]{1,2}(\d{1,2})([' + SPACE_SUBSTITUTE + '](part|cd|disc|pt)(\d))?)?([\&\-exEX]{1,2}(\d{1,2})([' + SPACE_SUBSTITUTE + '](part|cd|disc|pt)(\d))?)?|([\. \-]|^)[sS](\d{1,3}))'
 REGEX_TV_EP_NB=/#{BASIC_EP_MATCH}([#{SPACE_SUBSTITUTE}]|$)|(^|\/|[#{SPACE_SUBSTITUTE}\[])(\d{3,4})[#{SPACE_SUBSTITUTE}\]-]#{VALID_VIDEO_EXT}/
 FOLDER_HIERARCHY = {
     'shows' => 3,

--- a/test/app/tv_series_test.rb
+++ b/test/app/tv_series_test.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+class TvSeriesTest < Minitest::Test
+  def test_identify_tv_episodes_numbering_accepts_dot_between_season_and_episode
+    numbers, ids = TvSeries.identify_tv_episodes_numbering('Animal Kingdom S04.E01 Janine - MTL666.mkv')
+
+    assert_equal([{ s: 4, ep: 1, part: 0 }], numbers[4])
+    assert_includes ids, 'S04E01'
+  end
+end


### PR DESCRIPTION
## Summary
- Allow TV episode regex parsing to recognize filenames that include a separator between season and episode markers (e.g. `S04.E01`), not only contiguous `S04E01`.
- Add a focused unit test covering `TvSeries.identify_tv_episodes_numbering` with `S04.E01` input.

## Root cause
Completed TV files named like `Animal Kingdom S04.E01 ...` were treated as not identified because the global `BASIC_EP_MATCH` required `SxxEyy` with no separator between `Sxx` and `Eyy`.

## Changes
- `init/global.rb`
  - Updated `BASIC_EP_MATCH` from `... (\d{1,3})[exEX](\d{1,4}) ...` to `... (\d{1,3})[#{SPACE_SUBSTITUTE}]?[exEX](\d{1,4}) ...`.
  - This keeps existing behavior while adding support for dot/space/underscore/hyphen separators (already defined by `SPACE_SUBSTITUTE`).
- `test/app/tv_series_test.rb`
  - Added test asserting that `Animal Kingdom S04.E01 ...` resolves to season 4 episode 1 and includes `S04E01` in ids.

## Validation
- `ruby -c init/global.rb` ✅
- `ruby -c test/app/tv_series_test.rb` ✅
- `ruby -Itest test/app/tv_series_test.rb` ⚠️ failed due to missing git-sourced bundle dependency (`archive-zip` not checked out in this environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5df039c68832786d626dbc5b9c714)