### PR TITLE
Fix calendar title link contrast — override :link and :visited states

### DIFF
--- a/app/web/app.css
+++ b/app/web/app.css
@@ -963,7 +963,9 @@ button:disabled {
   font-size: 1.05rem;
 }
 
-.calendar-item h4 a {
+.calendar-item h4 a,
+.calendar-item h4 a:link,
+.calendar-item h4 a:visited {
   color: var(--text);
   text-decoration: none;
 }


### PR DESCRIPTION
## Problème

Les titres des vignettes calendrier restaient bleus malgré le premier fix. La règle `.calendar-item h4 a { color: var(--text) }` couvre l'état de base, mais les pseudo-classes `:link` et `:visited` du navigateur ont leur propre spécificité dans la feuille de style UA et peuvent s'imposer dans certains navigateurs ou configurations `color-scheme`.

## Solution

Extension de la règle CSS pour couvrir explicitement les trois états :

```css
.calendar-item h4 a,
.calendar-item h4 a:link,
.calendar-item h4 a:visited {
  color: var(--text);
  text-decoration: none;
}
```

Cela garantit que ni la couleur par défaut des liens non visités (bleu), ni celle des liens visités (violet), ne peut s'afficher sur les titres du calendrier.

---
_Generated by [Claude Code](https://claude.ai/code/session_019Zv19fe5C1jZFEm8ws4S8k)_