### PR TITLE
Fix calendar title link contrast (blue on blue)

### DIFF
--- a/app/web/app.css
+++ b/app/web/app.css
@@ -963,6 +963,15 @@ button:disabled {
   font-size: 1.05rem;
 }
 
+.calendar-item h4 a {
+  color: var(--text);
+  text-decoration: none;
+}
+
+.calendar-item h4 a:hover {
+  text-decoration: underline;
+}
+
 .calendar-badges {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Problème

Les titres des vignettes media dans la vue calendrier étaient illisibles quand ils contenaient un lien : la couleur par défaut des liens (`<a>`) du navigateur (bleu) se confondait avec le fond bleu de l'interface.

## Solution

Ajout d'une règle CSS explicite pour `.calendar-item h4 a` :
- `color: var(--text)` — texte blanc (#f9fafb) qui contraste clairement sur fond sombre
- `text-decoration: none` — supprime le soulignement par défaut
- `:hover` — réintroduit le soulignement au survol pour indiquer le lien interactif

---
_Generated by [Claude Code](https://claude.ai/code/session_019Zv19fe5C1jZFEm8ws4S8k)_