### PR TITLE
Fix calendar refresh hanging on stalled OMDb HTTP connection

### DIFF
--- a/app/media_librarian/services/calendar_feed_service.rb
+++ b/app/media_librarian/services/calendar_feed_service.rb
@@ -569,11 +569,16 @@ module MediaLibrarian
       end
 
       def omdb_search_details(api, entry)
+        return nil if @omdb_enrichment_failed
         return nil unless entry[:title]
 
         year = entry[:release_date]&.year
         omdb_type = entry[:media_type] == 'show' ? 'series' : entry[:media_type]
         api.find_by_title(title: entry[:title], year: year, type: omdb_type) if api.respond_to?(:find_by_title)
+      rescue StandardError => e
+        speaker&.tell_error(e, 'Calendar OMDb search enrichment failed')
+        @omdb_enrichment_failed = true
+        nil
       end
 
       def omdb_details(api, imdb_id)

--- a/lib/omdb_api.rb
+++ b/lib/omdb_api.rb
@@ -10,11 +10,14 @@ class OmdbApi
 
   attr_reader :last_request_path, :last_response_body
 
-  def initialize(api_key:, base_url: nil, http_client: HTTParty, speaker: nil)
+  DEFAULT_TIMEOUT = 30
+
+  def initialize(api_key:, base_url: nil, http_client: HTTParty, speaker: nil, timeout: nil)
     @api_key = api_key.to_s.strip
     @base_url = (base_url || DEFAULT_BASE_URL).to_s.chomp('/')
     @http_client = http_client
     @speaker = speaker
+    @timeout = timeout || DEFAULT_TIMEOUT
     @last_request_path = nil
   end
 
@@ -96,7 +99,7 @@ class OmdbApi
     query_with_key = query.merge(apikey: @api_key, r: 'json')
     @last_request_path = path_with_query(query_with_key)
     log_debug("OMDb request: #{@last_request_path}")
-    response = @http_client.get(@base_url, query: query_with_key)
+    response = @http_client.get(@base_url, query: query_with_key, timeout: @timeout)
     status = response.respond_to?(:code) ? response.code.to_i : nil
     @last_response_body = response&.body
     log_debug("OMDb response (status #{status || 'unknown'}): #{truncate_body(@last_response_body)}")


### PR DESCRIPTION
## Summary

- **Root cause**: `OmdbApi#request` called `HTTParty.get` with no timeout. A half-open TCP connection to the OMDb API would block the `calendar_refresh` job indefinitely — matching the observed symptom (stuck after last successful OMDb response, no error logged).
- Added a 30-second default timeout to all OMDb HTTP requests, configurable via `OmdbApi.new(timeout: N)`.
- Fixed `omdb_search_details` to respect the `@omdb_enrichment_failed` circuit-breaker flag and rescue its own errors — previously a failure or hang in the title-search fallback path was unguarded and independent of the flag set by `omdb_details`.

## How to restart the stuck job

Kill/restart the daemon — the stuck thread is blocking on `Net::HTTP` with no timeout and won't recover on its own. After deploying this fix, a stalled connection will raise `Net::ReadTimeout` after 30 s, which the rescue blocks will catch, set `@omdb_enrichment_failed`, and allow the rest of the enrichment loop to finish.

## Test plan

- [ ] Verify existing `OmdbApiTest` still passes (fake HTTP client captures `timeout:` in `**opts`)
- [ ] Run `calendar refresh_feed` and confirm it completes rather than hanging

https://claude.ai/code/session_01VrSaWwHAvGmqYDNMCKRqWE

---
_Generated by [Claude Code](https://claude.ai/code/session_01VrSaWwHAvGmqYDNMCKRqWE)_