### PR TITLE
Display last updated timestamp on calendar entry cards

### DIFF
--- a/app/calendar_entries_repository.rb
+++ b/app/calendar_entries_repository.rb
@@ -216,6 +216,7 @@ class CalendarEntriesRepository
       imdb_votes: parse_integer(row[:imdb_votes] || row['imdb_votes']),
       synopsis: normalize_synopsis(row[:synopsis] || row['synopsis']),
       release_date: release_date,
+      updated_at: parse_time(row[:updated_at] || row['updated_at']),
       downloaded: downloaded?(row, type, ids, downloaded_index),
       in_interest_list: interest_lookup&.include?(normalize_imdb(imdb_id)),
       poster_url: poster_url,

--- a/app/web/app.css
+++ b/app/web/app.css
@@ -1002,6 +1002,11 @@ button:disabled {
   word-break: break-word;
 }
 
+.calendar-meta--updated {
+  font-size: 0.8rem;
+  font-style: italic;
+}
+
 .calendar-actions-row {
   display: flex;
   justify-content: space-between;

--- a/app/web/app.js
+++ b/app/web/app.js
@@ -2482,6 +2482,17 @@ function buildCalendarEntryCard(entry, date = resolveCalendarDate(entry)) {
     body.appendChild(meta);
   }
 
+  const updatedAtRaw = pickEntryValue(entry, ['updated_at']);
+  if (updatedAtRaw) {
+    const updatedAt = new Date(updatedAtRaw);
+    if (!isNaN(updatedAt.getTime())) {
+      const updatedMeta = document.createElement('div');
+      updatedMeta.className = 'calendar-meta calendar-meta--updated';
+      updatedMeta.textContent = `Mis à jour: ${new Intl.DateTimeFormat('fr-FR', { day: 'numeric', month: 'short', year: 'numeric', hour: '2-digit', minute: '2-digit' }).format(updatedAt)}`;
+      body.appendChild(updatedMeta);
+    }
+  }
+
   if (!inWatchlist && !downloaded) {
     const actions = document.createElement('div');
     actions.className = 'calendar-actions-row';


### PR DESCRIPTION
## Summary
Add support for displaying the last updated timestamp on calendar entry cards in the web interface.

## Changes
- **Backend**: Parse and include `updated_at` timestamp in calendar entry normalization (`calendar_entries_repository.rb`)
- **Frontend**: Display formatted "Mis à jour" (Updated) timestamp on calendar cards with date and time (`app.js`)
- **Styling**: Add CSS styling for the updated timestamp with smaller, italicized text (`app.css`)

## Implementation Details
- The `updated_at` field is parsed from the calendar entry data using the existing `parse_time` utility
- The timestamp is displayed in French locale format (e.g., "Mis à jour: 15 déc. 2024, 14:30")
- The updated metadata is rendered as a new `.calendar-meta--updated` element in the card body
- Styling uses reduced font size (0.8rem) and italic styling to differentiate it from other metadata

https://claude.ai/code/session_018R67V6vBogCJjgCnDoSebs