### PR TITLE
Add visible websocket fallback reasons

### DIFF
--- a/app/web/app.js
+++ b/app/web/app.js
@@ -6,6 +6,10 @@ const state = {
     status: null,
     watchlist: null,
   },
+  socketMeta: {
+    status: { lastError: '', wasOnline: false },
+    watchlist: { lastError: '', wasOnline: false },
+  },
   statusFallbackTimer: null,
   watchlistImport: {
     jobId: null,
@@ -754,7 +758,15 @@ function renderWsStatus(stateLabel) {
     return;
   }
   const mode = stateLabel === 'online' ? 'online' : stateLabel === 'fallback' ? 'fallback' : 'offline';
-  badge.textContent = mode === 'online' ? 'WS en ligne' : mode === 'fallback' ? 'Mise à jour périodique' : 'WS indisponible';
+  const detail = state.socketMeta.status.lastError;
+  badge.textContent = typeof window.formatWsStatusLabel === 'function'
+    ? window.formatWsStatusLabel(mode, detail)
+    : mode === 'online'
+    ? 'WS en ligne'
+    : mode === 'fallback'
+    ? 'Mise à jour périodique'
+    : 'WS indisponible';
+  badge.title = detail || 'Connexion websocket';
   badge.classList.toggle('ws-status-online', mode === 'online');
   badge.classList.toggle('ws-status-fallback', mode === 'fallback');
   badge.classList.toggle('ws-status-offline', mode === 'offline');
@@ -788,9 +800,15 @@ function openSocket(name, path, onMessage, { onOpen = null, onClose = null } = {
   const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
   const url = `${protocol}//${window.location.host}${buildApiUrl(path)}`;
   const socket = new WebSocket(url);
+  const meta = state.socketMeta[name] || { lastError: '', wasOnline: false };
+  state.socketMeta[name] = meta;
+  meta.lastError = '';
+  meta.wasOnline = false;
   state.sockets[name] = socket;
 
   socket.addEventListener('open', () => {
+    meta.wasOnline = true;
+    meta.lastError = '';
     if (typeof onOpen === 'function') {
       onOpen();
     }
@@ -799,19 +817,52 @@ function openSocket(name, path, onMessage, { onOpen = null, onClose = null } = {
   socket.addEventListener('message', (event) => {
     try {
       const payload = JSON.parse(event.data);
+      if (payload?.type === 'error') {
+        meta.lastError = payload.error || payload.message || meta.lastError;
+        if (name === 'status') {
+          renderWsStatus('fallback');
+        }
+      }
       onMessage(payload);
     } catch (error) {
       // ignore malformed websocket payloads
     }
   });
 
-  socket.addEventListener('close', () => {
+  socket.addEventListener('error', (event) => {
+    const reason = typeof window.normalizeWsError === 'function'
+      ? window.normalizeWsError(event?.message || meta.lastError, {
+          isSecure: window.location.protocol === 'https:',
+          online: navigator.onLine !== false,
+        })
+      : 'WS indisponible';
+    meta.lastError = reason;
+    if (name === 'status') {
+      renderWsStatus('fallback');
+    }
+  });
+
+  socket.addEventListener('close', (event) => {
     if (state.sockets[name] !== socket) {
       return;
     }
     state.sockets[name] = null;
+    meta.lastError = typeof window.getWsCloseDetail === 'function'
+      ? window.getWsCloseDetail({
+          code: event.code,
+          wasOnline: meta.wasOnline,
+          lastError: meta.lastError,
+          isSecure: window.location.protocol === 'https:',
+          online: navigator.onLine !== false,
+        })
+      : meta.lastError;
     if (typeof onClose === 'function') {
-      onClose();
+      onClose({
+        code: event.code,
+        reason: meta.lastError,
+        phase: meta.wasOnline ? 'reconnect' : 'initial',
+        wasOnline: meta.wasOnline,
+      });
     }
     if (state.authenticated && document.visibilityState !== 'hidden') {
       window.setTimeout(() => {
@@ -843,7 +894,8 @@ function startStatusStream() {
         renderWsStatus('online');
         stopStatusFallback();
       },
-      onClose: () => {
+      onClose: ({ reason }) => {
+        state.socketMeta.status.lastError = reason || '';
         renderWsStatus('fallback');
         startStatusFallback();
       },

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -614,6 +614,7 @@
     <script src="path_utils.js" defer></script>
     <script src="calendar_window.js" defer></script>
     <script src="tracker_links.js" defer></script>
+    <script src="ws_status.js" defer></script>
     <script src="app.js?v=__APP_VERSION__" defer></script>
   </body>
 </html>

--- a/app/web/ws_status.js
+++ b/app/web/ws_status.js
@@ -1,0 +1,47 @@
+function normalizeWsError(raw = '', { isSecure = false, online = true } = {}) {
+  const message = String(raw || '').toLowerCase();
+  if (message.includes('tls') || message.includes('ssl') || message.includes('cert')) {
+    return 'WS bloqué par TLS/certificat';
+  }
+  if (
+    message.includes('refus')
+    || message.includes('refused')
+    || message.includes('forbidden')
+    || message.includes('403')
+  ) {
+    return 'WS refusé';
+  }
+  if (!online || isSecure) {
+    return 'WS bloqué par TLS/certificat';
+  }
+  return 'WS indisponible';
+}
+
+function getWsCloseDetail({
+  code = 1000,
+  wasOnline = false,
+  lastError = '',
+  isSecure = false,
+  online = true,
+} = {}) {
+  if (code === 1000 && wasOnline && !lastError) {
+    return '';
+  }
+  const reason = normalizeWsError(lastError, { isSecure, online });
+  return reason || (wasOnline ? 'WS indisponible' : 'WS refusé');
+}
+
+function formatWsStatusLabel(mode, detail = '') {
+  const label = mode === 'online' ? 'WS en ligne' : mode === 'fallback' ? 'Mise à jour périodique' : 'WS indisponible';
+  return detail && mode !== 'online' ? `${label} · ${detail}` : label;
+}
+
+if (typeof window !== 'undefined') {
+  window.normalizeWsError = normalizeWsError;
+  window.getWsCloseDetail = getWsCloseDetail;
+  window.formatWsStatusLabel = formatWsStatusLabel;
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { normalizeWsError, getWsCloseDetail, formatWsStatusLabel };
+}

--- a/test/web/ws_status.test.js
+++ b/test/web/ws_status.test.js
@@ -1,0 +1,21 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { formatWsStatusLabel, getWsCloseDetail, normalizeWsError } = require('../../app/web/ws_status.js');
+
+test('maps websocket errors to short visible messages', () => {
+  assert.equal(normalizeWsError('net::ERR_CERT_AUTHORITY_INVALID', { isSecure: true }), 'WS bloqué par TLS/certificat');
+  assert.equal(normalizeWsError('Error during WebSocket handshake: 403', { isSecure: false }), 'WS refusé');
+  assert.equal(normalizeWsError('', { isSecure: false, online: true }), 'WS indisponible');
+});
+
+test('keeps fallback reason empty for normal closes but visible for failures', () => {
+  assert.equal(getWsCloseDetail({ code: 1000, wasOnline: true, lastError: '' }), '');
+  assert.equal(getWsCloseDetail({ code: 1006, wasOnline: false, lastError: 'Error during WebSocket handshake: 403' }), 'WS refusé');
+  assert.equal(getWsCloseDetail({ code: 1006, wasOnline: true, lastError: '' }), 'WS indisponible');
+});
+
+test('formats fallback badge with visible websocket reason', () => {
+  assert.equal(formatWsStatusLabel('fallback', 'WS refusé'), 'Mise à jour périodique · WS refusé');
+  assert.equal(formatWsStatusLabel('online', 'WS refusé'), 'WS en ligne');
+});


### PR DESCRIPTION
### Motivation

- The UI had a `#ws-status` badge and a polling fallback but did not show concise reasons when WS connections failed or were refused.  
- Make failures visible and distinguish normal closures, initial connection refusals, and reconnection events without adding heavy code.

### Description

- Add a small helper `app/web/ws_status.js` with `normalizeWsError`, `getWsCloseDetail` and `formatWsStatusLabel` to classify short messages like `WS refusé`, `WS indisponible`, and `WS bloqué par TLS/certificat`.  
- Track lightweight per-socket state in `state.socketMeta` and enrich `openSocket` to listen to `error`, capture server-sent JSON `error` payloads, record `wasOnline` and `lastError`, and call `onClose` with `{ code, reason, phase, wasOnline }`.  
- Surface the short reason in the jobs badge via `renderWsStatus` (uses `formatWsStatusLabel`) and keep the existing polling fallback behavior intact.  
- Load the helper before `app.js` by adding `ws_status.js` to `app/web/index.html` and add a focused test `test/web/ws_status.test.js` covering error mapping and badge formatting. 

### Testing

- Ran syntax checks with `node --check app/web/app.js && node --check app/web/ws_status.js` which succeeded.  
- Ran the test suite with `node --test test/web/*.test.js` and all tests passed (12 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c03d0c38cc8327ac9c231a8a005b00)