### PR TITLE
Strip trailing year suffixes from series names derived from filenames

### DIFF
--- a/app/collection_repository.rb
+++ b/app/collection_repository.rb
@@ -219,22 +219,26 @@ class CollectionRepository
 
   def series_name_from(row)
     source = fetch(row, :calendar_title).to_s
-    source = File.basename(fetch(row, :local_path).to_s) if source.empty?
+    from_file = source.empty?
+    source = File.basename(fetch(row, :local_path).to_s) if from_file
     return '' if source.empty?
 
     if (match = source.match(/(.+?)[ ._-]*[sS]\d{1,2}[ ._-]*[eE]\d{1,2}/))
-      return normalize_series_name(match[1])
+      return normalize_series_name(match[1], strip_year_suffix: from_file)
     end
 
     if (match = source.match(/(.+?)\d{1,2}x\d{1,2}/))
-      return normalize_series_name(match[1])
+      return normalize_series_name(match[1], strip_year_suffix: from_file)
     end
 
-    normalize_series_name(source)
+    normalize_series_name(source, strip_year_suffix: from_file)
   end
 
-  def normalize_series_name(value)
-    value.to_s.tr('._', ' ').gsub(/\s+/, ' ').strip
+  def normalize_series_name(value, strip_year_suffix: false)
+    normalized = value.to_s.tr('._', ' ').gsub(/\s+/, ' ').strip
+    return normalized unless strip_year_suffix
+
+    normalized.sub(/\s*(?:\(\d{4}\)|\d{4})\z/, '').strip
   end
 
   def build_released_at(value)

--- a/test/app/collection_repository_test.rb
+++ b/test/app/collection_repository_test.rb
@@ -104,6 +104,20 @@ class CollectionRepositoryTest < Minitest::Test
     assert_equal [3], unnamed_entry[:seasons].first[:episodes].map { |episode| episode[:episode] }
   end
 
+  def test_show_grouping_ignores_year_suffix_in_filename_series_name
+    insert_media([
+      { media_type: 'show', imdb_id: '', local_path: '/tmp/media/Midnight.Mass.S01E02.mkv' },
+      { media_type: 'show', imdb_id: '', local_path: '/tmp/media/Midnight.Mass.2021.S01E01.mkv' }
+    ])
+    insert_calendar_entry(imdb_id: '', title: 'Midnight Mass', media_type: 'show')
+
+    result = @repository.paginated_entries(sort: 'title', page: 1, per_page: 10, type: 'show')
+
+    assert_equal 1, result[:total]
+    assert_equal 'Midnight Mass', result[:entries].first[:title]
+    assert_equal [1, 2], result[:entries].first[:seasons].first[:episodes].map { |episode| episode[:episode] }
+  end
+
   def test_enriches_entries_with_calendar_metadata_when_available
     insert_media([{ imdb_id: 'ttmeta', local_path: '/tmp/media/meta.mkv', created_at: '2023-02-01T00:00:00Z' }])
     insert_calendar_entry(


### PR DESCRIPTION
### Motivation
- Filenames that include a terminal year (e.g. `Midnight.Mass.2021.S01E01`) produced different `series_key` values compared to calendar titles, causing the same show to be split into multiple aggregated entries. 
- The intent is to normalize series names extracted from filenames by removing common trailing year suffixes so grouping is consistent with `calendar_title`-derived names.

### Description
- Detect when the series name is coming from the file path in `series_name_from` (uses a `from_file` flag) and pass that context into `normalize_series_name`.
- Extend `normalize_series_name` with an optional `strip_year_suffix:` parameter and remove trailing ` YYYY` or `(YYYY)` only when `strip_year_suffix` is true using a single regex.
- Ensure this normalization is applied before producing `series_key` by keeping the change local to `series_name_from` which `series_key` calls.
- Add `test_show_grouping_ignores_year_suffix_in_filename_series_name` in `test/app/collection_repository_test.rb` that verifies a calendar-resolved title and a filename-resolved title with a trailing year aggregate into a single show entry with both episodes.

### Testing
- Ran `bundle install` successfully to prepare the test environment. 
- Ran the new test with `bundle exec ruby -Itest test/app/collection_repository_test.rb -n /test_show_grouping_ignores_year_suffix_in_filename_series_name/` and it passed. 
- Ran a focused set of related tests with `bundle exec ruby -Itest test/app/collection_repository_test.rb -n "/test_show_grouping_prefers_imdb_id_over_series_name|test_show_seasons_do_not_mix_imdb_and_name_groupings|test_show_grouping_ignores_year_suffix_in_filename_series_name/"` and they all passed. 
- Running the full test file with `bundle exec ruby -Itest test/app/collection_repository_test.rb` revealed one pre-existing unrelated failure (`test_search_matches_titles_from_media_and_calendar_entries`), unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3f14340648327b6c261e03f3c5a54)