### PR TITLE
Keep websocket fallback badge generic by default

### DIFF
--- a/app/web/ws_status.js
+++ b/app/web/ws_status.js
@@ -1,4 +1,4 @@
-function normalizeWsError(raw = '', { isSecure = false, online = true } = {}) {
+function normalizeWsError(raw = '') {
   const message = String(raw || '').toLowerCase();
   if (
     message.includes('tls')
@@ -17,24 +17,18 @@ function normalizeWsError(raw = '', { isSecure = false, online = true } = {}) {
   ) {
     return 'WS refusé';
   }
-  if (!online) {
-    return 'WS indisponible';
-  }
-  return isSecure ? 'WS indisponible en HTTPS' : 'WS indisponible';
+  return '';
 }
 
 function getWsCloseDetail({
   code = 1000,
   wasOnline = false,
   lastError = '',
-  isSecure = false,
-  online = true,
 } = {}) {
   if (code === 1000 && wasOnline && !lastError) {
     return '';
   }
-  const reason = normalizeWsError(lastError, { isSecure, online });
-  return reason || (wasOnline ? (isSecure ? 'WS indisponible en HTTPS' : 'WS indisponible') : 'WS refusé');
+  return normalizeWsError(lastError);
 }
 
 function formatWsStatusLabel(mode, detail = '') {

--- a/test/web/ws_status.test.js
+++ b/test/web/ws_status.test.js
@@ -3,18 +3,17 @@ const assert = require('node:assert/strict');
 
 const { formatWsStatusLabel, getWsCloseDetail, normalizeWsError } = require('../../app/web/ws_status.js');
 
-test('maps websocket errors to short visible messages', () => {
-  assert.equal(normalizeWsError('net::ERR_CERT_AUTHORITY_INVALID', { isSecure: true }), 'WS bloqué par TLS/certificat');
-  assert.equal(normalizeWsError('Error during WebSocket handshake: 403', { isSecure: true }), 'WS refusé');
-  assert.equal(normalizeWsError('', { isSecure: false, online: true }), 'WS indisponible');
-  assert.equal(normalizeWsError('', { isSecure: true, online: true }), 'WS indisponible en HTTPS');
+test('maps only qualified websocket errors to short visible messages', () => {
+  assert.equal(normalizeWsError('net::ERR_CERT_AUTHORITY_INVALID'), 'WS bloqué par TLS/certificat');
+  assert.equal(normalizeWsError('Error during WebSocket handshake: 403'), 'WS refusé');
+  assert.equal(normalizeWsError(''), '');
+  assert.equal(normalizeWsError('WebSocket closed unexpectedly'), '');
 });
 
-test('keeps fallback reason empty for normal closes but visible for failures', () => {
+test('keeps fallback reason empty unless a qualified failure was observed', () => {
   assert.equal(getWsCloseDetail({ code: 1000, wasOnline: true, lastError: '' }), '');
   assert.equal(getWsCloseDetail({ code: 1006, wasOnline: false, lastError: 'Error during WebSocket handshake: 403' }), 'WS refusé');
-  assert.equal(getWsCloseDetail({ code: 1006, wasOnline: true, lastError: '', isSecure: true }), 'WS indisponible en HTTPS');
-  assert.equal(getWsCloseDetail({ code: 1006, wasOnline: true, lastError: '' }), 'WS indisponible');
+  assert.equal(getWsCloseDetail({ code: 1006, wasOnline: true, lastError: '' }), '');
 });
 
 test('formats fallback badge with visible websocket reason', () => {


### PR DESCRIPTION
### Motivation
- Allow the `Mise à jour périodique` fallback badge to appear without an appended reason unless a truly qualified websocket failure was observed (explicit WS error payload, explicit refusal/403, or TLS/certificate issue). 

### Description
- Restrict error classification in `app/web/ws_status.js` by making `normalizeWsError()` only return a human message for TLS/certificate and refusal/403 signatures and return an empty string for generic browser `error`/`close` texts. 
- Simplify `getWsCloseDetail()` to avoid inventing HTTPS/certificate or connectivity reasons when there is no explicit failure, and update `test/web/ws_status.test.js` to assert the new behavior. 

### Testing
- Ran `node --test test/web/ws_status.test.js`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1496957008327b6f59e2c76f04e95)