### PR TITLE
Debug calendar refresh: add diagnostic logging to locate hang

### DIFF
--- a/app/media_librarian/services/calendar_feed_service.rb
+++ b/app/media_librarian/services/calendar_feed_service.rb
@@ -48,10 +48,14 @@ module MediaLibrarian
       def refresh(date_range: default_date_range, limit: 100, sources: nil)
         return [] unless calendar_table_available?
 
+        @omdb_enrichment_failed = nil
         normalized, stats = collect_entries(date_range, limit, normalize_sources(sources))
+        speaker.speak_up('[debug] calendar: collect_entries done', 0, Thread.current, 1)
         normalized = enrich_with_omdb(normalized)
+        speaker.speak_up('[debug] calendar: enrich_with_omdb done', 0, Thread.current, 1)
         stats = recompute_stats(stats, normalized)
         speaker.speak_up("Calendar feed collected #{normalized.length} items")
+        speaker.speak_up('[debug] calendar: calling persist_entries', 0, Thread.current, 1)
         persist_entries(normalized)
         speaker.speak_up("Calendar feed persisted #{normalized.length} items#{summary_suffix(stats)}")
         normalized
@@ -252,10 +256,13 @@ module MediaLibrarian
       def persist_entries(entries)
         return [] if entries.empty?
 
+        speaker&.speak_up('[debug] calendar: persist_entries start', 0, Thread.current, 1)
         prepared = entries.filter_map { |entry| ensure_imdb_id(entry) }
         return [] if prepared.empty?
 
+        speaker&.speak_up('[debug] calendar: loading existing entries', 0, Thread.current, 1)
         existing_index = load_existing_by_imdb_id
+        speaker&.speak_up("[debug] calendar: existing_index loaded (#{existing_index.size} rows)", 0, Thread.current, 1)
 
         to_insert = []
         prepared.each do |entry|
@@ -270,7 +277,9 @@ module MediaLibrarian
           end
         end
 
+        speaker&.speak_up("[debug] calendar: inserting #{to_insert.size} new rows", 0, Thread.current, 1)
         db.insert_rows(:calendar_entries, to_insert, true) unless to_insert.empty?
+        speaker&.speak_up('[debug] calendar: persist_entries done', 0, Thread.current, 1)
         prepared
       end
 


### PR DESCRIPTION
## Context

The calendar refresh job stalls reproducibly after logging "OMDb enrichment applied to STZ" on each daily run. PR #803 added an HTTP timeout to `OmdbApi`, but the second run reproduced the hang — meaning there is at least one more cause still in play.

Static analysis could not pinpoint the exact blocking step because all code paths after the last OMDb log entry are silent (no `speak_up` calls) and the job never logs "Calendar feed collected…" either.

## Changes

### Diagnostic logging (`immediate=1`)

Added `speak_up` calls with `immediate=1` at the key phase boundaries in `refresh()` and `persist_entries()`. The `immediate=1` flag bypasses `thread[:log_msg]` buffering and writes directly to the log file, so these lines will appear regardless of whether the job completes.

```
[debug] calendar: collect_entries done
[debug] calendar: enrich_with_omdb done
[debug] calendar: calling persist_entries
[debug] calendar: persist_entries start
[debug] calendar: loading existing entries
[debug] calendar: existing_index loaded (N rows)
[debug] calendar: inserting N new rows
[debug] calendar: persist_entries done
```

The last line that appears on the next stuck run will identify the blocking step.

### Reset `@omdb_enrichment_failed` between runs

`CalendarFeed.calendar_service` is a class-level cached instance (`@calendar_service ||= …`), so `@omdb_enrichment_failed` set by a previous run persists into the next one. Added a reset at the top of `refresh()`.

## Test plan

- [ ] Deploy to server, trigger `calendar refresh_feed`, grep log for `debug.*calendar` and report the last line seen before the hang
- [ ] Once the blocking step is identified, remove these diagnostic lines and push a targeted fix

https://claude.ai/code/session_01VrSaWwHAvGmqYDNMCKRqWE

---
_Generated by [Claude Code](https://claude.ai/code/session_01VrSaWwHAvGmqYDNMCKRqWE)_