### PR TITLE
Améliore reconnexion WS : backoff exponentiel, seuil d’échecs et stabilisation UI

### DIFF
--- a/app/web/app.js
+++ b/app/web/app.js
@@ -7,8 +7,8 @@ const state = {
     watchlist: null,
   },
   socketMeta: {
-    status: { lastError: '', wasOnline: false },
-    watchlist: { lastError: '', wasOnline: false },
+    status: { lastError: '', wasOnline: false, failures: 0, retryTimer: null },
+    watchlist: { lastError: '', wasOnline: false, failures: 0, retryTimer: null },
   },
   statusFallbackTimer: null,
   watchlistImport: {
@@ -738,6 +738,11 @@ async function parseErrorMessage(response) {
 }
 
 function closeSocket(name) {
+  const meta = state.socketMeta[name];
+  if (meta?.retryTimer) {
+    window.clearTimeout(meta.retryTimer);
+    meta.retryTimer = null;
+  }
   const socket = state.sockets[name];
   if (socket) {
     socket.close();
@@ -792,6 +797,8 @@ function stopStatusFallback() {
   state.statusFallbackTimer = null;
 }
 
+const STATUS_WS_FAILURE_THRESHOLD = 3;
+
 function openSocket(name, path, onMessage, { onOpen = null, onClose = null } = {}) {
   closeSocket(name);
   if (!state.authenticated || document.visibilityState === 'hidden') {
@@ -800,15 +807,20 @@ function openSocket(name, path, onMessage, { onOpen = null, onClose = null } = {
   const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
   const url = `${protocol}//${window.location.host}${buildApiUrl(path)}`;
   const socket = new WebSocket(url);
-  const meta = state.socketMeta[name] || { lastError: '', wasOnline: false };
+  const meta = state.socketMeta[name] || { lastError: '', wasOnline: false, failures: 0, retryTimer: null };
   state.socketMeta[name] = meta;
   meta.lastError = '';
   meta.wasOnline = false;
+  if (meta.retryTimer) {
+    window.clearTimeout(meta.retryTimer);
+    meta.retryTimer = null;
+  }
   state.sockets[name] = socket;
 
   socket.addEventListener('open', () => {
     meta.wasOnline = true;
     meta.lastError = '';
+    meta.failures = 0;
     if (typeof onOpen === 'function') {
       onOpen();
     }
@@ -834,9 +846,6 @@ function openSocket(name, path, onMessage, { onOpen = null, onClose = null } = {
       ? window.normalizeWsError(event?.message || meta.lastError)
       : 'WS indisponible';
     meta.lastError = reason;
-    if (name === 'status') {
-      renderWsStatus('fallback');
-    }
   });
 
   socket.addEventListener('close', (event) => {
@@ -853,20 +862,28 @@ function openSocket(name, path, onMessage, { onOpen = null, onClose = null } = {
           online: navigator.onLine !== false,
         })
       : meta.lastError;
+    if (state.authenticated && document.visibilityState !== 'hidden') {
+      meta.failures += 1;
+    }
     if (typeof onClose === 'function') {
       onClose({
         code: event.code,
         reason: meta.lastError,
         phase: meta.wasOnline ? 'reconnect' : 'initial',
         wasOnline: meta.wasOnline,
+        failures: meta.failures,
       });
     }
     if (state.authenticated && document.visibilityState !== 'hidden') {
-      window.setTimeout(() => {
+      const retryDelay = typeof window.computeReconnectDelayMs === 'function'
+        ? window.computeReconnectDelayMs(meta.failures)
+        : 2000;
+      meta.retryTimer = window.setTimeout(() => {
+        meta.retryTimer = null;
         if (state.sockets[name] === null) {
           openSocket(name, path, onMessage, { onOpen, onClose });
         }
-      }, 2000);
+      }, retryDelay);
     }
   });
 }
@@ -891,9 +908,15 @@ function startStatusStream() {
         renderWsStatus('online');
         stopStatusFallback();
       },
-      onClose: ({ reason }) => {
+      onClose: ({ reason, failures }) => {
         state.socketMeta.status.lastError = reason || '';
-        renderWsStatus('fallback');
+        const display = typeof window.getWsDisplayState === 'function'
+          ? window.getWsDisplayState(failures, STATUS_WS_FAILURE_THRESHOLD)
+          : { mode: 'fallback', detail: '' };
+        if (display.detail && !state.socketMeta.status.lastError) {
+          state.socketMeta.status.lastError = display.detail;
+        }
+        renderWsStatus(display.mode);
         startStatusFallback();
       },
     }

--- a/app/web/ws_status.js
+++ b/app/web/ws_status.js
@@ -55,12 +55,37 @@ function formatWsStatusLabel(mode, detail = '') {
   return detail && mode !== 'online' ? `${label} · ${detail}` : label;
 }
 
+function getWsDisplayState(consecutiveFailures = 0, failureThreshold = 3) {
+  const safeThreshold = Math.max(1, Number(failureThreshold) || 1);
+  return consecutiveFailures >= safeThreshold
+    ? { mode: 'offline', detail: '' }
+    : { mode: 'fallback', detail: 'reconnexion…' };
+}
+
+function computeReconnectDelayMs(
+  attempt = 1,
+  { baseMs = 2000, maxMs = 30000, jitterRatio = 0.25, random = Math.random } = {}
+) {
+  const step = Math.max(1, Number(attempt) || 1) - 1;
+  const backoffMs = Math.min(maxMs, baseMs * 2 ** step);
+  const jitterMs = backoffMs * jitterRatio * ((typeof random === 'function' ? random() : 0.5) * 2 - 1);
+  return Math.max(0, Math.round(backoffMs + jitterMs));
+}
+
 if (typeof window !== 'undefined') {
   window.normalizeWsError = normalizeWsError;
   window.getWsCloseDetail = getWsCloseDetail;
   window.formatWsStatusLabel = formatWsStatusLabel;
+  window.getWsDisplayState = getWsDisplayState;
+  window.computeReconnectDelayMs = computeReconnectDelayMs;
 }
 
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = { normalizeWsError, getWsCloseDetail, formatWsStatusLabel };
+  module.exports = {
+    normalizeWsError,
+    getWsCloseDetail,
+    formatWsStatusLabel,
+    getWsDisplayState,
+    computeReconnectDelayMs,
+  };
 }

--- a/test/web/ws_status.test.js
+++ b/test/web/ws_status.test.js
@@ -1,7 +1,13 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 
-const { formatWsStatusLabel, getWsCloseDetail, normalizeWsError } = require('../../app/web/ws_status.js');
+const {
+  computeReconnectDelayMs,
+  formatWsStatusLabel,
+  getWsCloseDetail,
+  getWsDisplayState,
+  normalizeWsError,
+} = require('../../app/web/ws_status.js');
 
 test('maps only qualified websocket errors to short visible messages', () => {
   assert.equal(normalizeWsError('net::ERR_CERT_AUTHORITY_INVALID'), 'WS bloqué par TLS/certificat');
@@ -28,4 +34,22 @@ test('keeps fallback reason empty unless a qualified failure was observed', () =
 test('formats fallback badge with visible websocket reason', () => {
   assert.equal(formatWsStatusLabel('fallback', 'WS refusé'), 'Mise à jour périodique · WS refusé');
   assert.equal(formatWsStatusLabel('online', 'WS refusé'), 'WS en ligne');
+});
+
+test('maps websocket status by consecutive failures and threshold', () => {
+  assert.deepEqual(getWsDisplayState(1, 3), { mode: 'fallback', detail: 'reconnexion…' });
+  assert.deepEqual(getWsDisplayState(2, 3), { mode: 'fallback', detail: 'reconnexion…' });
+  assert.deepEqual(getWsDisplayState(3, 3), { mode: 'offline', detail: '' });
+  assert.deepEqual(getWsDisplayState(1, 0), { mode: 'offline', detail: '' });
+});
+
+test('computes reconnect delay with exponential backoff and jitter', () => {
+  const random = () => 0.5;
+  assert.equal(computeReconnectDelayMs(1, { random }), 2000);
+  assert.equal(computeReconnectDelayMs(2, { random }), 4000);
+  assert.equal(computeReconnectDelayMs(3, { random }), 8000);
+  assert.equal(computeReconnectDelayMs(8, { random }), 30000);
+
+  assert.equal(computeReconnectDelayMs(1, { random: () => 0 }), 1500);
+  assert.equal(computeReconnectDelayMs(1, { random: () => 1 }), 2500);
 });


### PR DESCRIPTION
### Motivation
- Réduire les basculements d’affichage et la sur-reconnexion lors de micro-coupures en remplaçant le délai fixe par un backoff et en n’affichant “WS indisponible” qu’après N échecs consécutifs.
- Conserver le fallback HTTP (`startStatusFallback`) tout en évitant que l’UI clignote entre online/fallback à chaque interruption brève.

### Description
- Ajout de `failures` et `retryTimer` dans `state.socketMeta` et nettoyage du `retryTimer` dans `closeSocket` pour éviter timers résiduels (`app/web/app.js`).
- Remplacement du délai fixe de 2s par un backoff exponentiel avec jitter via `computeReconnectDelayMs(baseMs=2000, maxMs=30000)` et usage dans `openSocket` pour planifier les tentatives de reconnexion (`app/web/ws_status.js`, `app/web/app.js`).
- Réinitialisation du compteur `failures` sur l’événement `open` et incrément sur `close`, et suppression du rendu immédiat `fallback` depuis `error` pour réduire les basculements UI (`app/web/app.js`).
- Ajout de `getWsDisplayState(consecutiveFailures, failureThreshold=3)` qui mappe les échecs consécutifs en état affiché (`fallback` avec « reconnection… » ou `offline`), et intégration pour la stream `status` afin d’afficher `WS indisponible` seulement après le seuil (3) (`app/web/ws_status.js`, `app/web/app.js`).
- Exposition des helpers aux deux environnements (`window` et `module.exports`) et ajout de tests ciblés dans `test/web/ws_status.test.js` pour le mapping d’état et le calcul du délai.

### Testing
- Exécution de `node --test test/web/ws_status.test.js` : tous les tests ciblés sur `getWsDisplayState` et `computeReconnectDelayMs` sont passés.
- Exécution de la suite web complète `node --test test/web/*.test.js` : la suite complète est passée (aucun échec).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2546756088327883e9f2af8404a86)