### PR TITLE
Make jobs fallback refresh reliable when websocket is unavailable

### DIFF
--- a/app/web/app.css
+++ b/app/web/app.css
@@ -164,17 +164,33 @@ main {
 
 
 .ws-status {
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
   margin-left: 0.5rem;
-  padding: 0.1rem 0.45rem;
+  padding: 0.2rem 0.55rem;
   border-radius: 999px;
-  font-size: 0.72rem;
+  font-size: 0.78rem;
+  line-height: 1;
   vertical-align: middle;
+}
+
+.ws-status::before {
+  content: '';
+  width: 0.45rem;
+  height: 0.45rem;
+  border-radius: 999px;
+  background: currentColor;
 }
 
 .ws-status-online {
   background: #173f2a;
   color: #6be2a2;
+}
+
+.ws-status-fallback {
+  background: #3a2f0d;
+  color: #ffd76b;
 }
 
 .ws-status-offline {

--- a/app/web/app.js
+++ b/app/web/app.js
@@ -745,7 +745,7 @@ function closeSockets() {
   closeSocket('status');
   closeSocket('watchlist');
   stopStatusFallback();
-  renderWsStatus('offline');
+  renderWsStatus(state.authenticated ? 'fallback' : 'offline');
 }
 
 function renderWsStatus(stateLabel) {
@@ -753,10 +753,11 @@ function renderWsStatus(stateLabel) {
   if (!badge) {
     return;
   }
-  const online = stateLabel === 'online';
-  badge.textContent = online ? 'WS en ligne' : 'WS hors ligne';
-  badge.classList.toggle('ws-status-online', online);
-  badge.classList.toggle('ws-status-offline', !online);
+  const mode = stateLabel === 'online' ? 'online' : stateLabel === 'fallback' ? 'fallback' : 'offline';
+  badge.textContent = mode === 'online' ? 'WS en ligne' : mode === 'fallback' ? 'Mise à jour périodique' : 'WS indisponible';
+  badge.classList.toggle('ws-status-online', mode === 'online');
+  badge.classList.toggle('ws-status-fallback', mode === 'fallback');
+  badge.classList.toggle('ws-status-offline', mode === 'offline');
 }
 
 function startStatusFallback() {
@@ -768,7 +769,7 @@ function startStatusFallback() {
       return;
     }
     loadStatus();
-  }, 15000);
+  }, 5000);
 }
 
 function stopStatusFallback() {
@@ -823,7 +824,7 @@ function openSocket(name, path, onMessage, { onOpen = null, onClose = null } = {
 }
 
 function startStatusStream() {
-  renderWsStatus('offline');
+  renderWsStatus('fallback');
   startStatusFallback();
   loadStatus();
   openSocket(
@@ -843,7 +844,7 @@ function startStatusStream() {
         stopStatusFallback();
       },
       onClose: () => {
-        renderWsStatus('offline');
+        renderWsStatus('fallback');
         startStatusFallback();
       },
     }
@@ -3144,7 +3145,7 @@ async function loadCollection(options = {}) {
 
 async function loadStatus() {
   try {
-    const data = await fetchJson('/status');
+    const data = await fetchJson(`/status?_=${Date.now()}`);
     updateJobMetrics(data);
     renderJobs(data);
   } catch (error) {

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -112,7 +112,7 @@
           <section class="panel" id="jobs-panel">
             <div class="panel-header">
               <div class="panel-title">
-                <h2>Jobs <span id="ws-status" class="ws-status ws-status-offline" title="Connexion websocket">WS hors ligne</span></h2>
+                <h2>Jobs <span id="ws-status" class="ws-status ws-status-fallback" title="Connexion websocket">Mise à jour périodique</span></h2>
                 <div id="jobs-metrics" class="jobs-metrics" hidden></div>
               </div>
               <div class="actions">


### PR DESCRIPTION
## Summary
- keeps the Jobs status badge in fallback mode (`Mise à jour périodique`) while authenticated, instead of reverting to offline red state during socket close cycles
- speeds up HTTP fallback polling from 15s to 5s so updates remain visible when WS is blocked
- adds a cache-busting query param to `/status` polling to avoid stale proxy/browser-cached responses

## Root cause addressed
Your screenshot shows the UI still in `WS hors ligne` with stale metrics. Even without WS, the app should refresh via HTTP polling. Two things could still make it look stuck:
1. transient socket closes forced the badge into offline styling
2. status polling could be cached by an intermediary, making refreshes appear inactive

This patch fixes both without adding new subsystems.

## Validation
- `node --test test/web/*.test.js` ✅

## Screenshot
- Updated badge rendering baseline: `browser:/tmp/codex_browser_invocations/6b92671bd462f832/artifacts/artifacts/ws-status-refresh-fix.png`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5c49068b08327b628da81c6ed5b95)