### PR TITLE
Simplify websocket utility APIs and align tests

### DIFF
--- a/app/web/app.js
+++ b/app/web/app.js
@@ -831,10 +831,7 @@ function openSocket(name, path, onMessage, { onOpen = null, onClose = null } = {
 
   socket.addEventListener('error', (event) => {
     const reason = typeof window.normalizeWsError === 'function'
-      ? window.normalizeWsError(event?.message || meta.lastError, {
-          isSecure: window.location.protocol === 'https:',
-          online: navigator.onLine !== false,
-        })
+      ? window.normalizeWsError(event?.message || meta.lastError)
       : 'WS indisponible';
     meta.lastError = reason;
     if (name === 'status') {

--- a/app/web/ws_status.js
+++ b/app/web/ws_status.js
@@ -1,3 +1,16 @@
+/**
+ * WebSocket utility contracts:
+ * - normalizeWsError(raw: string): string
+ *   Pure textual normalization. Returns a short user-facing reason or '' when unknown.
+ * - getWsCloseDetail(context: {
+ *     code?: number,
+ *     wasOnline?: boolean,
+ *     lastError?: string,
+ *     isSecure?: boolean,
+ *     online?: boolean
+ *   }): string
+ *   Computes the final visible reason on close from close code + connection context.
+ */
 function normalizeWsError(raw = '') {
   const message = String(raw || '').toLowerCase();
   if (

--- a/test/web/ws_status.test.js
+++ b/test/web/ws_status.test.js
@@ -6,6 +6,10 @@ const { formatWsStatusLabel, getWsCloseDetail, normalizeWsError } = require('../
 test('maps only qualified websocket errors to short visible messages', () => {
   assert.equal(normalizeWsError('net::ERR_CERT_AUTHORITY_INVALID'), 'WS bloqué par TLS/certificat');
   assert.equal(normalizeWsError('Error during WebSocket handshake: 403'), 'WS refusé');
+  assert.equal(
+    normalizeWsError('Error during WebSocket handshake: 403', { isSecure: false, online: false }),
+    'WS refusé',
+  );
   assert.equal(normalizeWsError(''), '');
   assert.equal(normalizeWsError('WebSocket closed unexpectedly'), '');
 });


### PR DESCRIPTION
### Motivation
- Unifier la stratégie des utilitaires WebSocket pour que `normalizeWsError(raw)` reste une fonction purement textuelle et que l’interprétation contextuelle soit confiée à `getWsCloseDetail`.
- Éviter l’ambiguïté d’un second argument passé à `normalizeWsError` depuis le code appelant et documenter clairement les contrats des deux fonctions.
- Garder l’API minimale et rendre les tests cohérents avec cette décision.

### Description
- Retiré l’objet contexte passé à `normalizeWsError` dans le handler `error` de `app/web/app.js`, en appelant désormais `window.normalizeWsError(event?.message || meta.lastError)`.
- Ajouté une description des contrats en tête de `app/web/ws_status.js` précisant que `normalizeWsError(raw: string): string` est purement textuelle et que `getWsCloseDetail(context): string` accepte le contexte enrichi.
- Adapté `test/web/ws_status.test.js` pour vérifier que `normalizeWsError` reste indépendant du contexte et pour conserver les tests existants de `getWsCloseDetail`.
- Aucun changement comportemental du calcul final de motif de fermeture géré par `getWsCloseDetail` dans le handler `close` qui continue d’utiliser le contexte complet.

### Testing
- Executed `node --test test/web/ws_status.test.js` and all tests passed (3 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6b06dce98832791ad967793409054)