### PR TITLE
Fix infinite retry loop in OmdbApi#parse_json for malformed JSON

### DIFF
--- a/lib/omdb_api.rb
+++ b/lib/omdb_api.rb
@@ -122,8 +122,11 @@ class OmdbApi
   rescue JSON::ParserError => e
     fallback = tighten_json(text)
     if fallback && fallback != text
-      body = fallback
-      retry
+      begin
+        return JSON.parse(fallback)
+      rescue JSON::ParserError
+        # fallback also failed
+      end
     end
 
     report_error(e, "OMDb #{op} response was invalid JSON (status #{status || 'unknown'}): #{e.message}")


### PR DESCRIPTION
## Summary

- Replaces `retry` in `parse_json` with a single nested `begin/rescue` that attempts to parse the `tighten_json` fallback exactly once
- Prevents an infinite loop when `tighten_json` is non-idempotent (produces a different string on each successive call)
- Root cause: STZ's OMDb response contains `"Director":"Matthew Clark \"` — an unterminated string literal — causing `JSON.parse` to fail, `tighten_json` to mutate the body, and `retry` to loop forever, hanging the `calendar_refresh` daemon job indefinitely

## Test plan

- [ ] Trigger `calendar refresh_feed` and confirm it completes without hanging
- [ ] Verify that when OMDb returns malformed JSON, the error is logged and enrichment skips the entry (returns `nil`) rather than looping
- [ ] Confirm entries with valid OMDb responses are still enriched correctly

https://claude.ai/code/session_01VrSaWwHAvGmqYDNMCKRqWE

---
_Generated by [Claude Code](https://claude.ai/code/session_01VrSaWwHAvGmqYDNMCKRqWE)_