### PR TITLE
Calendrier : dates de création/MAJ sur les fiches + mise à jour intelligente au refresh

### DIFF
--- a/app/media_librarian/services/calendar_feed_service.rb
+++ b/app/media_librarian/services/calendar_feed_service.rb
@@ -247,14 +247,84 @@ module MediaLibrarian
         ids.merge('imdb' => imdb_id)
       end
 
+      UPDATEABLE_FIELDS = %i[title rating imdb_votes poster_url backdrop_url synopsis release_date genres languages countries ids].freeze
+
       def persist_entries(entries)
         return [] if entries.empty?
 
         prepared = entries.filter_map { |entry| ensure_imdb_id(entry) }
         return [] if prepared.empty?
 
-        db.insert_rows(:calendar_entries, prepared, true)
+        existing_index = load_existing_by_imdb_id
+
+        to_insert = []
+        prepared.each do |entry|
+          imdb_id = normalize_identifier(entry[:imdb_id])
+          existing = existing_index[imdb_id]
+
+          if existing.nil?
+            to_insert << entry
+          else
+            updates = compute_updates(entry, existing)
+            db.update_rows(:calendar_entries, updates, { imdb_id: entry[:imdb_id] }) unless updates.empty?
+          end
+        end
+
+        db.insert_rows(:calendar_entries, to_insert, true) unless to_insert.empty?
         prepared
+      end
+
+      def load_existing_by_imdb_id
+        rows = db.get_rows(:calendar_entries)
+        rows.each_with_object({}) do |row, memo|
+          imdb_id = normalize_identifier(row[:imdb_id] || row['imdb_id'])
+          memo[imdb_id] = row unless imdb_id.empty?
+        end
+      rescue StandardError
+        {}
+      end
+
+      def compute_updates(new_entry, existing_row)
+        UPDATEABLE_FIELDS.each_with_object({}) do |field, updates|
+          new_val = new_entry[field]
+          next if new_val.nil?
+
+          existing_val = existing_row[field]
+
+          if field == :ids
+            merged = merge_ids(existing_val, new_val)
+            updates[field] = merged unless entry_values_equal?(:ids, existing_val, merged)
+          else
+            updates[field] = new_val unless entry_values_equal?(field, new_val, existing_val)
+          end
+        end
+      end
+
+      def merge_ids(existing, incoming)
+        existing_normalized = normalize_ids_to_strings(existing)
+        incoming_normalized = normalize_ids_to_strings(incoming)
+        existing_normalized.merge(incoming_normalized)
+      end
+
+      def normalize_ids_to_strings(value)
+        return {} unless value.is_a?(Hash)
+
+        value.each_with_object({}) { |(k, v), memo| memo[k.to_s] = v unless v.nil? }
+      end
+
+      def entry_values_equal?(field, a, b)
+        case field
+        when :genres, :languages, :countries
+          Array(a).map(&:to_s).sort == Array(b).map(&:to_s).sort
+        when :rating
+          a.to_f.round(3) == b.to_f.round(3)
+        when :release_date
+          a.respond_to?(:iso8601) ? a.iso8601 == b.to_s : a.to_s == b.to_s
+        when :ids
+          normalize_ids_to_strings(a) == normalize_ids_to_strings(b)
+        else
+          a.to_s == b.to_s
+        end
       end
 
       def log_entries(entries)

--- a/test/services/calendar_feed_service_test.rb
+++ b/test/services/calendar_feed_service_test.rb
@@ -102,6 +102,80 @@ class CalendarFeedServiceTest < Minitest::Test
     assert_equal 'First', rows.first[:title]
   end
 
+  def test_refresh_updates_existing_entry_when_votes_change
+    imdb_id = 'tt8000001'
+    entry = base_entry.merge(imdb_id: imdb_id, ids: { 'imdb' => imdb_id }, imdb_votes: 100)
+    provider = FakeProvider.new([entry])
+    service = MediaLibrarian::Services::CalendarFeedService.new(app: nil, speaker: @speaker, db: @db, providers: [provider])
+    service.refresh(date_range: Date.today..(Date.today + 5), limit: 10)
+
+    row_before = @db.get_rows(:calendar_entries).first
+    assert_equal 100, row_before[:imdb_votes]
+    created_at_before = row_before[:created_at]
+
+    updated_entry = entry.merge(imdb_votes: 9999)
+    provider2 = FakeProvider.new([updated_entry])
+    service2 = MediaLibrarian::Services::CalendarFeedService.new(app: nil, speaker: @speaker, db: @db, providers: [provider2])
+    service2.refresh(date_range: Date.today..(Date.today + 5), limit: 10)
+
+    row_after = @db.get_rows(:calendar_entries).first
+    assert_equal 9999, row_after[:imdb_votes]
+    assert_equal created_at_before, row_after[:created_at], 'created_at must not change on update'
+  end
+
+  def test_refresh_updates_existing_entry_when_rating_changes
+    imdb_id = 'tt8000002'
+    entry = base_entry.merge(imdb_id: imdb_id, ids: { 'imdb' => imdb_id }, rating: 6.5)
+    provider = FakeProvider.new([entry])
+    service = MediaLibrarian::Services::CalendarFeedService.new(app: nil, speaker: @speaker, db: @db, providers: [provider])
+    service.refresh(date_range: Date.today..(Date.today + 5), limit: 10)
+
+    updated_entry = entry.merge(rating: 8.2)
+    provider2 = FakeProvider.new([updated_entry])
+    service2 = MediaLibrarian::Services::CalendarFeedService.new(app: nil, speaker: @speaker, db: @db, providers: [provider2])
+    service2.refresh(date_range: Date.today..(Date.today + 5), limit: 10)
+
+    row = @db.get_rows(:calendar_entries).find { |r| r[:imdb_id] == imdb_id }
+    assert_in_delta 8.2, row[:rating], 0.001
+  end
+
+  def test_refresh_does_not_update_updated_at_when_nothing_changes
+    imdb_id = 'tt8000003'
+    entry = base_entry.merge(imdb_id: imdb_id, ids: { 'imdb' => imdb_id })
+    provider = FakeProvider.new([entry])
+    service = MediaLibrarian::Services::CalendarFeedService.new(app: nil, speaker: @speaker, db: @db, providers: [provider])
+    service.refresh(date_range: Date.today..(Date.today + 5), limit: 10)
+
+    row_before = @db.get_rows(:calendar_entries).find { |r| r[:imdb_id] == imdb_id }
+    updated_at_before = row_before[:updated_at]
+
+    service2 = MediaLibrarian::Services::CalendarFeedService.new(app: nil, speaker: @speaker, db: @db, providers: [provider])
+    service2.refresh(date_range: Date.today..(Date.today + 5), limit: 10)
+
+    row_after = @db.get_rows(:calendar_entries).find { |r| r[:imdb_id] == imdb_id }
+    assert_equal updated_at_before, row_after[:updated_at], 'updated_at must not change when nothing differs'
+  end
+
+  def test_refresh_merges_ids_with_existing_on_update
+    imdb_id = 'tt8000004'
+    entry = base_entry.merge(imdb_id: imdb_id, ids: { 'imdb' => imdb_id, 'tmdb' => 42 })
+    provider = FakeProvider.new([entry])
+    service = MediaLibrarian::Services::CalendarFeedService.new(app: nil, speaker: @speaker, db: @db, providers: [provider])
+    service.refresh(date_range: Date.today..(Date.today + 5), limit: 10)
+
+    updated_entry = entry.merge(ids: { 'imdb' => imdb_id, 'trakt' => 99 }, imdb_votes: 500)
+    provider2 = FakeProvider.new([updated_entry])
+    service2 = MediaLibrarian::Services::CalendarFeedService.new(app: nil, speaker: @speaker, db: @db, providers: [provider2])
+    service2.refresh(date_range: Date.today..(Date.today + 5), limit: 10)
+
+    row = @db.get_rows(:calendar_entries).find { |r| r[:imdb_id] == imdb_id }
+    ids = row[:ids].is_a?(Hash) ? row[:ids].transform_keys(&:to_s) : {}
+    assert_equal imdb_id, ids['imdb']
+    assert_equal 42, ids['tmdb'], 'existing tmdb id must be preserved'
+    assert_equal 99, ids['trakt'], 'new trakt id must be added'
+    assert_equal 500, row[:imdb_votes]
+  end
+
   def test_enriches_tmdb_entries_with_omdb_details
     entry = base_entry.merge(
       source: 'tmdb',

--- a/test/support/dependency_stubs.rb
+++ b/test/support/dependency_stubs.rb
@@ -119,6 +119,14 @@ class Utils
     def timeperiod_to_sec(*)
       0
     end
+
+    def canonical_media_type(type)
+      normalized = type.to_s.strip.downcase
+      return 'movie' if normalized.start_with?('movie')
+      return 'show' if normalized.start_with?('show') || normalized.start_with?('tv') || normalized.start_with?('series')
+
+      normalized
+    end
   end
 end unless defined?(Utils) && Utils.is_a?(Class)
 


### PR DESCRIPTION
## Résumé

### Affichage des dates sur les fiches média du calendrier

Chaque fiche affiche désormais deux nouvelles lignes en bas de carte :
- **Ajouté :** date/heure de création de l'entrée en base (`created_at`)
- **Mis à jour :** date/heure de dernière modification (`updated_at`)

Format français via `Intl.DateTimeFormat('fr-FR')` — ex: "12 janv. 2026 14:30". Les lignes n'apparaissent que si la valeur est présente et valide.

### Mise à jour intelligente lors du calendar refresh

Au lieu de remplacer aveuglément toute la ligne (`INSERT OR REPLACE`), le refresh compare maintenant les champs updatables avec la valeur en base et n'émet un `UPDATE` que si au moins un champ a changé :

- `created_at` est **préservé** (ne repart plus de zéro à chaque refresh)
- `updated_at` ne change **que** quand des données ont réellement évolué
- Les `ids` sont **fusionnés** (union) — un ID tmdb enrichi précédemment ne sera pas écrasé par un provider qui ne le connaît pas
- Une valeur `nil` venant d'un provider ne remplace pas une donnée existante enrichie

Champs mis à jour si différents : `title`, `rating`, `imdb_votes`, `poster_url`, `backdrop_url`, `synopsis`, `release_date`, `genres`, `languages`, `countries`, `ids`.

### Correctif test (bonus)

Le stub `Utils` dans les tests manquait `canonical_media_type`, ce qui rendait silencieusement toutes les insertions dans `calendar_entries` inopérantes en tests. Corrigé au passage.

## Plan de test

- [ ] Ouvrir la vue calendrier — vérifier que chaque fiche affiche "Ajouté" et "Mis à jour"
- [ ] Vérifier le format de date en français
- [ ] Lancer un `calendar refresh` — vérifier que `created_at` ne change pas sur les entrées existantes
- [ ] Modifier manuellement `imdb_votes` d'une entrée en base, relancer le refresh — vérifier que la valeur est mise à jour et que `updated_at` change
- [ ] Relancer le refresh sans changement — vérifier que `updated_at` reste stable
- [ ] `bundle exec rake test` — aucun échec imputable à cette branche

https://claude.ai/code/session_018R67V6vBogCJjgCnDoSebs