### PR TITLE
Refine websocket fallback error labels

### DIFF
--- a/app/web/ws_status.js
+++ b/app/web/ws_status.js
@@ -1,6 +1,12 @@
 function normalizeWsError(raw = '', { isSecure = false, online = true } = {}) {
   const message = String(raw || '').toLowerCase();
-  if (message.includes('tls') || message.includes('ssl') || message.includes('cert')) {
+  if (
+    message.includes('tls')
+    || message.includes('ssl')
+    || message.includes('cert')
+    || message.includes('certificate')
+    || message.includes('authority invalid')
+  ) {
     return 'WS bloqué par TLS/certificat';
   }
   if (
@@ -11,10 +17,10 @@ function normalizeWsError(raw = '', { isSecure = false, online = true } = {}) {
   ) {
     return 'WS refusé';
   }
-  if (!online || isSecure) {
-    return 'WS bloqué par TLS/certificat';
+  if (!online) {
+    return 'WS indisponible';
   }
-  return 'WS indisponible';
+  return isSecure ? 'WS indisponible en HTTPS' : 'WS indisponible';
 }
 
 function getWsCloseDetail({
@@ -28,7 +34,7 @@ function getWsCloseDetail({
     return '';
   }
   const reason = normalizeWsError(lastError, { isSecure, online });
-  return reason || (wasOnline ? 'WS indisponible' : 'WS refusé');
+  return reason || (wasOnline ? (isSecure ? 'WS indisponible en HTTPS' : 'WS indisponible') : 'WS refusé');
 }
 
 function formatWsStatusLabel(mode, detail = '') {

--- a/test/web/ws_status.test.js
+++ b/test/web/ws_status.test.js
@@ -5,13 +5,15 @@ const { formatWsStatusLabel, getWsCloseDetail, normalizeWsError } = require('../
 
 test('maps websocket errors to short visible messages', () => {
   assert.equal(normalizeWsError('net::ERR_CERT_AUTHORITY_INVALID', { isSecure: true }), 'WS bloqué par TLS/certificat');
-  assert.equal(normalizeWsError('Error during WebSocket handshake: 403', { isSecure: false }), 'WS refusé');
+  assert.equal(normalizeWsError('Error during WebSocket handshake: 403', { isSecure: true }), 'WS refusé');
   assert.equal(normalizeWsError('', { isSecure: false, online: true }), 'WS indisponible');
+  assert.equal(normalizeWsError('', { isSecure: true, online: true }), 'WS indisponible en HTTPS');
 });
 
 test('keeps fallback reason empty for normal closes but visible for failures', () => {
   assert.equal(getWsCloseDetail({ code: 1000, wasOnline: true, lastError: '' }), '');
   assert.equal(getWsCloseDetail({ code: 1006, wasOnline: false, lastError: 'Error during WebSocket handshake: 403' }), 'WS refusé');
+  assert.equal(getWsCloseDetail({ code: 1006, wasOnline: true, lastError: '', isSecure: true }), 'WS indisponible en HTTPS');
   assert.equal(getWsCloseDetail({ code: 1006, wasOnline: true, lastError: '' }), 'WS indisponible');
 });
 


### PR DESCRIPTION
### Motivation
- Éviter d’attribuer systématiquement une panne aux problèmes TLS/certificat lorsque le message brut ne contient pas d’indice explicite.
- Fournir un libellé générique plus approprié pour les pages HTTPS quand aucun message exploitable n’est disponible.
- Conserver ce comportement pour les closes `1006` sans détail afin d’afficher une raison générique au lieu d’un faux positif TLS.

### Description
- Modifié `app/web/ws_status.js` : `normalizeWsError()` n’implique plus TLS par défaut ; il ne retourne `WS bloqué par TLS/certificat` que si le message contient des indices explicites (`tls`, `ssl`, `cert`, `certificate`, `authority invalid`).
- Modifié `app/web/ws_status.js` : en l’absence de message exploitable, `normalizeWsError()` retourne `WS indisponible` ou `WS indisponible en HTTPS` selon `isSecure`.
- Modifié `app/web/ws_status.js` : `getWsCloseDetail()` réutilise cette logique pour les closes (y compris `1006`) et renvoie la variante HTTPS si `isSecure` est vrai.
- Mis à jour `test/web/ws_status.test.js` pour couvrir au minimum : erreur explicite de certificat => `WS bloqué par TLS/certificat`, handshake 403 => `WS refusé`, et close/error sans message en HTTPS => `WS indisponible en HTTPS`.

### Testing
- Exécuté `node --test test/web/ws_status.test.js` et tous les tests sont passés avec succès.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c05b2377c08327bfabe4ba997a1cc6)