### PR TITLE
WebSocket: structured lifecycle logs, status heartbeat, and integration test

### DIFF
--- a/app/daemon.rb
+++ b/app/daemon.rb
@@ -99,6 +99,8 @@ class Daemon
   SESSION_TTL = 86_400
   FINISHED_STATUSES = %w[finished failed cancelled].freeze
   CAPTURE_OUTPUT_RETENTION_SECONDS = 5
+  STATUS_STREAM_INTERVAL_SECONDS = 15
+  STATUS_STREAM_HEARTBEAT_SECONDS = 5
   UUID_REGEX = /\b[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\b/i.freeze
   INLINE_EXECUTED = Object.new
   SOCKET_PATH = '/home/raph/.medialibrarian/librarian.sock'
@@ -1507,6 +1509,10 @@ class Daemon
     end
 
     def handle_websocket_request(req, res)
+      socket = nil
+      started_at = Time.now
+      stream = req.query['stream'].to_s
+      close_code = nil
       key = req.header['sec-websocket-key']&.first.to_s
       upgrade = req.header['upgrade']&.first.to_s.downcase
       connection = req.header['connection']&.first.to_s.downcase
@@ -1517,9 +1523,9 @@ class Daemon
       socket = websocket_socket(req, res)
       return error_response(res, status: 500, message: 'websocket_unavailable') unless socket
 
-      stream = req.query['stream'].to_s
       job_id = req.query['job_id'].to_s
       socket.write(websocket_handshake_response(key))
+      websocket_log('opened', stream:, socket:)
 
       case stream
       when 'job'
@@ -1529,9 +1535,14 @@ class Daemon
       end
 
       raise WEBrick::HTTPStatus::EOFError
+    rescue IOError, SystemCallError => e
+      websocket_log('closed', stream:, socket:, started_at:, close_code:, exception: e, expected: true)
     rescue StandardError => e
+      websocket_log('closed', stream:, socket:, started_at:, close_code:, exception: e, expected: false)
       app.speaker.tell_error(e, 'websocket request failure') if Env.debug?
     ensure
+      close_code = socket.close_code if socket&.respond_to?(:close_code)
+      websocket_log('closed', stream:, socket:, started_at:, close_code:) unless $ERROR_INFO
       socket&.close unless socket&.closed?
       res.keep_alive = false
     end
@@ -1596,16 +1607,22 @@ class Daemon
     end
 
     def stream_status_updates(socket)
+      last_status_sent = nil
       loop do
-        payload = {
-          type: 'status',
-          data: status_snapshot_payload
-        }
-        socket.write(websocket_text_frame(payload.to_json))
-        sleep 15
+        now = Time.now
+        if last_status_sent.nil? || now - last_status_sent >= STATUS_STREAM_INTERVAL_SECONDS
+          socket.write(websocket_text_frame({ type: 'status', data: status_snapshot_payload }.to_json))
+          last_status_sent = now
+        else
+          socket.write(websocket_text_frame({ type: 'hb', t: now.to_i }.to_json))
+        end
+        sleep STATUS_STREAM_HEARTBEAT_SECONDS
       end
-    rescue IOError, SystemCallError
-      nil
+    rescue IOError, SystemCallError => e
+      websocket_log('status_stream_closed', stream: 'status', socket:, exception: e, expected: true)
+    rescue StandardError => e
+      websocket_log('status_stream_closed', stream: 'status', socket:, exception: e, expected: false)
+      raise
     end
 
     def stream_job_updates(socket, job_id)
@@ -1640,6 +1657,23 @@ class Daemon
         8.times { |i| header << ((length >> (56 - (i * 8))) & 0xff) }
       end
       header.pack('C*') + bytes
+    end
+
+    def websocket_log(event, stream:, socket: nil, started_at: nil, close_code: nil, exception: nil, expected: nil)
+      return if event == 'opened' && Env.debug?
+
+      payload = {
+        event: "websocket_#{event}",
+        stream: stream.to_s.empty? ? 'status' : stream.to_s
+      }
+      payload[:duration_ms] = ((Time.now - started_at) * 1000).round if started_at
+      payload[:close_code] = close_code if close_code
+      if exception
+        payload[:exception] = exception.class.name
+        payload[:expected] = expected unless expected.nil?
+      end
+      payload[:socket] = socket.class.name if Env.debug? && socket
+      app.speaker.speak_up(payload.to_json, 0, Thread.current, 1)
     end
 
     def handle_jobs_request(req, res)

--- a/test/daemon_integration_test.rb
+++ b/test/daemon_integration_test.rb
@@ -664,6 +664,30 @@ class DaemonIntegrationTest < Minitest::Test
     assert_kind_of Hash, message['data']
   end
 
+  def test_websocket_status_stream_remains_active_across_multiple_reads
+    boot_daemon_environment(authenticate: false)
+    authenticate_session
+
+    header, socket, buffer = websocket_upgrade_stream('/ws?stream=status', cookie: @session_cookie)
+    assert_includes header, '101 Switching Protocols'
+
+    frames = []
+    Timeout.timeout(8) do
+      while frames.size < 3
+        frame, buffer = read_websocket_frame_with_buffer(socket, buffer)
+        message = JSON.parse(frame[:payload])
+        next unless %w[status hb].include?(message['type'])
+
+        frames << message
+      end
+    end
+
+    assert_equal 'status', frames.first['type']
+    assert frames.drop(1).all? { |message| %w[status hb].include?(message['type']) }
+  ensure
+    socket&.close unless socket&.closed?
+  end
+
   def test_https_control_server_serves_requests
     boot_daemon_environment(api_overrides: { 'ssl_enabled' => true, 'ssl_verify_mode' => 'none' })
 
@@ -949,6 +973,13 @@ class DaemonIntegrationTest < Minitest::Test
   end
 
   def websocket_upgrade_response(path, cookie: nil)
+    header, socket, payload = websocket_upgrade_stream(path, cookie:)
+    [header, read_websocket_frame(socket, payload.to_s.b)]
+  ensure
+    socket&.close unless socket&.closed?
+  end
+
+  def websocket_upgrade_stream(path, cookie: nil)
     socket = open_control_socket
     key = Base64.strict_encode64(Random.bytes(16))
     request = [
@@ -963,14 +994,10 @@ class DaemonIntegrationTest < Minitest::Test
     socket.write(request.join("\r\n") + "\r\n\r\n")
 
     response = +''
-    until response.include?("\r\n\r\n")
-      response << socket.readpartial(1024)
-    end
+    response << socket.readpartial(1024) until response.include?("\r\n\r\n")
 
     header, payload = response.split("\r\n\r\n", 2)
-    [header, read_websocket_frame(socket, payload.to_s.b)]
-  ensure
-    socket&.close unless socket&.closed?
+    [header, socket, payload.to_s.b]
   end
 
   def open_control_socket
@@ -988,6 +1015,10 @@ class DaemonIntegrationTest < Minitest::Test
   end
 
   def read_websocket_frame(socket, buffer = ''.b)
+    read_websocket_frame_with_buffer(socket, buffer).first
+  end
+
+  def read_websocket_frame_with_buffer(socket, buffer = ''.b)
     first_byte, buffer = read_from_socket(socket, buffer, 1)
     second_byte, buffer = read_from_socket(socket, buffer, 1)
     raise 'missing websocket frame' if first_byte.nil? || second_byte.nil?
@@ -1001,12 +1032,12 @@ class DaemonIntegrationTest < Minitest::Test
       length = extended.unpack1('Q>')
     end
 
-    payload, = read_from_socket(socket, buffer, length)
-    {
+    payload, buffer = read_from_socket(socket, buffer, length)
+    [{
       fin: (first_byte.getbyte(0) & 0x80) != 0,
       opcode: first_byte.getbyte(0) & 0x0f,
       payload: payload
-    }
+    }, buffer]
   end
 
   def read_from_socket(socket, buffer, length)


### PR DESCRIPTION
### Motivation
- Improve observability and robustness of the control WebSocket path by adding minimal structured lifecycle logs and by ensuring `stream=status` remains active between multiple reads. 

### Description
- Add two constants `STATUS_STREAM_INTERVAL_SECONDS` and `STATUS_STREAM_HEARTBEAT_SECONDS` and implement a lightweight heartbeat for `stream=status` that sends compact `{ "type": "hb", "t": ... }` frames between full status snapshots in `stream_status_updates` (`app/daemon.rb`).
- Introduce compact structured logging via `websocket_log` and log socket `opened` and `closed` events with `event`, `stream`, duration, optional `close_code`, and exception class, while keeping noise low in non-debug modes (`app/daemon.rb`).
- Explicitly separate expected disconnect exceptions (`IOError`, `SystemCallError`) from unexpected errors and log them differently in `handle_websocket_request` (`app/daemon.rb`).
- Add an integration test `test_websocket_status_stream_remains_active_across_multiple_reads` and helper refactors to allow multi-frame reads on the same socket (`test/daemon_integration_test.rb`).

### Testing
- Syntax checks passed with `ruby -c app/daemon.rb` and `ruby -c test/daemon_integration_test.rb` (success).
- Targeted integration test run using `bundle exec ruby -Itest ...` could not complete in this environment because Bundler tried to load a git-sourced gem (`archive-zip`) that is not checked out, causing the run to be blocked (environmental issue, not code failure).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d258a72bc88327843b8a86034eb7dc)