### PR TITLE
Fix websocket upgrade stream when request socket is unavailable

### DIFF
--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -1514,12 +1514,12 @@ class Daemon
         return error_response(res, status: 400, message: 'invalid_websocket_upgrade')
       end
 
-      socket = req.instance_variable_get(:@socket)
+      socket = websocket_socket(req, res)
       return error_response(res, status: 500, message: 'websocket_unavailable') unless socket
 
       stream = req.query['stream'].to_s
       job_id = req.query['job_id'].to_s
-      socket << websocket_handshake_response(key)
+      socket.write(websocket_handshake_response(key))
 
       case stream
       when 'job'
@@ -1547,6 +1547,14 @@ class Daemon
         '',
         ''
       ].join("\r\n")
+    end
+
+    def websocket_socket(req, res)
+      [req, res].each do |object|
+        socket = object.instance_variable_get(:@socket)
+        return socket if socket.respond_to?(:write)
+      end
+      nil
     end
 
     def stream_status_updates(socket)

--- a/test/daemon_websocket_test.rb
+++ b/test/daemon_websocket_test.rb
@@ -35,6 +35,30 @@ class DaemonWebsocketTest < Minitest::Test
     assert_equal 'ok', frame.byteslice(2..)
   end
 
+  def test_websocket_socket_prefers_request_socket
+    req_socket = StringIO.new
+    res_socket = StringIO.new
+    request = Struct.new(:query).new({})
+    response = Object.new
+    request.instance_variable_set(:@socket, req_socket)
+    response.instance_variable_set(:@socket, res_socket)
+
+    socket = Daemon.send(:websocket_socket, request, response)
+
+    assert_same req_socket, socket
+  end
+
+  def test_websocket_socket_falls_back_to_response_socket
+    res_socket = StringIO.new
+    request = Struct.new(:query).new({})
+    response = Object.new
+    response.instance_variable_set(:@socket, res_socket)
+
+    socket = Daemon.send(:websocket_socket, request, response)
+
+    assert_same res_socket, socket
+  end
+
   def test_websocket_text_frame_for_126_plus_payload
     payload = 'a' * 130
 


### PR DESCRIPTION
## Summary
- fixed websocket handshake socket selection in `Daemon#handle_websocket_request`
- added a small `websocket_socket(req, res)` helper that safely checks both WEBrick request and response internals
- switched handshake write to `socket.write` for consistency with frame writes
- added websocket unit tests covering request-socket preference and response-socket fallback

## Why
Some WEBrick/runtime combinations expose the connection socket on `res` rather than `req` during upgraded requests. In that case, websocket setup returned `websocket_unavailable`, forcing the UI to remain on periodic polling.

## Validation
- `bundle exec ruby -Itest test/daemon_websocket_test.rb`
- `bundle exec ruby -Itest test/daemon_authentication_requirements_test.rb`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6ed93225c83279cde075774b21444)