### PR TITLE
Affiche les dates de création et mise à jour dans les fiches du calendrier

### DIFF
--- a/app/calendar_entries_repository.rb
+++ b/app/calendar_entries_repository.rb
@@ -216,6 +216,7 @@ class CalendarEntriesRepository
       imdb_votes: parse_integer(row[:imdb_votes] || row['imdb_votes']),
       synopsis: normalize_synopsis(row[:synopsis] || row['synopsis']),
       release_date: release_date,
+      created_at: parse_time(row[:created_at] || row['created_at']),
       updated_at: parse_time(row[:updated_at] || row['updated_at']),
       downloaded: downloaded?(row, type, ids, downloaded_index),
       in_interest_list: interest_lookup&.include?(normalize_imdb(imdb_id)),

--- a/app/web/app.js
+++ b/app/web/app.js
@@ -2482,13 +2482,25 @@ function buildCalendarEntryCard(entry, date = resolveCalendarDate(entry)) {
     body.appendChild(meta);
   }
 
+  const dateMetaOptions = { day: 'numeric', month: 'short', year: 'numeric', hour: '2-digit', minute: '2-digit' };
+  const createdAtRaw = pickEntryValue(entry, ['created_at']);
+  if (createdAtRaw) {
+    const createdAt = new Date(createdAtRaw);
+    if (!isNaN(createdAt.getTime())) {
+      const createdMeta = document.createElement('div');
+      createdMeta.className = 'calendar-meta calendar-meta--updated';
+      createdMeta.textContent = `Ajouté: ${new Intl.DateTimeFormat('fr-FR', dateMetaOptions).format(createdAt)}`;
+      body.appendChild(createdMeta);
+    }
+  }
+
   const updatedAtRaw = pickEntryValue(entry, ['updated_at']);
   if (updatedAtRaw) {
     const updatedAt = new Date(updatedAtRaw);
     if (!isNaN(updatedAt.getTime())) {
       const updatedMeta = document.createElement('div');
       updatedMeta.className = 'calendar-meta calendar-meta--updated';
-      updatedMeta.textContent = `Mis à jour: ${new Intl.DateTimeFormat('fr-FR', { day: 'numeric', month: 'short', year: 'numeric', hour: '2-digit', minute: '2-digit' }).format(updatedAt)}`;
+      updatedMeta.textContent = `Mis à jour: ${new Intl.DateTimeFormat('fr-FR', dateMetaOptions).format(updatedAt)}`;
       body.appendChild(updatedMeta);
     }
   }


### PR DESCRIPTION
## Résumé

- Expose les champs `created_at` et `updated_at` de la base de données dans `CalendarEntriesRepository#normalize_row`
- Affiche sur chaque fiche média du calendrier deux nouvelles lignes en bas de carte :
  - **Ajouté :** date/heure de création de l'entrée en BDD
  - **Mis à jour :** date/heure de dernière mise à jour
- Format français via `Intl.DateTimeFormat('fr-FR')` (ex: "12 janv. 2026 14:30")
- Styling via la classe CSS existante `.calendar-meta` + modificateur `.calendar-meta--updated` (italique, taille légèrement réduite)

## Plan de test

- [ ] Lancer le daemon et ouvrir la vue calendrier
- [ ] Vérifier qu'une fiche affiche bien les deux lignes "Ajouté" et "Mis à jour"
- [ ] Vérifier le format de date en français
- [ ] Vérifier qu'une fiche sans `created_at`/`updated_at` n'affiche pas de ligne vide
- [ ] `bundle exec rake test` — aucun échec

https://claude.ai/code/session_018R67V6vBogCJjgCnDoSebs