### PR TITLE
Handle initial secure websocket close 1006 with TLS heuristic

### DIFF
--- a/app/web/ws_status.js
+++ b/app/web/ws_status.js
@@ -24,11 +24,17 @@ function getWsCloseDetail({
   code = 1000,
   wasOnline = false,
   lastError = '',
+  isSecure = false,
+  online = true,
 } = {}) {
   if (code === 1000 && wasOnline && !lastError) {
     return '';
   }
-  return normalizeWsError(lastError);
+  const normalizedError = normalizeWsError(lastError);
+  if (!normalizedError && code === 1006 && wasOnline === false && isSecure === true && online !== false) {
+    return 'WS bloqué par TLS/certificat';
+  }
+  return normalizedError;
 }
 
 function formatWsStatusLabel(mode, detail = '') {

--- a/test/web/ws_status.test.js
+++ b/test/web/ws_status.test.js
@@ -14,6 +14,11 @@ test('keeps fallback reason empty unless a qualified failure was observed', () =
   assert.equal(getWsCloseDetail({ code: 1000, wasOnline: true, lastError: '' }), '');
   assert.equal(getWsCloseDetail({ code: 1006, wasOnline: false, lastError: 'Error during WebSocket handshake: 403' }), 'WS refusé');
   assert.equal(getWsCloseDetail({ code: 1006, wasOnline: true, lastError: '' }), '');
+
+  assert.equal(
+    getWsCloseDetail({ code: 1006, wasOnline: false, lastError: '', isSecure: true, online: true }),
+    'WS bloqué par TLS/certificat',
+  );
 });
 
 test('formats fallback badge with visible websocket reason', () => {


### PR DESCRIPTION
### Motivation
- Detect cases where an initial WebSocket close (code `1006`) happens in a secure context while the client is online but no explicit error message was produced, and surface a helpful TLS/certificate hint instead of an empty fallback reason.

### Description
- Updated `getWsCloseDetail` in `app/web/ws_status.js` to accept `isSecure` and `online` parameters and kept the existing `code === 1000` + established connection behavior intact.
- Normalize `lastError` first via `normalizeWsError`, and when the normalized message is empty and `code === 1006` and `wasOnline === false` and `isSecure === true` and `online !== false`, return the heuristic message `WS bloqué par TLS/certificat`.
- Added a regression assertion in `test/web/ws_status.test.js` that calls `getWsCloseDetail` with `{ code: 1006, wasOnline: false, lastError: '', isSecure: true, online: true }` to lock the behavior.

### Testing
- Ran `node --test test/web/ws_status.test.js` and all tests passed (`3` tests, `0` failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6afb81778832798605a5fc38e5d5d)