### PR TITLE
Add optional Dolby Vision filter for torrent search results

### DIFF
--- a/config/templates/search_from_torrents.yml.example
+++ b/config/templates/search_from_torrents.yml.example
@@ -38,6 +38,7 @@ qualities:
   max_size: 3000 #MB
   target_size: 8000 #MB
   timeframe_size: 96 hours
+  ban_dolby_vision: 0 #Set to 1 to exclude Dolby Vision (DV/DoVi) releases from torrent results
   illegal:
     - x265 2160p
 download_criteria:

--- a/init/global.rb
+++ b/init/global.rb
@@ -51,6 +51,7 @@ EXTENSIONS_TYPE= {
 VALID_VIDEO_EXT="(.*)\\.(#{EXTENSIONS_TYPE[:video].join('|')})$"
 SEP_CHARS='[\/ \.\(\)\-]'
 REGEX_QUALITIES=Regexp.new('(?=(' + SEP_CHARS + '(' + VALID_QUALITIES.join('|') + ')' + SEP_CHARS + '))')
+DOLBY_VISION_REGEX=Regexp.new('(^|' + SEP_CHARS + ')(dolby[\. ]?vision|dovi|dv)(' + SEP_CHARS + '|$)', Regexp::IGNORECASE)
 SPACE_SUBSTITUTE='\. _\-'
 BASIC_EP_MATCH='((([' + SPACE_SUBSTITUTE + ']|^)[sS]|[' + SPACE_SUBSTITUTE + '\^\[])(\d{1,3})[' + SPACE_SUBSTITUTE + ']?[exEX](\d{1,4})([' + SPACE_SUBSTITUTE + '](part|cd|disc|pt)(\d))?([\&\-exEX]{1,2}(\d{1,2})([' + SPACE_SUBSTITUTE + '](part|cd|disc|pt)(\d))?)?([\&\-exEX]{1,2}(\d{1,2})([' + SPACE_SUBSTITUTE + '](part|cd|disc|pt)(\d))?)?|([\. \-]|^)[sS](\d{1,3}))'
 REGEX_TV_EP_NB=/#{BASIC_EP_MATCH}([#{SPACE_SUBSTITUTE}]|$)|(^|\/|[#{SPACE_SUBSTITUTE}\[])(\d{3,4})[#{SPACE_SUBSTITUTE}\]-]#{VALID_VIDEO_EXT}/

--- a/lib/quality.rb
+++ b/lib/quality.rb
@@ -46,6 +46,10 @@ class Quality
       MediaLibrarian.app.speaker.speak_up "'#{filename}' contains hardcoded subtitles, removing from list" if Env.debug?
       return timeframe, false
     end
+    if (qualities['ban_dolby_vision'] == true || qualities['ban_dolby_vision'].to_i > 0) && filename.to_s.match?(DOLBY_VISION_REGEX)
+      MediaLibrarian.app.speaker.speak_up "'#{filename}' is a Dolby Vision release, removing from list" if Env.debug?
+      return timeframe, false
+    end
     file_q = parse_qualities(filename, VALID_QUALITIES, language, category)
     (qualities['illegal'].is_a?(Array) ? qualities['illegal'] : [qualities['illegal'].to_s]).each do |iq|
       next if iq.to_s == ''

--- a/test/lib/quality_dolby_vision_test.rb
+++ b/test/lib/quality_dolby_vision_test.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+require_relative '../../lib/quality'
+
+class QualityDolbyVisionTest < Minitest::Test
+  DV_RELEASES = [
+    'Movie.2024.2160p.WEB-DL.DV.HDR.x265-GROUP.mkv',
+    'Movie.2024.2160p.BluRay.DoVi.x265.mkv',
+    'Movie 2024 2160p Dolby Vision x265.mkv',
+    'Movie.2024.2160p.Dolby.Vision.Atmos.mkv'
+  ].freeze
+
+  NON_DV_RELEASES = [
+    'Show.S01E01.1080p.WEB.h264.mkv',
+    'The.DVD.Special.Edition.1080p.mkv',
+    'Movie.2024.DVDRip.XviD.avi'
+  ].freeze
+
+  def test_dolby_vision_releases_are_rejected_when_banned
+    DV_RELEASES.each do |name|
+      _, accept = Quality.filter_quality(name, { 'ban_dolby_vision' => 1 })
+      refute accept, "Expected Dolby Vision release to be rejected: #{name}"
+    end
+  end
+
+  def test_dolby_vision_releases_are_kept_when_option_disabled
+    DV_RELEASES.each do |name|
+      _, accept = Quality.filter_quality(name, { 'ban_dolby_vision' => 0 })
+      assert accept, "Expected Dolby Vision release to be kept when option is off: #{name}"
+    end
+  end
+
+  def test_dolby_vision_releases_are_kept_when_option_absent
+    DV_RELEASES.each do |name|
+      _, accept = Quality.filter_quality(name, {})
+      assert accept, "Expected Dolby Vision release to be kept when option is unset: #{name}"
+    end
+  end
+
+  def test_non_dolby_vision_releases_are_kept_when_banned
+    NON_DV_RELEASES.each do |name|
+      _, accept = Quality.filter_quality(name, { 'ban_dolby_vision' => 1 })
+      assert accept, "Expected non Dolby Vision release to be kept: #{name}"
+    end
+  end
+
+  def test_ban_accepts_boolean_true
+    _, accept = Quality.filter_quality(DV_RELEASES.first, { 'ban_dolby_vision' => true })
+    refute accept, 'Expected ban_dolby_vision: true to reject Dolby Vision release'
+  end
+end


### PR DESCRIPTION
## Résumé

Permet de **bannir optionnellement les releases Dolby Vision** des résultats de recherche torrent.

Une nouvelle option `ban_dolby_vision` est ajoutée dans le bloc `qualities` de la config de recherche. Quand elle est activée (`1`), tout torrent dont le nom contient un marqueur Dolby Vision (`DV`, `DoVi`, `Dolby Vision`) est exclu des résultats. Désactivée par défaut (`0`), donc aucun changement de comportement existant.

## Détails techniques

- **`init/global.rb`** : ajout de la constante `DOLBY_VISION_REGEX` détectant les tags `dolby vision` / `dolby.vision` / `dovi` / `dv`, bornés par les séparateurs habituels (`SEP_CHARS`) pour éviter les faux positifs (`DVDRip`, `DVD`, `Devil`, `Advanced`…).
- **`lib/quality.rb`** : `Quality.filter_quality` rejette la release si l'option est active et que le nom correspond au regex. Le contrôle est placé à côté de l'exclusion existante des sous-titres hardcodés (`hc`), donc il s'applique à **tous** les chemins de filtrage des résultats (`TrackerQueryService#get_results` et `Quality.sort_media_files`). L'option accepte `1` ou `true`.
- **`config/templates/search_from_torrents.yml.example`** : documentation de l'option (`ban_dolby_vision: 0`).

## Tests

- Ajout de `test/lib/quality_dolby_vision_test.rb` couvrant : rejet des releases DV quand activé, conservation quand désactivé/absent, non-régression sur les releases non-DV, et support de la valeur booléenne `true`.
- Le regex a été validé contre des échantillons positifs et négatifs.

> Note : la suite de tests complète (`bundle exec rake test`) n'a pas pu être exécutée dans cet environnement car les gems forkés (`raphyduck/*`, sources Git) ne sont pas accessibles via le proxy réseau. Les fichiers Ruby modifiés passent `ruby -c` et la logique du regex a été vérifiée de façon isolée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dqiz2SMWwPAQ4s2bdbVHYC)_