### PR TITLE
Add lean websocket close diagnostics in app.js

### DIFF
--- a/app/web/app.js
+++ b/app/web/app.js
@@ -799,6 +799,16 @@ function stopStatusFallback() {
 
 const STATUS_WS_FAILURE_THRESHOLD = 3;
 
+function logWsClose(name, event, meta) {
+  console.warn('[ws.close]', {
+    stream: name,
+    code: event.code,
+    wasOnline: meta.wasOnline,
+    failures: meta.failures,
+    lastError: meta.lastError,
+  });
+}
+
 function openSocket(name, path, onMessage, { onOpen = null, onClose = null } = {}) {
   closeSocket(name);
   if (!state.authenticated || document.visibilityState === 'hidden') {
@@ -865,6 +875,7 @@ function openSocket(name, path, onMessage, { onOpen = null, onClose = null } = {
     if (state.authenticated && document.visibilityState !== 'hidden') {
       meta.failures += 1;
     }
+    logWsClose(name, event, meta);
     if (typeof onClose === 'function') {
       onClose({
         code: event.code,


### PR DESCRIPTION
### Motivation
- Provide a minimal, non-verbose console diagnostic when a websocket closes so operators can see stream name, close code and key socket metadata without changing the UI.

### Description
- Add a small local helper `logWsClose(name, event, meta)` that emits a single `console.warn` with `stream`, `code`, `wasOnline`, `failures`, and `lastError`, and call it from the websocket `close` handler in `app/web/app.js`.

### Testing
- Ran `node --check app/web/app.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3e2a036f08327aae124cfcdf19c9b)