### PR TITLE
Prefer IMDb grouping for show entries and keep season aggregation consistent

### DIFF
--- a/app/collection_repository.rb
+++ b/app/collection_repository.rb
@@ -170,8 +170,8 @@ class CollectionRepository
     return {} if app.db.respond_to?(:table_exists?) && !app.db.table_exists?(:local_media)
 
     grouped = Hash.new { |h, k| h[k] = [] }
-    dataset.where(media_type: 'show').select(:local_path).all.each do |row|
-      key = series_key(row)
+    dataset.where(media_type: 'show').select(:id, :media_type, :imdb_id, :local_path).all.each do |row|
+      key = group_key(row)
       next if key.empty?
 
       grouped[key] << row
@@ -180,12 +180,16 @@ class CollectionRepository
   end
 
   def group_key(row)
+    imdb_id = fetch(row, :imdb_id).to_s
+
     if fetch(row, :media_type) == 'show'
+      return imdb_id unless imdb_id.empty?
+
       series = series_key(row)
       return series unless series.empty?
     end
 
-    key = fetch(row, :imdb_id).to_s
+    key = imdb_id
     key = fetch(row, :id).to_s if key.empty?
     key
   end

--- a/test/app/collection_repository_test.rb
+++ b/test/app/collection_repository_test.rb
@@ -77,6 +77,33 @@ class CollectionRepositoryTest < Minitest::Test
     assert_equal ['/tmp/media/Show.1x02.mkv'], seasons.first[:episodes].last[:files]
   end
 
+  def test_show_grouping_prefers_imdb_id_over_series_name
+    insert_media([
+      { media_type: 'show', imdb_id: 'ttshow', local_path: '/tmp/media/Shared.Name.S01E01.mkv' },
+      { media_type: 'show', imdb_id: 'ttshow', local_path: '/tmp/media/Shared.Name.S01E02.mkv' }
+    ])
+
+    result = @repository.paginated_entries(sort: 'title', page: 1, per_page: 10, type: 'show')
+
+    assert_equal 1, result[:total]
+    assert_equal 'ttshow', result[:entries].first[:imdb_id]
+    assert_equal [1, 2], result[:entries].first[:seasons].first[:episodes].map { |episode| episode[:episode] }
+  end
+
+  def test_show_seasons_do_not_mix_imdb_and_name_groupings
+    insert_media([
+      { media_type: 'show', imdb_id: 'ttalpha', local_path: '/tmp/media/Shared.Name.S01E01.mkv' },
+      { media_type: 'show', imdb_id: '', local_path: '/tmp/media/Shared.Name.S01E03.mkv' }
+    ])
+
+    result = @repository.paginated_entries(sort: 'title', page: 1, per_page: 10, type: 'show')
+    seasons_by_imdb = result[:entries].to_h { |entry| [entry[:imdb_id], entry[:seasons]] }
+
+    assert_equal [1], seasons_by_imdb['ttalpha'].first[:episodes].map { |episode| episode[:episode] }
+    unnamed_entry = result[:entries].find { |entry| entry[:imdb_id].to_s.empty? }
+    assert_equal [3], unnamed_entry[:seasons].first[:episodes].map { |episode| episode[:episode] }
+  end
+
   def test_enriches_entries_with_calendar_metadata_when_available
     insert_media([{ imdb_id: 'ttmeta', local_path: '/tmp/media/meta.mkv', created_at: '2023-02-01T00:00:00Z' }])
     insert_calendar_entry(


### PR DESCRIPTION
### Motivation
- Shows were previously grouped by `series_key` before considering an `imdb_id`, which caused mixed grouping semantics when some episodes had IMDb identifiers and others only a name. 
- The change ensures grouping is deterministic and consistent with movie grouping semantics by preferring explicit identifiers where available.

### Description
- Change `group_key` so when `media_type == 'show'` it returns the `imdb_id` if present, then falls back to `series_key`, and finally to the row `id` as the last resort. 
- Update `all_show_series_rows` to use `group_key(row)` instead of `series_key(row)` and to select `:id, :media_type, :imdb_id, :local_path` so season aggregation aligns with the same grouping key. 
- Keep the overall `aggregate_rows`/`serialize_group` logic intact and use the aligned `series_rows[group_key]` when building seasons. 
- Add two tests: `test_show_grouping_prefers_imdb_id_over_series_name` and `test_show_seasons_do_not_mix_imdb_and_name_groupings` to assert IMDb-first grouping and that season aggregation does not mix IMDb-based and name-based groups.

### Testing
- Ran `bundle install` to ensure dependencies were available, which completed successfully. 
- Ran the full file with `bundle exec ruby -Itest test/app/collection_repository_test.rb` and observed one pre-existing unrelated failure in `test_search_matches_titles_from_media_and_calendar_entries`. 
- Ran targeted tests with `bundle exec ruby -Itest test/app/collection_repository_test.rb -n "/show_grouping_prefers_imdb_id_over_series_name|show_seasons_do_not_mix_imdb_and_name_groupings/"` and those new tests passed. 
- Ran a subset including grouping and season tests with `-n "/groups_entries_by_imdb_id|builds_seasons_for_tv_entries|show_grouping_prefers_imdb_id_over_series_name|show_seasons_do_not_mix_imdb_and_name_groupings/"` and all succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3e1faca6c8327a1e384911ca2cb6e)