### PR TITLE
Keep websocket fallback badge generic by default

### DIFF
--- a/app/web/app.js
+++ b/app/web/app.js
@@ -749,16 +749,27 @@ function closeSockets() {
   closeSocket('status');
   closeSocket('watchlist');
   stopStatusFallback();
-  renderWsStatus(state.authenticated ? 'fallback' : 'offline', '');
+  if (state.authenticated) {
+    renderStatusFallbackWithoutDetail();
+    return;
+  }
+  renderWsStatus('offline');
 }
 
-function renderWsStatus(stateLabel, detailOverride = null) {
+function renderStatusFallbackWithoutDetail() {
+  const { lastError } = state.socketMeta.status;
+  state.socketMeta.status.lastError = '';
+  renderWsStatus('fallback');
+  state.socketMeta.status.lastError = lastError;
+}
+
+function renderWsStatus(stateLabel) {
   const badge = document.getElementById('ws-status');
   if (!badge) {
     return;
   }
   const mode = stateLabel === 'online' ? 'online' : stateLabel === 'fallback' ? 'fallback' : 'offline';
-  const detail = stateLabel === 'fallback' ? (detailOverride ?? state.socketMeta.status.lastError) : '';
+  const detail = stateLabel === 'fallback' ? state.socketMeta.status.lastError : '';
   badge.textContent = typeof window.formatWsStatusLabel === 'function'
     ? window.formatWsStatusLabel(mode, detail)
     : mode === 'online'
@@ -870,7 +881,7 @@ function openSocket(name, path, onMessage, { onOpen = null, onClose = null } = {
 }
 
 function startStatusStream() {
-  renderWsStatus('fallback', '');
+  renderStatusFallbackWithoutDetail();
   startStatusFallback();
   loadStatus();
   openSocket(

--- a/app/web/app.js
+++ b/app/web/app.js
@@ -749,6 +749,9 @@ function closeSockets() {
   closeSocket('status');
   closeSocket('watchlist');
   stopStatusFallback();
+  if (state.authenticated) {
+    state.socketMeta.status.lastError = '';
+  }
   renderWsStatus(state.authenticated ? 'fallback' : 'offline');
 }
 
@@ -758,7 +761,7 @@ function renderWsStatus(stateLabel) {
     return;
   }
   const mode = stateLabel === 'online' ? 'online' : stateLabel === 'fallback' ? 'fallback' : 'offline';
-  const detail = state.socketMeta.status.lastError;
+  const detail = stateLabel === 'fallback' ? state.socketMeta.status.lastError : '';
   badge.textContent = typeof window.formatWsStatusLabel === 'function'
     ? window.formatWsStatusLabel(mode, detail)
     : mode === 'online'
@@ -831,12 +834,9 @@ function openSocket(name, path, onMessage, { onOpen = null, onClose = null } = {
 
   socket.addEventListener('error', (event) => {
     const reason = typeof window.normalizeWsError === 'function'
-      ? window.normalizeWsError(event?.message || meta.lastError, {
-          isSecure: window.location.protocol === 'https:',
-          online: navigator.onLine !== false,
-        })
-      : 'WS indisponible';
-    meta.lastError = reason;
+      ? window.normalizeWsError(event?.message || meta.lastError)
+      : '';
+    meta.lastError = reason || meta.lastError;
     if (name === 'status') {
       renderWsStatus('fallback');
     }
@@ -852,8 +852,6 @@ function openSocket(name, path, onMessage, { onOpen = null, onClose = null } = {
           code: event.code,
           wasOnline: meta.wasOnline,
           lastError: meta.lastError,
-          isSecure: window.location.protocol === 'https:',
-          online: navigator.onLine !== false,
         })
       : meta.lastError;
     if (typeof onClose === 'function') {
@@ -875,6 +873,7 @@ function openSocket(name, path, onMessage, { onOpen = null, onClose = null } = {
 }
 
 function startStatusStream() {
+  state.socketMeta.status.lastError = '';
   renderWsStatus('fallback');
   startStatusFallback();
   loadStatus();

--- a/app/web/app.js
+++ b/app/web/app.js
@@ -749,19 +749,16 @@ function closeSockets() {
   closeSocket('status');
   closeSocket('watchlist');
   stopStatusFallback();
-  if (state.authenticated) {
-    state.socketMeta.status.lastError = '';
-  }
-  renderWsStatus(state.authenticated ? 'fallback' : 'offline');
+  renderWsStatus(state.authenticated ? 'fallback' : 'offline', '');
 }
 
-function renderWsStatus(stateLabel) {
+function renderWsStatus(stateLabel, detailOverride = null) {
   const badge = document.getElementById('ws-status');
   if (!badge) {
     return;
   }
   const mode = stateLabel === 'online' ? 'online' : stateLabel === 'fallback' ? 'fallback' : 'offline';
-  const detail = stateLabel === 'fallback' ? state.socketMeta.status.lastError : '';
+  const detail = stateLabel === 'fallback' ? (detailOverride ?? state.socketMeta.status.lastError) : '';
   badge.textContent = typeof window.formatWsStatusLabel === 'function'
     ? window.formatWsStatusLabel(mode, detail)
     : mode === 'online'
@@ -873,8 +870,7 @@ function openSocket(name, path, onMessage, { onOpen = null, onClose = null } = {
 }
 
 function startStatusStream() {
-  state.socketMeta.status.lastError = '';
-  renderWsStatus('fallback');
+  renderWsStatus('fallback', '');
   startStatusFallback();
   loadStatus();
   openSocket(

--- a/app/web/ws_status.js
+++ b/app/web/ws_status.js
@@ -1,5 +1,8 @@
-function normalizeWsError(raw = '', { isSecure = false, online = true } = {}) {
+function normalizeWsError(raw = '') {
   const message = String(raw || '').toLowerCase();
+  if (!message) {
+    return '';
+  }
   if (message.includes('tls') || message.includes('ssl') || message.includes('cert')) {
     return 'WS bloqué par TLS/certificat';
   }
@@ -11,24 +14,18 @@ function normalizeWsError(raw = '', { isSecure = false, online = true } = {}) {
   ) {
     return 'WS refusé';
   }
-  if (!online || isSecure) {
-    return 'WS bloqué par TLS/certificat';
-  }
-  return 'WS indisponible';
+  return '';
 }
 
 function getWsCloseDetail({
   code = 1000,
   wasOnline = false,
   lastError = '',
-  isSecure = false,
-  online = true,
 } = {}) {
   if (code === 1000 && wasOnline && !lastError) {
     return '';
   }
-  const reason = normalizeWsError(lastError, { isSecure, online });
-  return reason || (wasOnline ? 'WS indisponible' : 'WS refusé');
+  return normalizeWsError(lastError) || '';
 }
 
 function formatWsStatusLabel(mode, detail = '') {

--- a/test/web/ws_status.test.js
+++ b/test/web/ws_status.test.js
@@ -3,16 +3,17 @@ const assert = require('node:assert/strict');
 
 const { formatWsStatusLabel, getWsCloseDetail, normalizeWsError } = require('../../app/web/ws_status.js');
 
-test('maps websocket errors to short visible messages', () => {
-  assert.equal(normalizeWsError('net::ERR_CERT_AUTHORITY_INVALID', { isSecure: true }), 'WS bloqué par TLS/certificat');
-  assert.equal(normalizeWsError('Error during WebSocket handshake: 403', { isSecure: false }), 'WS refusé');
-  assert.equal(normalizeWsError('', { isSecure: false, online: true }), 'WS indisponible');
+test('maps only qualified websocket errors to visible messages', () => {
+  assert.equal(normalizeWsError('net::ERR_CERT_AUTHORITY_INVALID'), 'WS bloqué par TLS/certificat');
+  assert.equal(normalizeWsError('Error during WebSocket handshake: 403'), 'WS refusé');
+  assert.equal(normalizeWsError(''), '');
+  assert.equal(normalizeWsError('WebSocket connection failed'), '');
 });
 
-test('keeps fallback reason empty for normal closes but visible for failures', () => {
+test('keeps fallback reason empty for normal or unqualified closes', () => {
   assert.equal(getWsCloseDetail({ code: 1000, wasOnline: true, lastError: '' }), '');
   assert.equal(getWsCloseDetail({ code: 1006, wasOnline: false, lastError: 'Error during WebSocket handshake: 403' }), 'WS refusé');
-  assert.equal(getWsCloseDetail({ code: 1006, wasOnline: true, lastError: '' }), 'WS indisponible');
+  assert.equal(getWsCloseDetail({ code: 1006, wasOnline: true, lastError: '' }), '');
 });
 
 test('formats fallback badge with visible websocket reason', () => {


### PR DESCRIPTION
### Motivation
- Make the websocket status badge show the generic label `Mise à jour périodique` by default when no explicit cause is known, avoiding misleading diagnostics carried from previous failures. 
- Only preserve `state.socketMeta.status.lastError` for truly qualified error signals (WS payload `type: "error"`, explicit refusal/403 text, TLS/cert messages). 
- Ensure browser `error`/`close` events without useful details do not fabricate a TLS/refusal reason and do not overwrite a healthy state.

### Description
- Updated `renderWsStatus` so the badge detail is shown only when `stateLabel === 'fallback'`, keeping other modes detail-free; file changed: `app/web/app.js` and the badge title logic adjusted. 
- Clear stale fallback reasons before generic fallback rendering in `closeSockets()` and at the start of `startStatusStream()` by resetting `state.socketMeta.status.lastError` when appropriate; changes in `app/web/app.js`. 
- Restrict error normalization to explicit messages by simplifying `normalizeWsError()` and `getWsCloseDetail()` to only return non-empty reasons for explicit TLS/cert or refusal/403 textual matches; file changed: `app/web/ws_status.js`. 
- Adjusted `openSocket()` handling so browser `error` events only set `lastError` when `normalizeWsError()` yields a qualified reason, and `close` dispatch to `getWsCloseDetail()` no longer tries to infer causes from the environment; file changed: `app/web/app.js`. 
- Updated tests in `test/web/ws_status.test.js` to assert that only qualified errors produce visible messages and that unqualified closes keep the fallback reason empty.

### Testing
- Ran `node --test test/web/*.test.js`, which exercised the `normalizeWsError`, `getWsCloseDetail` and label formatting behavior. 
- All targeted tests passed (`12` tests, `0` failures). 
- No other automated test suites were modified or executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c05b2bc28083279ce32494ce8d106b)